### PR TITLE
Improve SNN training speed and add a compile-friendly FlexSN path

### DIFF
--- a/spikingjelly/activation_based/base.py
+++ b/spikingjelly/activation_based/base.py
@@ -473,7 +473,7 @@ class MemoryModule(nn.Module, StepModule):
             elif isinstance(cur, torch.Tensor) and isinstance(rv, (int, float)):
                 # Preserve Python-scalar sentinel semantics so the next forward
                 # can materialize a fresh tensor with the new runtime shape.
-                self._memories[key] = copy.deepcopy(rv)
+                self._memories[key] = rv
             else:
                 self._memories[key] = copy.deepcopy(rv)
 

--- a/spikingjelly/activation_based/base.py
+++ b/spikingjelly/activation_based/base.py
@@ -471,12 +471,11 @@ class MemoryModule(nn.Module, StepModule):
                 except RuntimeError:
                     self._memories[key] = rv.detach().clone()
             elif isinstance(cur, torch.Tensor) and isinstance(rv, (int, float)):
-                # Keep tensor states as tensors across resets so Dynamo does not
-                # re-specialize on float -> Tensor transitions. Rebuild a fresh
-                # tensor instead of mutating the old one in-place because state
-                # tensors can come from compiled graph outputs / CUDAGraph
-                # captures, whose storages must not be reused after later runs.
-                self._memories[key] = torch.full_like(cur, rv)
+                # Scalar reset values should return to scalar semantics so the
+                # next forward can materialize them to the new runtime shape.
+                self._memories[key] = torch.as_tensor(
+                    rv, dtype=cur.dtype, device=cur.device
+                )
             else:
                 self._memories[key] = copy.deepcopy(rv)
 

--- a/spikingjelly/activation_based/base.py
+++ b/spikingjelly/activation_based/base.py
@@ -471,11 +471,9 @@ class MemoryModule(nn.Module, StepModule):
                 except RuntimeError:
                     self._memories[key] = rv.detach().clone()
             elif isinstance(cur, torch.Tensor) and isinstance(rv, (int, float)):
-                # Scalar reset values should return to scalar semantics so the
-                # next forward can materialize them to the new runtime shape.
-                self._memories[key] = torch.as_tensor(
-                    rv, dtype=cur.dtype, device=cur.device
-                )
+                # Preserve Python-scalar sentinel semantics so the next forward
+                # can materialize a fresh tensor with the new runtime shape.
+                self._memories[key] = copy.deepcopy(rv)
             else:
                 self._memories[key] = copy.deepcopy(rv)
 

--- a/spikingjelly/activation_based/base.py
+++ b/spikingjelly/activation_based/base.py
@@ -471,11 +471,12 @@ class MemoryModule(nn.Module, StepModule):
                 except RuntimeError:
                     self._memories[key] = rv.detach().clone()
             elif isinstance(cur, torch.Tensor) and isinstance(rv, (int, float)):
-                # Restore to the scalar reset value so v_float_to_tensor() can
-                # detect a float on the next forward and re-create a correctly
-                # shaped/device tensor.  Do NOT fill in-place: that would keep
-                # a tensor with a potentially stale grad_fn in the registry.
-                self._memories[key] = rv
+                # Keep tensor states as tensors across resets so Dynamo does not
+                # re-specialize on float -> Tensor transitions. Rebuild a fresh
+                # tensor instead of mutating the old one in-place because state
+                # tensors can come from compiled graph outputs / CUDAGraph
+                # captures, whose storages must not be reused after later runs.
+                self._memories[key] = torch.full_like(cur, rv)
             else:
                 self._memories[key] = copy.deepcopy(rv)
 

--- a/spikingjelly/activation_based/examples/DSQN/utils/model.py
+++ b/spikingjelly/activation_based/examples/DSQN/utils/model.py
@@ -48,8 +48,8 @@ class DSQN(nn.Module):
             functional.set_backend(self.network, backend="cupy")
 
     def forward(self, x):
-        x_seq = x.unsqueeze(0).repeat(
-            self.T, 1, 1, 1, 1
+        x_seq = x.unsqueeze(0).expand(
+            self.T, -1, -1, -1, -1
         )  # [N, C, H, W] -> [T, N, C, H, W]
 
         if "mem" in self.dec_type:

--- a/spikingjelly/activation_based/examples/conv_fashion_mnist.py
+++ b/spikingjelly/activation_based/examples/conv_fashion_mnist.py
@@ -42,8 +42,8 @@ class CSNN(nn.Module):
 
     def forward(self, x: torch.Tensor):
         # x.shape = [N, C, H, W]
-        x_seq = x.unsqueeze(0).repeat(
-            self.T, 1, 1, 1, 1
+        x_seq = x.unsqueeze(0).expand(
+            self.T, -1, -1, -1, -1
         )  # [N, C, H, W] -> [T, N, C, H, W]
         x_seq = self.conv_fc(x_seq)
         fr = x_seq.mean(0)
@@ -195,8 +195,8 @@ def main():
                     img = img.to(args.device)
                     label = label.to(args.device)
                     # img.shape = [N, C, H, W]
-                    img_seq = img.unsqueeze(0).repeat(
-                        net.T, 1, 1, 1, 1
+                    img_seq = img.unsqueeze(0).expand(
+                        net.T, -1, -1, -1, -1
                     )  # [N, C, H, W] -> [T, N, C, H, W]
                     spike_seq = encoder(img_seq)
                     functional.reset_net(encoder)

--- a/spikingjelly/activation_based/examples/lava_mnist.py
+++ b/spikingjelly/activation_based/examples/lava_mnist.py
@@ -144,7 +144,7 @@ def main():
             optimizer.zero_grad()
             img = img.to(args.device)
             label = label.to(args.device)
-            img = img.unsqueeze(0).repeat(args.T, 1, 1, 1, 1)
+            img = img.unsqueeze(0).expand(args.T, -1, -1, -1, -1)
 
             fr = net(encoder(img)).mean(0)
             loss = F.cross_entropy(fr, label)
@@ -167,7 +167,7 @@ def main():
             for img, label in test_data_loader:
                 img = img.to(args.device)
                 label = label.to(args.device)
-                img = img.unsqueeze(0).repeat(args.T, 1, 1, 1, 1)
+                img = img.unsqueeze(0).expand(args.T, -1, -1, -1, -1)
 
                 fr = net(encoder(img)).mean(0)
                 loss = F.cross_entropy(fr, label)
@@ -196,7 +196,7 @@ def main():
         for img, label in test_data_loader:
             img = img.to(args.device)
             label = label.to(args.device)
-            img = img.unsqueeze(0).repeat(args.T, 1, 1, 1, 1)
+            img = img.unsqueeze(0).expand(args.T, -1, -1, -1, -1)
             img = encoder(img)
             img = lava_exchange.TNX_to_NXT(img)
             fr = net_ladl(img).mean(-1)

--- a/spikingjelly/activation_based/layer/bn.py
+++ b/spikingjelly/activation_based/layer/bn.py
@@ -147,7 +147,10 @@ class BatchNorm2d(nn.BatchNorm2d, base.StepModule):
                 raise ValueError(
                     f"expected x with shape [T, N, C, H, W], but got x with shape {x.shape}!"
                 )
-            return functional.seq_to_ann_forward(x, self.super_forward)
+            y_shape = [x.shape[0], x.shape[1]]
+            x = self.super_forward(x.flatten(0, 1))
+            y_shape.extend(x.shape[1:])
+            return x.view(y_shape)
 
 
 class BatchNorm3d(nn.BatchNorm3d, base.StepModule):

--- a/spikingjelly/activation_based/layer/stateless_wrapper.py
+++ b/spikingjelly/activation_based/layer/stateless_wrapper.py
@@ -181,7 +181,10 @@ class Conv2d(nn.Conv2d, base.StepModule):
                 raise ValueError(
                     f"expected x with shape [T, N, C, H, W], but got x with shape {x.shape}!"
                 )
-            x = functional.seq_to_ann_forward(x, super().forward)
+            y_shape = [x.shape[0], x.shape[1]]
+            x = super().forward(x.flatten(0, 1))
+            y_shape.extend(x.shape[1:])
+            x = x.view(y_shape)
 
         return x
 
@@ -449,7 +452,10 @@ class ConvTranspose2d(nn.ConvTranspose2d, base.StepModule):
                 raise ValueError(
                     f"expected x with shape [T, N, C, H, W], but got x with shape {x.shape}!"
                 )
-            x = functional.seq_to_ann_forward(x, super().forward)
+            y_shape = [x.shape[0], x.shape[1]]
+            x = super().forward(x.flatten(0, 1))
+            y_shape.extend(x.shape[1:])
+            x = x.view(y_shape)
 
         return x
 
@@ -688,7 +694,10 @@ class MaxPool2d(nn.MaxPool2d, base.StepModule):
                 raise ValueError(
                     f"expected x with shape [T, N, C, H, W], but got x with shape {x.shape}!"
                 )
-            x = functional.seq_to_ann_forward(x, super().forward)
+            y_shape = [x.shape[0], x.shape[1]]
+            x = super().forward(x.flatten(0, 1))
+            y_shape.extend(x.shape[1:])
+            x = x.view(y_shape)
 
         return x
 
@@ -862,7 +871,10 @@ class AvgPool2d(nn.AvgPool2d, base.StepModule):
                 raise ValueError(
                     f"expected x with shape [T, N, C, H, W], but got x with shape {x.shape}!"
                 )
-            x = functional.seq_to_ann_forward(x, super().forward)
+            y_shape = [x.shape[0], x.shape[1]]
+            x = super().forward(x.flatten(0, 1))
+            y_shape.extend(x.shape[1:])
+            x = x.view(y_shape)
 
         return x
 
@@ -1017,7 +1029,10 @@ class AdaptiveAvgPool2d(nn.AdaptiveAvgPool2d, base.StepModule):
                 raise ValueError(
                     f"expected x with shape [T, N, C, H, W], but got x with shape {x.shape}!"
                 )
-            x = functional.seq_to_ann_forward(x, super().forward)
+            y_shape = [x.shape[0], x.shape[1]]
+            x = super().forward(x.flatten(0, 1))
+            y_shape.extend(x.shape[1:])
+            x = x.view(y_shape)
 
         return x
 
@@ -1143,7 +1158,10 @@ class Flatten(nn.Flatten, base.StepModule):
             x = super().forward(x)
 
         elif self.step_mode == "m":
-            x = functional.seq_to_ann_forward(x, super().forward)
+            y_shape = [x.shape[0], x.shape[1]]
+            x = super().forward(x.flatten(0, 1))
+            y_shape.extend(x.shape[1:])
+            x = x.view(y_shape)
         return x
 
 

--- a/spikingjelly/activation_based/layer/stateless_wrapper.py
+++ b/spikingjelly/activation_based/layer/stateless_wrapper.py
@@ -112,10 +112,6 @@ class Conv1d(nn.Conv1d, base.StepModule):
                     f"expected x with shape [T, N, C, L], but got x with shape {x.shape}!"
                 )
             y = super().forward(x.flatten(0, 1))
-            if isinstance(y, tuple):
-                y_shape = [x.shape[0], x.shape[1]]
-                y_shape.extend(y[0].shape[1:])
-                return y[0].view(y_shape), y[1].view(y_shape)
             x = y.view(x.shape[0], x.shape[1], *y.shape[1:])
 
         return x
@@ -188,9 +184,6 @@ class Conv2d(nn.Conv2d, base.StepModule):
                 )
             y_shape = [x.shape[0], x.shape[1]]
             y = super().forward(x.flatten(0, 1))
-            if isinstance(y, tuple):
-                y_shape.extend(y[0].shape[1:])
-                return y[0].view(y_shape), y[1].view(y_shape)
             y_shape.extend(y.shape[1:])
             x = y.view(y_shape)
 
@@ -263,10 +256,6 @@ class Conv3d(nn.Conv3d, base.StepModule):
                     f"expected x with shape [T, N, C, D, H, W], but got x with shape {x.shape}!"
                 )
             y = super().forward(x.flatten(0, 1))
-            if isinstance(y, tuple):
-                y_shape = [x.shape[0], x.shape[1]]
-                y_shape.extend(y[0].shape[1:])
-                return y[0].view(y_shape), y[1].view(y_shape)
             x = y.view(x.shape[0], x.shape[1], *y.shape[1:])
 
         return x
@@ -394,10 +383,6 @@ class ConvTranspose1d(nn.ConvTranspose1d, base.StepModule):
                     f"expected x with shape [T, N, C, L], but got x with shape {x.shape}!"
                 )
             y = super().forward(x.flatten(0, 1))
-            if isinstance(y, tuple):
-                y_shape = [x.shape[0], x.shape[1]]
-                y_shape.extend(y[0].shape[1:])
-                return y[0].view(y_shape), y[1].view(y_shape)
             x = y.view(x.shape[0], x.shape[1], *y.shape[1:])
 
         return x
@@ -472,9 +457,6 @@ class ConvTranspose2d(nn.ConvTranspose2d, base.StepModule):
                 )
             y_shape = [x.shape[0], x.shape[1]]
             y = super().forward(x.flatten(0, 1))
-            if isinstance(y, tuple):
-                y_shape.extend(y[0].shape[1:])
-                return y[0].view(y_shape), y[1].view(y_shape)
             y_shape.extend(y.shape[1:])
             x = y.view(y_shape)
 
@@ -549,10 +531,6 @@ class ConvTranspose3d(nn.ConvTranspose3d, base.StepModule):
                     f"expected x with shape [T, N, C, D, H, W], but got x with shape {x.shape}!"
                 )
             y = super().forward(x.flatten(0, 1))
-            if isinstance(y, tuple):
-                y_shape = [x.shape[0], x.shape[1]]
-                y_shape.extend(y[0].shape[1:])
-                return y[0].view(y_shape), y[1].view(y_shape)
             x = y.view(x.shape[0], x.shape[1], *y.shape[1:])
 
         return x
@@ -912,12 +890,7 @@ class AvgPool2d(nn.AvgPool2d, base.StepModule):
                 )
             t, n = x.shape[0], x.shape[1]
             out = super().forward(x.flatten(0, 1))
-            if isinstance(out, tuple):
-                y, indices = out
-                y_shape = [t, n, *y.shape[1:]]
-                x = (y.view(y_shape), indices.view(y_shape))
-            else:
-                x = out.view(t, n, *out.shape[1:])
+            x = out.view(t, n, *out.shape[1:])
 
         return x
 
@@ -977,10 +950,6 @@ class AvgPool3d(nn.AvgPool3d, base.StepModule):
                     f"expected x with shape [T, N, C, D, H, W], but got x with shape {x.shape}!"
                 )
             y = super().forward(x.flatten(0, 1))
-            if isinstance(y, tuple):
-                y_shape = [x.shape[0], x.shape[1]]
-                y_shape.extend(y[0].shape[1:])
-                return y[0].view(y_shape), y[1].view(y_shape)
             x = y.view(x.shape[0], x.shape[1], *y.shape[1:])
 
         return x

--- a/spikingjelly/activation_based/layer/stateless_wrapper.py
+++ b/spikingjelly/activation_based/layer/stateless_wrapper.py
@@ -111,7 +111,12 @@ class Conv1d(nn.Conv1d, base.StepModule):
                 raise ValueError(
                     f"expected x with shape [T, N, C, L], but got x with shape {x.shape}!"
                 )
-            x = functional.seq_to_ann_forward(x, super().forward)
+            y = super().forward(x.flatten(0, 1))
+            if isinstance(y, tuple):
+                y_shape = [x.shape[0], x.shape[1]]
+                y_shape.extend(y[0].shape[1:])
+                return y[0].view(y_shape), y[1].view(y_shape)
+            x = y.view(x.shape[0], x.shape[1], *y.shape[1:])
 
         return x
 
@@ -182,9 +187,12 @@ class Conv2d(nn.Conv2d, base.StepModule):
                     f"expected x with shape [T, N, C, H, W], but got x with shape {x.shape}!"
                 )
             y_shape = [x.shape[0], x.shape[1]]
-            x = super().forward(x.flatten(0, 1))
-            y_shape.extend(x.shape[1:])
-            x = x.view(y_shape)
+            y = super().forward(x.flatten(0, 1))
+            if isinstance(y, tuple):
+                y_shape.extend(y[0].shape[1:])
+                return y[0].view(y_shape), y[1].view(y_shape)
+            y_shape.extend(y.shape[1:])
+            x = y.view(y_shape)
 
         return x
 
@@ -254,7 +262,12 @@ class Conv3d(nn.Conv3d, base.StepModule):
                 raise ValueError(
                     f"expected x with shape [T, N, C, D, H, W], but got x with shape {x.shape}!"
                 )
-            x = functional.seq_to_ann_forward(x, super().forward)
+            y = super().forward(x.flatten(0, 1))
+            if isinstance(y, tuple):
+                y_shape = [x.shape[0], x.shape[1]]
+                y_shape.extend(y[0].shape[1:])
+                return y[0].view(y_shape), y[1].view(y_shape)
+            x = y.view(x.shape[0], x.shape[1], *y.shape[1:])
 
         return x
 
@@ -380,7 +393,12 @@ class ConvTranspose1d(nn.ConvTranspose1d, base.StepModule):
                 raise ValueError(
                     f"expected x with shape [T, N, C, L], but got x with shape {x.shape}!"
                 )
-            x = functional.seq_to_ann_forward(x, super().forward)
+            y = super().forward(x.flatten(0, 1))
+            if isinstance(y, tuple):
+                y_shape = [x.shape[0], x.shape[1]]
+                y_shape.extend(y[0].shape[1:])
+                return y[0].view(y_shape), y[1].view(y_shape)
+            x = y.view(x.shape[0], x.shape[1], *y.shape[1:])
 
         return x
 
@@ -453,9 +471,12 @@ class ConvTranspose2d(nn.ConvTranspose2d, base.StepModule):
                     f"expected x with shape [T, N, C, H, W], but got x with shape {x.shape}!"
                 )
             y_shape = [x.shape[0], x.shape[1]]
-            x = super().forward(x.flatten(0, 1))
-            y_shape.extend(x.shape[1:])
-            x = x.view(y_shape)
+            y = super().forward(x.flatten(0, 1))
+            if isinstance(y, tuple):
+                y_shape.extend(y[0].shape[1:])
+                return y[0].view(y_shape), y[1].view(y_shape)
+            y_shape.extend(y.shape[1:])
+            x = y.view(y_shape)
 
         return x
 
@@ -527,7 +548,12 @@ class ConvTranspose3d(nn.ConvTranspose3d, base.StepModule):
                 raise ValueError(
                     f"expected x with shape [T, N, C, D, H, W], but got x with shape {x.shape}!"
                 )
-            x = functional.seq_to_ann_forward(x, super().forward)
+            y = super().forward(x.flatten(0, 1))
+            if isinstance(y, tuple):
+                y_shape = [x.shape[0], x.shape[1]]
+                y_shape.extend(y[0].shape[1:])
+                return y[0].view(y_shape), y[1].view(y_shape)
+            x = y.view(x.shape[0], x.shape[1], *y.shape[1:])
 
         return x
 
@@ -635,7 +661,12 @@ class MaxPool1d(nn.MaxPool1d, base.StepModule):
                 raise ValueError(
                     f"expected x with shape [T, N, C, L], but got x with shape {x.shape}!"
                 )
-            x = functional.seq_to_ann_forward(x, super().forward)
+            y = super().forward(x.flatten(0, 1))
+            if isinstance(y, tuple):
+                y_shape = [x.shape[0], x.shape[1]]
+                y_shape.extend(y[0].shape[1:])
+                return y[0].view(y_shape), y[1].view(y_shape)
+            x = y.view(x.shape[0], x.shape[1], *y.shape[1:])
 
         return x
 
@@ -695,9 +726,12 @@ class MaxPool2d(nn.MaxPool2d, base.StepModule):
                     f"expected x with shape [T, N, C, H, W], but got x with shape {x.shape}!"
                 )
             y_shape = [x.shape[0], x.shape[1]]
-            x = super().forward(x.flatten(0, 1))
-            y_shape.extend(x.shape[1:])
-            x = x.view(y_shape)
+            y = super().forward(x.flatten(0, 1))
+            if isinstance(y, tuple):
+                y_shape.extend(y[0].shape[1:])
+                return y[0].view(y_shape), y[1].view(y_shape)
+            y_shape.extend(y.shape[1:])
+            x = y.view(y_shape)
 
         return x
 
@@ -756,7 +790,12 @@ class MaxPool3d(nn.MaxPool3d, base.StepModule):
                 raise ValueError(
                     f"expected x with shape [T, N, C, D, H, W], but got x with shape {x.shape}!"
                 )
-            x = functional.seq_to_ann_forward(x, super().forward)
+            y = super().forward(x.flatten(0, 1))
+            if isinstance(y, tuple):
+                y_shape = [x.shape[0], x.shape[1]]
+                y_shape.extend(y[0].shape[1:])
+                return y[0].view(y_shape), y[1].view(y_shape)
+            x = y.view(x.shape[0], x.shape[1], *y.shape[1:])
 
         return x
 
@@ -871,10 +910,14 @@ class AvgPool2d(nn.AvgPool2d, base.StepModule):
                 raise ValueError(
                     f"expected x with shape [T, N, C, H, W], but got x with shape {x.shape}!"
                 )
-            y_shape = [x.shape[0], x.shape[1]]
-            x = super().forward(x.flatten(0, 1))
-            y_shape.extend(x.shape[1:])
-            x = x.view(y_shape)
+            t, n = x.shape[0], x.shape[1]
+            out = super().forward(x.flatten(0, 1))
+            if isinstance(out, tuple):
+                y, indices = out
+                y_shape = [t, n, *y.shape[1:]]
+                x = (y.view(y_shape), indices.view(y_shape))
+            else:
+                x = out.view(t, n, *out.shape[1:])
 
         return x
 
@@ -933,7 +976,12 @@ class AvgPool3d(nn.AvgPool3d, base.StepModule):
                 raise ValueError(
                     f"expected x with shape [T, N, C, D, H, W], but got x with shape {x.shape}!"
                 )
-            x = functional.seq_to_ann_forward(x, super().forward)
+            y = super().forward(x.flatten(0, 1))
+            if isinstance(y, tuple):
+                y_shape = [x.shape[0], x.shape[1]]
+                y_shape.extend(y[0].shape[1:])
+                return y[0].view(y_shape), y[1].view(y_shape)
+            x = y.view(x.shape[0], x.shape[1], *y.shape[1:])
 
         return x
 

--- a/spikingjelly/activation_based/model/train_classify.py
+++ b/spikingjelly/activation_based/model/train_classify.py
@@ -111,6 +111,7 @@ class Trainer:
                 f"{compile_options!r}; retrying without options. "
                 f"Original error: {e}",
                 RuntimeWarning,
+                stacklevel=2,
             )
             compile_kwargs.pop("options", None)
             return torch.compile(model, **compile_kwargs)

--- a/spikingjelly/activation_based/model/train_classify.py
+++ b/spikingjelly/activation_based/model/train_classify.py
@@ -127,7 +127,7 @@ class Trainer:
         metric_logger = utils.MetricLogger(delimiter="  ")
         metric_logger.add_meter("lr", utils.SmoothedValue(window_size=1, fmt="{value}"))
         metric_logger.add_meter(
-            "img/s", utils.SmoothedValue(window_size=10, fmt="{value}")
+            "img/s", utils.SmoothedValue(window_size=10, fmt="{global_avg:.3f}")
         )
 
         header = f"Epoch: [{epoch}]"
@@ -181,7 +181,7 @@ class Trainer:
             metric_logger.acc5.global_avg,
         )
         print(
-            f"Train: train_acc1={train_acc1:.3f}, train_acc5={train_acc5:.3f}, train_loss={train_loss:.6f}, samples/s={metric_logger.meters['img/s']}"
+            f"Train: train_acc1={train_acc1:.3f}, train_acc5={train_acc5:.3f}, train_loss={train_loss:.6f}, samples/s={metric_logger.meters['img/s'].global_avg:.3f}"
         )
         return train_loss, train_acc1, train_acc5
 

--- a/spikingjelly/activation_based/model/train_classify.py
+++ b/spikingjelly/activation_based/model/train_classify.py
@@ -512,6 +512,10 @@ class Trainer:
 
     def main(self, args):
         set_deterministic(args.seed, args.disable_uda)
+        if args.workers > 0 and args.prefetch_factor < 1:
+            raise ValueError(
+                f"--prefetch-factor must be >= 1 when --workers > 0, but got {args.prefetch_factor}."
+            )
         if args.prototype and prototype is None:
             raise ImportError(
                 "The prototype module couldn't be found. Please install the latest torchvision nightly."

--- a/spikingjelly/activation_based/model/train_classify.py
+++ b/spikingjelly/activation_based/model/train_classify.py
@@ -102,7 +102,16 @@ class Trainer:
 
         try:
             return torch.compile(model, **compile_kwargs)
-        except RuntimeError:
+        except RuntimeError as e:
+            compile_options = compile_kwargs.get("options")
+            if not compile_options:
+                raise
+            warnings.warn(
+                "torch.compile failed with backend options "
+                f"{compile_options!r}; retrying without options. "
+                f"Original error: {e}",
+                RuntimeWarning,
+            )
             compile_kwargs.pop("options", None)
             return torch.compile(model, **compile_kwargs)
 
@@ -126,9 +135,7 @@ class Trainer:
         model.train()
         metric_logger = utils.MetricLogger(delimiter="  ")
         metric_logger.add_meter("lr", utils.SmoothedValue(window_size=1, fmt="{value}"))
-        metric_logger.add_meter(
-            "img/s", utils.SmoothedValue(window_size=10, fmt="{global_avg:.3f}")
-        )
+        metric_logger.add_meter("img/s", utils.ThroughputValue(fmt="{global_avg:.3f}"))
 
         header = f"Epoch: [{epoch}]"
         data_to_device_kwargs = self.get_data_to_device_kwargs(args)
@@ -171,7 +178,7 @@ class Trainer:
             metric_logger.meters["acc1"].update(acc1.item(), n=batch_size)
             metric_logger.meters["acc5"].update(acc5.item(), n=batch_size)
             metric_logger.meters["img/s"].update(
-                batch_size / (time.time() - start_time)
+                samples=batch_size, elapsed_time=time.time() - start_time
             )
         # gather the stats from all processes
         metric_logger.synchronize_between_processes()

--- a/spikingjelly/activation_based/model/train_classify.py
+++ b/spikingjelly/activation_based/model/train_classify.py
@@ -50,6 +50,14 @@ def seed_worker(worker_id):
 
 
 class Trainer:
+    def get_data_to_device_kwargs(self, args):
+        return {"non_blocking": not args.disable_pinmemory}
+
+    def format_input_tensor(self, args, x: torch.Tensor) -> torch.Tensor:
+        if getattr(args, "channels_last", False) and x.ndim == 4:
+            return x.contiguous(memory_format=torch.channels_last)
+        return x
+
     def cal_acc1_acc5(self, output, target):
         # define how to calculate acc1 and acc5
         acc1, acc5 = utils.accuracy(output, target, topk=(1, 5))
@@ -66,6 +74,47 @@ class Trainer:
     def process_model_output(self, args, y: torch.Tensor):
         # define how to process y = model(x)
         return y
+
+    def compile_model(
+        self, args, model: nn.Module, *, enabled: bool | None = None
+    ) -> nn.Module:
+        if enabled is None:
+            enabled = args.compile
+
+        if not enabled:
+            return model
+
+        if not hasattr(torch, "compile"):
+            raise RuntimeError(
+                "torch.compile is not available in the current PyTorch version."
+            )
+
+        compile_kwargs = {"backend": args.compile_backend}
+        if args.compile_mode is not None:
+            compile_kwargs["mode"] = args.compile_mode
+
+        if args.compile_backend == "inductor":
+            compile_options = {}
+            if args.compile_disable_cudagraphs:
+                compile_options.update(
+                    {
+                        "triton.cudagraphs": False,
+                        "triton.cudagraph_trees": False,
+                    }
+                )
+            if compile_options:
+                compile_kwargs["options"] = compile_options
+
+        try:
+            return torch.compile(model, **compile_kwargs)
+        except RuntimeError:
+            compile_kwargs.pop("options", None)
+            return torch.compile(model, **compile_kwargs)
+
+    def get_eval_model(self, args, train_model, model_without_ddp):
+        if args.compile and not args.compile_eval:
+            return model_without_ddp
+        return train_model
 
     def train_one_epoch(
         self,
@@ -87,17 +136,20 @@ class Trainer:
         )
 
         header = f"Epoch: [{epoch}]"
+        data_to_device_kwargs = self.get_data_to_device_kwargs(args)
         for i, (image, target) in enumerate(
             metric_logger.log_every(data_loader, -1, header)
         ):
             start_time = time.time()
-            image, target = image.to(device), target.to(device)
+            image = image.to(device, **data_to_device_kwargs)
+            image = self.format_input_tensor(args, image)
+            target = target.to(device, **data_to_device_kwargs)
             with torch.cuda.amp.autocast(enabled=scaler is not None):
                 image = self.preprocess_train_sample(args, image)
                 output = self.process_model_output(args, model(image))
                 loss = criterion(output, target)
 
-            optimizer.zero_grad()
+            optimizer.zero_grad(set_to_none=True)
             if scaler is not None:
                 scaler.scale(loss).backward()
                 if args.clip_grad_norm is not None:
@@ -143,13 +195,15 @@ class Trainer:
         model.eval()
         metric_logger = utils.MetricLogger(delimiter="  ")
         header = f"Test: {log_suffix}"
+        data_to_device_kwargs = self.get_data_to_device_kwargs(args)
 
         num_processed_samples = 0
         start_time = time.time()
         with torch.inference_mode():
             for image, target in metric_logger.log_every(data_loader, -1, header):
-                image = image.to(device, non_blocking=True)
-                target = target.to(device, non_blocking=True)
+                image = image.to(device, **data_to_device_kwargs)
+                image = self.format_input_tensor(args, image)
+                target = target.to(device, **data_to_device_kwargs)
                 image = self.preprocess_test_sample(args, image)
                 output = self.process_model_output(args, model(image))
                 loss = criterion(output, target)
@@ -499,6 +553,10 @@ class Trainer:
             pin_memory=not args.disable_pinmemory,
             collate_fn=collate_fn,
             worker_init_fn=seed_worker,
+            persistent_workers=args.persistent_workers and args.workers > 0,
+            prefetch_factor=(
+                args.prefetch_factor if args.workers > 0 else None
+            ),
         )
 
         data_loader_test = torch.utils.data.DataLoader(
@@ -508,11 +566,17 @@ class Trainer:
             num_workers=args.workers,
             pin_memory=not args.disable_pinmemory,
             worker_init_fn=seed_worker,
+            persistent_workers=args.persistent_workers and args.workers > 0,
+            prefetch_factor=(
+                args.prefetch_factor if args.workers > 0 else None
+            ),
         )
 
         print("Creating model")
         model = self.load_model(args, num_classes)
         model.to(device)
+        if args.channels_last:
+            model.to(memory_format=torch.channels_last)
         print(model)
 
         if args.distributed and args.sync_bn:
@@ -541,11 +605,6 @@ class Trainer:
         lr_scheduler = self.set_lr_scheduler(args, optimizer)
 
         model_without_ddp = model
-        if args.distributed:
-            model = torch.nn.parallel.DistributedDataParallel(
-                model, device_ids=[args.gpu]
-            )
-            model_without_ddp = model.module
 
         model_ema = None
         if args.model_ema:
@@ -607,6 +666,14 @@ class Trainer:
                 if model_ema:
                     max_ema_test_acc1 = checkpoint["max_ema_test_acc1"]
 
+        model = self.compile_model(args, model_without_ddp)
+        eval_model = self.get_eval_model(args, model, model_without_ddp)
+
+        if args.distributed:
+            model = torch.nn.parallel.DistributedDataParallel(
+                model, device_ids=[args.gpu]
+            )
+
         if utils.is_main_process():
             tb_writer = SummaryWriter(tb_dir, purge_step=args.start_epoch)
             with open(
@@ -631,7 +698,9 @@ class Trainer:
                     log_suffix="EMA",
                 )
             else:
-                self.evaluate(args, model, criterion, data_loader_test, device=device)
+                self.evaluate(
+                    args, eval_model, criterion, data_loader_test, device=device
+                )
             return
 
         for epoch in range(args.start_epoch, args.epochs):
@@ -657,9 +726,9 @@ class Trainer:
                 tb_writer.add_scalar("train_acc5", train_acc5, epoch)
 
             lr_scheduler.step()
-            self.before_test_one_epoch(args, model, epoch)
+            self.before_test_one_epoch(args, eval_model, epoch)
             test_loss, test_acc1, test_acc5 = self.evaluate(
-                args, model, criterion, data_loader_test, device=device
+                args, eval_model, criterion, data_loader_test, device=device
             )
             if utils.is_main_process():
                 tb_writer.add_scalar("test_loss", test_loss, epoch)
@@ -993,9 +1062,52 @@ class Trainer:
             help="not use pin memory in dataloader, which can help reduce memory consumption",
         )
         parser.add_argument(
+            "--persistent-workers",
+            action="store_true",
+            help="keep dataloader workers alive across epochs for better throughput",
+        )
+        parser.add_argument(
+            "--prefetch-factor",
+            default=2,
+            type=int,
+            help="number of batches prefetched by each dataloader worker (default: 2)",
+        )
+        parser.add_argument(
             "--disable-amp",
             action="store_true",
             help="not use automatic mixed precision training",
+        )
+        parser.add_argument(
+            "--channels-last",
+            action="store_true",
+            help="use channels_last memory format for 4D image tensors and conv-heavy models",
+        )
+        parser.add_argument(
+            "--compile",
+            action="store_true",
+            help="compile the training model with torch.compile",
+        )
+        parser.add_argument(
+            "--compile-backend",
+            default="inductor",
+            type=str,
+            help="backend passed to torch.compile (default: inductor)",
+        )
+        parser.add_argument(
+            "--compile-mode",
+            default=None,
+            type=str,
+            help="optional mode passed to torch.compile, e.g. default or max-autotune",
+        )
+        parser.add_argument(
+            "--compile-disable-cudagraphs",
+            action="store_true",
+            help="disable Inductor cudagraph options for better cross-version stability",
+        )
+        parser.add_argument(
+            "--compile-eval",
+            action="store_true",
+            help="also compile evaluation instead of using the eager model for validation",
         )
         parser.add_argument(
             "--local_rank",

--- a/spikingjelly/activation_based/model/train_classify.py
+++ b/spikingjelly/activation_based/model/train_classify.py
@@ -53,11 +53,6 @@ class Trainer:
     def get_data_to_device_kwargs(self, args):
         return {"non_blocking": not args.disable_pinmemory}
 
-    def format_input_tensor(self, args, x: torch.Tensor) -> torch.Tensor:
-        if getattr(args, "channels_last", False) and x.ndim == 4:
-            return x.contiguous(memory_format=torch.channels_last)
-        return x
-
     def cal_acc1_acc5(self, output, target):
         # define how to calculate acc1 and acc5
         acc1, acc5 = utils.accuracy(output, target, topk=(1, 5))
@@ -142,7 +137,6 @@ class Trainer:
         ):
             start_time = time.time()
             image = image.to(device, **data_to_device_kwargs)
-            image = self.format_input_tensor(args, image)
             target = target.to(device, **data_to_device_kwargs)
             with torch.cuda.amp.autocast(enabled=scaler is not None):
                 image = self.preprocess_train_sample(args, image)
@@ -202,7 +196,6 @@ class Trainer:
         with torch.inference_mode():
             for image, target in metric_logger.log_every(data_loader, -1, header):
                 image = image.to(device, **data_to_device_kwargs)
-                image = self.format_input_tensor(args, image)
                 target = target.to(device, **data_to_device_kwargs)
                 image = self.preprocess_test_sample(args, image)
                 output = self.process_model_output(args, model(image))
@@ -575,8 +568,6 @@ class Trainer:
         print("Creating model")
         model = self.load_model(args, num_classes)
         model.to(device)
-        if args.channels_last:
-            model.to(memory_format=torch.channels_last)
         print(model)
 
         if args.distributed and args.sync_bn:
@@ -1076,11 +1067,6 @@ class Trainer:
             "--disable-amp",
             action="store_true",
             help="not use automatic mixed precision training",
-        )
-        parser.add_argument(
-            "--channels-last",
-            action="store_true",
-            help="use channels_last memory format for 4D image tensors and conv-heavy models",
         )
         parser.add_argument(
             "--compile",

--- a/spikingjelly/activation_based/model/train_classify.py
+++ b/spikingjelly/activation_based/model/train_classify.py
@@ -104,7 +104,13 @@ class Trainer:
             return torch.compile(model, **compile_kwargs)
         except RuntimeError as e:
             compile_options = compile_kwargs.get("options")
-            if not compile_options:
+            error_text = str(e).lower()
+            retryable_option_error = (
+                "options" in error_text
+                or "cudagraph" in error_text
+                or "config" in error_text
+            )
+            if not compile_options or not retryable_option_error:
                 raise
             warnings.warn(
                 "torch.compile failed with backend options "

--- a/spikingjelly/activation_based/model/train_flexsn_inductor_example.py
+++ b/spikingjelly/activation_based/model/train_flexsn_inductor_example.py
@@ -1,3 +1,10 @@
+"""Example training entrypoint for FlexSN inductor models.
+
+This script mirrors ``train_imagenet_example.py`` but uses ``spiking_vgg`` with
+``FlexSN(backend="inductor")`` and defaults to ``torch.compile`` so users can
+exercise the compile-friendly FlexSN training path end-to-end.
+"""
+
 import torch
 from spikingjelly.activation_based import functional, surrogate
 from spikingjelly.activation_based.model import spiking_vgg, train_classify

--- a/spikingjelly/activation_based/model/train_flexsn_inductor_example.py
+++ b/spikingjelly/activation_based/model/train_flexsn_inductor_example.py
@@ -1,0 +1,70 @@
+import torch
+from spikingjelly.activation_based import functional, surrogate
+from spikingjelly.activation_based.model import spiking_vgg, train_classify
+from spikingjelly.activation_based.neuron.flexsn import FlexSN
+
+
+class FlexSNTrainer(train_classify.Trainer):
+    def preprocess_train_sample(self, args, x: torch.Tensor):
+        return x.unsqueeze(0).expand(args.T, -1, -1, -1, -1)
+
+    def preprocess_test_sample(self, args, x: torch.Tensor):
+        return x.unsqueeze(0).expand(args.T, -1, -1, -1, -1)
+
+    def process_model_output(self, args, y: torch.Tensor):
+        return y.mean(0)
+
+    def get_args_parser(self, add_help=True):
+        parser = super().get_args_parser(add_help=add_help)
+        parser.add_argument("--T", type=int, default=4, help="total time-steps")
+        parser.add_argument(
+            "--surrogate-alpha",
+            type=float,
+            default=4.0,
+            help="alpha for surrogate.Sigmoid used by the FlexSN core",
+        )
+        parser.set_defaults(compile=True, compile_eval=False, disable_uda=True)
+        return parser
+
+    def get_tb_logdir_name(self, args):
+        return (
+            super().get_tb_logdir_name(args)
+            + f"_T{args.T}_flexsn_inductor_sa{args.surrogate_alpha}"
+        )
+
+    def load_model(self, args, num_classes):
+        if args.model not in spiking_vgg.__all__:
+            raise ValueError(f"args.model should be one of {spiking_vgg.__all__}")
+
+        sg = surrogate.Sigmoid(alpha=args.surrogate_alpha)
+
+        def lif_core_sg(x: torch.Tensor, v: torch.Tensor):
+            tau, v_th = 2.0, 1.0
+            h = v + (x - v) / tau
+            s = sg(h - v_th)
+            return s, h * (1.0 - s)
+
+        def make_flexsn(**kwargs):
+            return FlexSN(
+                core=lif_core_sg,
+                num_inputs=1,
+                num_states=1,
+                num_outputs=1,
+                step_mode=kwargs.get("step_mode", "m"),
+                backend="inductor",
+            )
+
+        model = spiking_vgg.__dict__[args.model](
+            pretrained=args.pretrained,
+            spiking_neuron=make_flexsn,
+            num_classes=num_classes,
+        )
+        functional.set_step_mode(model, step_mode="m")
+        return model
+
+
+if __name__ == "__main__":
+    # python -m spikingjelly.activation_based.model.train_flexsn_inductor_example --model spiking_vgg11_bn --data-path /datasets/ImageNet0_03125 --batch-size 64 --lr 0.1 --lr-scheduler cosa --epochs 90
+    trainer = FlexSNTrainer()
+    args = trainer.get_args_parser().parse_args()
+    trainer.main(args)

--- a/spikingjelly/activation_based/model/train_imagenet_example.py
+++ b/spikingjelly/activation_based/model/train_imagenet_example.py
@@ -6,14 +6,14 @@ from spikingjelly.activation_based.model import spiking_resnet, train_classify
 class SResNetTrainer(train_classify.Trainer):
     def preprocess_train_sample(self, args, x: torch.Tensor):
         # define how to process train sample before send it to model
-        return x.unsqueeze(0).repeat(
-            args.T, 1, 1, 1, 1
+        return x.unsqueeze(0).expand(
+            args.T, -1, -1, -1, -1
         )  # [N, C, H, W] -> [T, N, C, H, W]
 
     def preprocess_test_sample(self, args, x: torch.Tensor):
         # define how to process test sample before send it to model
-        return x.unsqueeze(0).repeat(
-            args.T, 1, 1, 1, 1
+        return x.unsqueeze(0).expand(
+            args.T, -1, -1, -1, -1
         )  # [N, C, H, W] -> [T, N, C, H, W]
 
     def process_model_output(self, args, y: torch.Tensor):

--- a/spikingjelly/activation_based/model/tv_ref_classify/utils.py
+++ b/spikingjelly/activation_based/model/tv_ref_classify/utils.py
@@ -97,10 +97,9 @@ class ThroughputValue:
         if not is_dist_avail_and_initialized():
             return
 
-        samples = torch.tensor(
-            self.total_samples, device="cuda", dtype=torch.float64
-        )
-        elapsed = torch.tensor(self.total_time, device="cuda", dtype=torch.float64)
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        samples = torch.tensor(self.total_samples, device=device, dtype=torch.float64)
+        elapsed = torch.tensor(self.total_time, device=device, dtype=torch.float64)
         dist.barrier()
         dist.all_reduce(samples, op=dist.ReduceOp.SUM)
         dist.all_reduce(elapsed, op=dist.ReduceOp.MAX)

--- a/spikingjelly/activation_based/model/tv_ref_classify/utils.py
+++ b/spikingjelly/activation_based/model/tv_ref_classify/utils.py
@@ -93,10 +93,16 @@ class ThroughputValue:
 
         Windowed statistics stored in ``deque`` remain local to each rank.
         """
-        t = reduce_across_processes([self.total_samples, self.total_time])
-        t = t.tolist()
-        self.total_samples = t[0]
-        self.total_time = t[1]
+        if not is_dist_avail_and_initialized():
+            return
+
+        samples = torch.tensor(self.total_samples, device="cuda")
+        elapsed = torch.tensor(self.total_time, device="cuda")
+        dist.barrier()
+        dist.all_reduce(samples, op=dist.ReduceOp.SUM)
+        dist.all_reduce(elapsed, op=dist.ReduceOp.MAX)
+        self.total_samples = samples.item()
+        self.total_time = elapsed.item()
 
     @property
     def median(self):

--- a/spikingjelly/activation_based/model/tv_ref_classify/utils.py
+++ b/spikingjelly/activation_based/model/tv_ref_classify/utils.py
@@ -69,6 +69,63 @@ class SmoothedValue:
         )
 
 
+class ThroughputValue:
+    """Track throughput as total_samples / total_time."""
+
+    def __init__(self, window_size=20, fmt=None):
+        if fmt is None:
+            fmt = "{global_avg:.4f}"
+        self.deque = deque(maxlen=window_size)
+        self.total_samples = 0.0
+        self.total_time = 0.0
+        self.fmt = fmt
+
+    def update(self, samples, elapsed_time):
+        throughput = samples / elapsed_time
+        self.deque.append(throughput)
+        self.total_samples += samples
+        self.total_time += elapsed_time
+
+    def synchronize_between_processes(self):
+        t = reduce_across_processes([self.total_samples, self.total_time])
+        t = t.tolist()
+        self.total_samples = t[0]
+        self.total_time = t[1]
+
+    @property
+    def median(self):
+        d = torch.tensor(list(self.deque))
+        return d.median().item()
+
+    @property
+    def avg(self):
+        d = torch.tensor(list(self.deque), dtype=torch.float32)
+        return d.mean().item()
+
+    @property
+    def global_avg(self):
+        if self.total_time == 0.0:
+            return 0.0
+        return self.total_samples / self.total_time
+
+    @property
+    def max(self):
+        return max(self.deque)
+
+    @property
+    def value(self):
+        return self.deque[-1]
+
+    def __str__(self):
+        return self.fmt.format(
+            median=self.median,
+            avg=self.avg,
+            global_avg=self.global_avg,
+            max=self.max,
+            value=self.value,
+        )
+
+
 class MetricLogger:
     def __init__(self, delimiter="\t"):
         self.meters = defaultdict(SmoothedValue)

--- a/spikingjelly/activation_based/model/tv_ref_classify/utils.py
+++ b/spikingjelly/activation_based/model/tv_ref_classify/utils.py
@@ -100,11 +100,15 @@ class ThroughputValue:
 
     @property
     def median(self):
+        if not self.deque:
+            return 0.0
         d = torch.tensor(list(self.deque))
         return d.median().item()
 
     @property
     def avg(self):
+        if not self.deque:
+            return 0.0
         d = torch.tensor(list(self.deque), dtype=torch.float32)
         return d.mean().item()
 
@@ -116,10 +120,14 @@ class ThroughputValue:
 
     @property
     def max(self):
+        if not self.deque:
+            return 0.0
         return max(self.deque)
 
     @property
     def value(self):
+        if not self.deque:
+            return 0.0
         return self.deque[-1]
 
     def __str__(self):

--- a/spikingjelly/activation_based/model/tv_ref_classify/utils.py
+++ b/spikingjelly/activation_based/model/tv_ref_classify/utils.py
@@ -81,12 +81,18 @@ class ThroughputValue:
         self.fmt = fmt
 
     def update(self, samples, elapsed_time):
+        if elapsed_time <= 0:
+            return
         throughput = samples / elapsed_time
         self.deque.append(throughput)
         self.total_samples += samples
         self.total_time += elapsed_time
 
     def synchronize_between_processes(self):
+        """Synchronize cumulative samples/time across ranks.
+
+        Windowed statistics stored in ``deque`` remain local to each rank.
+        """
         t = reduce_across_processes([self.total_samples, self.total_time])
         t = t.tolist()
         self.total_samples = t[0]

--- a/spikingjelly/activation_based/model/tv_ref_classify/utils.py
+++ b/spikingjelly/activation_based/model/tv_ref_classify/utils.py
@@ -3,6 +3,7 @@ import datetime
 import errno
 import hashlib
 import os
+import statistics
 import time
 from collections import defaultdict, deque, OrderedDict
 
@@ -96,8 +97,10 @@ class ThroughputValue:
         if not is_dist_avail_and_initialized():
             return
 
-        samples = torch.tensor(self.total_samples, device="cuda")
-        elapsed = torch.tensor(self.total_time, device="cuda")
+        samples = torch.tensor(
+            self.total_samples, device="cuda", dtype=torch.float64
+        )
+        elapsed = torch.tensor(self.total_time, device="cuda", dtype=torch.float64)
         dist.barrier()
         dist.all_reduce(samples, op=dist.ReduceOp.SUM)
         dist.all_reduce(elapsed, op=dist.ReduceOp.MAX)
@@ -108,15 +111,13 @@ class ThroughputValue:
     def median(self):
         if not self.deque:
             return 0.0
-        d = torch.tensor(list(self.deque))
-        return d.median().item()
+        return float(statistics.median(self.deque))
 
     @property
     def avg(self):
         if not self.deque:
             return 0.0
-        d = torch.tensor(list(self.deque), dtype=torch.float32)
-        return d.mean().item()
+        return sum(self.deque) / len(self.deque)
 
     @property
     def global_avg(self):

--- a/spikingjelly/activation_based/neuron/base_node.py
+++ b/spikingjelly/activation_based/neuron/base_node.py
@@ -351,7 +351,16 @@ class BaseNode(base.MemoryModule):
     def v_float_to_tensor(self, x: torch.Tensor):
         if isinstance(self.v, float):
             v_init = self.v
-            self.v = torch.full_like(x.data, v_init)
+            self.v = torch.full_like(x, v_init)
+        elif (
+            isinstance(self.v, torch.Tensor)
+            and (
+                self.v.shape != x.shape
+                or self.v.dtype != x.dtype
+                or self.v.device != x.device
+            )
+        ):
+            self.v = torch.full_like(x, self.v_reset if self.v_reset is not None else 0.0)
 
 
 class NonSpikingBaseNode(nn.Module, base.MultiStepModule):

--- a/spikingjelly/activation_based/neuron/base_node.py
+++ b/spikingjelly/activation_based/neuron/base_node.py
@@ -351,7 +351,7 @@ class BaseNode(base.MemoryModule):
     def v_float_to_tensor(self, x: torch.Tensor):
         if isinstance(self.v, float):
             v_init = self.v
-            self.v = torch.full_like(x, v_init)
+            self.v = torch.full_like(x, v_init, requires_grad=False)
         elif isinstance(self.v, torch.Tensor):
             if self.v.shape != x.shape:
                 self.v = torch.full_like(

--- a/spikingjelly/activation_based/neuron/base_node.py
+++ b/spikingjelly/activation_based/neuron/base_node.py
@@ -355,7 +355,9 @@ class BaseNode(base.MemoryModule):
         elif isinstance(self.v, torch.Tensor):
             if self.v.shape != x.shape:
                 self.v = torch.full_like(
-                    x, self.v_reset if self.v_reset is not None else 0.0
+                    x,
+                    self.v_reset if self.v_reset is not None else 0.0,
+                    requires_grad=False,
                 )
             elif self.v.dtype != x.dtype or self.v.device != x.device:
                 self.v = self.v.to(dtype=x.dtype, device=x.device)

--- a/spikingjelly/activation_based/neuron/base_node.py
+++ b/spikingjelly/activation_based/neuron/base_node.py
@@ -352,15 +352,13 @@ class BaseNode(base.MemoryModule):
         if isinstance(self.v, float):
             v_init = self.v
             self.v = torch.full_like(x, v_init)
-        elif (
-            isinstance(self.v, torch.Tensor)
-            and (
-                self.v.shape != x.shape
-                or self.v.dtype != x.dtype
-                or self.v.device != x.device
-            )
-        ):
-            self.v = torch.full_like(x, self.v_reset if self.v_reset is not None else 0.0)
+        elif isinstance(self.v, torch.Tensor):
+            if self.v.shape != x.shape:
+                self.v = torch.full_like(
+                    x, self.v_reset if self.v_reset is not None else 0.0
+                )
+            elif self.v.dtype != x.dtype or self.v.device != x.device:
+                self.v = self.v.to(dtype=x.dtype, device=x.device)
 
 
 class NonSpikingBaseNode(nn.Module, base.MultiStepModule):

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -37,7 +37,7 @@ def _validate_scan_backend_contract(
             torch.zeros(1, device=device) for _ in range(num_inputs + num_states)
         )
     else:
-        device = "cuda" if torch.cuda.is_available() else example_inputs[0].device
+        device = example_inputs[0].device
         example_inputs = tuple(x.detach().to(device).clone() for x in example_inputs)
 
     with torch.no_grad():

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -255,6 +255,7 @@ class FlexSN(base.MemoryModule):
                     build_inference_kernel, build_training_kernels,
                 )
                 from ..triton_kernel.flex_sn_inductor.custom_ops import (
+                    attach_flexsn_handle_finalizer,
                     register_flexsn_kernel_handle,
                 )
             except Exception as e:
@@ -264,6 +265,7 @@ class FlexSN(base.MemoryModule):
                 )
                 build_inference_kernel = None
                 build_training_kernels = None
+                attach_flexsn_handle_finalizer = None
                 register_flexsn_kernel_handle = None
             if build_inference_kernel is not None:
                 try:
@@ -316,6 +318,11 @@ class FlexSN(base.MemoryModule):
                 backward_kernel=self._inductor_bwd_kernel,
                 training_info=self._inductor_train_info,
             )
+            self._inductor_handle_finalizer = attach_flexsn_handle_finalizer(
+                self, self._inductor_handle
+            )
+        else:
+            self._inductor_handle_finalizer = None
 
         # register states as memory buffers
         self.register_memory("states", None)
@@ -440,7 +447,8 @@ class FlexSN(base.MemoryModule):
                 a.requires_grad for a in (*args, *self.states)
             )
             flat_args = [*(a.contiguous() for a in args), *(s.contiguous() for s in self.states)]
-            if self._inductor_handle is not None and args[0].is_cuda:
+            has_cuda_tensor = any(t.is_cuda for t in flat_args)
+            if self._inductor_handle is not None and has_cuda_tensor:
                 from ..triton_kernel.flex_sn_inductor.custom_ops import (
                     flexsn_inductor_inference,
                     flexsn_inductor_training,
@@ -469,7 +477,10 @@ class FlexSN(base.MemoryModule):
                         "eager_scan failed to import. "
                         "See logs from spikingjelly.activation_based.triton_kernel.flex_sn_inductor."
                     )
-                scan_impl = flex_sn_scan if flex_sn_scan is not None else eager_scan
+                if torch.compiler.is_compiling() or flex_sn_scan is None:
+                    scan_impl = eager_scan
+                else:
+                    scan_impl = flex_sn_scan
                 result_seqs = scan_impl(
                     self.core,
                     self.num_inputs,

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -446,7 +446,7 @@ class FlexSN(base.MemoryModule):
             _no_grad = not torch.is_grad_enabled() or not any(
                 a.requires_grad for a in (*args, *self.states)
             )
-            flat_args = [*(a.contiguous() for a in args), *(s.contiguous() for s in self.states)]
+            flat_args = [*args, *self.states]
             has_cuda_tensor = any(t.is_cuda for t in flat_args)
             if self._inductor_handle is not None and has_cuda_tensor:
                 from ..triton_kernel.flex_sn_inductor.custom_ops import (

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -15,6 +15,57 @@ except BaseException as e:
 __all__ = ["FlexSNKernel", "FlexSN"]
 
 
+def _as_tuple(outputs):
+    if isinstance(outputs, torch.Tensor):
+        return (outputs,)
+    return tuple(outputs)
+
+
+def _validate_scan_backend_contract(
+    core: Callable,
+    num_inputs: int,
+    num_states: int,
+    num_outputs: int,
+    example_inputs: Optional[Tuple[torch.Tensor, ...]],
+):
+    if num_inputs + num_states == 0:
+        raise ValueError("FlexSN requires at least one input or state tensor.")
+
+    if example_inputs is None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        example_inputs = tuple(
+            torch.zeros(1, device=device) for _ in range(num_inputs + num_states)
+        )
+    else:
+        device = "cuda" if torch.cuda.is_available() else example_inputs[0].device
+        example_inputs = tuple(x.detach().to(device).clone() for x in example_inputs)
+
+    with torch.no_grad():
+        returns = _as_tuple(core(*example_inputs))
+
+    expected = num_outputs + num_states
+    if len(returns) != expected:
+        raise ValueError(
+            f"FlexSN core returned {len(returns)} values, but expected "
+            f"{expected} (= num_outputs + num_states)."
+        )
+
+    seq_template = example_inputs[0]
+    for i, tensor in enumerate(returns):
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(
+                f"FlexSN core return #{i} is {type(tensor)!r}; "
+                "scan backends require tensor outputs."
+            )
+        if tensor.shape != seq_template.shape:
+            raise ValueError(
+                "FlexSN triton/inductor scan backends currently require every "
+                "per-step output and updated state to have the same shape as "
+                f"the first example tensor {tuple(seq_template.shape)}, but "
+                f"return #{i} has shape {tuple(tensor.shape)}."
+            )
+
+
 class FlexSNKernel:
     def __init__(
         self,
@@ -241,6 +292,11 @@ class FlexSN(base.MemoryModule):
         self.backend = backend
         self.store_state_seqs = store_state_seqs
 
+        if backend in ("triton", "inductor"):
+            _validate_scan_backend_contract(
+                core, num_inputs, num_states, num_outputs, example_inputs
+            )
+
         if backend == "triton":
             self.kernel = FlexSNKernel(
                 core, num_inputs, num_states, num_outputs, example_inputs, requires_grad
@@ -258,7 +314,7 @@ class FlexSN(base.MemoryModule):
                     attach_flexsn_handle_finalizer,
                     register_flexsn_kernel_handle,
                 )
-            except Exception as e:
+            except (ImportError, RuntimeError) as e:
                 logging.warning(
                     "FlexSN: could not import inductor kernel builders (%s); "
                     "falling back to eager_scan/flex_sn_scan for all paths." % e

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Callable, Optional, Tuple, List
 import logging
 
@@ -389,6 +390,35 @@ class FlexSN(base.MemoryModule):
 
         # register states as memory buffers
         self.register_memory("states", None)
+
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+
+        for key, value in self.__dict__.items():
+            if key == "_inductor_handle_finalizer":
+                continue
+            result.__dict__[key] = copy.deepcopy(value, memo)
+
+        handle = result.__dict__.get("_inductor_handle")
+        if handle is not None:
+            try:
+                from ..triton_kernel.flex_sn_inductor.custom_ops import (
+                    attach_flexsn_handle_finalizer,
+                    retain_owner_flexsn_kernel_handle,
+                )
+            except (ImportError, RuntimeError):
+                result._inductor_handle_finalizer = None
+            else:
+                retain_owner_flexsn_kernel_handle(handle)
+                result._inductor_handle_finalizer = attach_flexsn_handle_finalizer(
+                    result, handle
+                )
+        else:
+            result._inductor_handle_finalizer = None
+
+        return result
 
     @property
     def supported_backends(self):

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -304,8 +304,15 @@ class FlexSN(base.MemoryModule):
             self._inductor_bwd_kernel = None
             self._inductor_train_info = None
         self._inductor_handle = None
-        self._inductor_inference_available = self._inductor_scan_kernel is not None
-        self._inductor_training_available = self._inductor_fwd_kernel is not None
+        self._inductor_inference_available = (
+            self._inductor_scan_kernel is not None
+            and self._inductor_scan_info is not None
+        )
+        self._inductor_training_available = (
+            self._inductor_fwd_kernel is not None
+            and self._inductor_bwd_kernel is not None
+            and self._inductor_train_info is not None
+        )
         if (
             backend == "inductor"
             and register_flexsn_kernel_handle is not None
@@ -447,8 +454,9 @@ class FlexSN(base.MemoryModule):
                 a.requires_grad for a in (*args, *self.states)
             )
             flat_args = [*args, *self.states]
-            has_cuda_tensor = any(t.is_cuda for t in flat_args)
-            if self._inductor_handle is not None and has_cuda_tensor:
+            all_cuda = len(flat_args) > 0 and all(t.is_cuda for t in flat_args)
+            same_device = len({t.device for t in flat_args}) == 1
+            if self._inductor_handle is not None and all_cuda and same_device:
                 from ..triton_kernel.flex_sn_inductor.custom_ops import (
                     flexsn_inductor_inference,
                     flexsn_inductor_training,

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -247,11 +247,15 @@ class FlexSN(base.MemoryModule):
             )
         else:
             self.kernel = None
+        register_flexsn_kernel_handle = None
 
         if backend == "inductor" and torch.cuda.is_available():
             try:
                 from ..triton_kernel.flex_sn_inductor.kernel import (
                     build_inference_kernel, build_training_kernels,
+                )
+                from ..triton_kernel.flex_sn_inductor.custom_ops import (
+                    register_flexsn_kernel_handle,
                 )
             except Exception as e:
                 logging.warning(
@@ -260,6 +264,7 @@ class FlexSN(base.MemoryModule):
                 )
                 build_inference_kernel = None
                 build_training_kernels = None
+                register_flexsn_kernel_handle = None
             if build_inference_kernel is not None:
                 try:
                     self._inductor_scan_kernel, self._inductor_scan_info = (
@@ -296,24 +301,21 @@ class FlexSN(base.MemoryModule):
             self._inductor_fwd_kernel = None
             self._inductor_bwd_kernel = None
             self._inductor_train_info = None
-
-        # Pre-create a @torch._dynamo.disable-wrapped training scan so that
-        # torch.compile (without fullgraph=True) creates a safe graph break
-        # here instead of replacing the Triton kernels with the slow eager_scan.
-        if backend == "inductor" and self._inductor_fwd_kernel is not None:
-            from ..triton_kernel.flexsn.wrapper import FlexSNFunction as _FSF
-            _inf_k = self._inductor_scan_kernel
-            _fwd_k = self._inductor_fwd_kernel
-            _bwd_k = self._inductor_bwd_kernel
-            _info  = self._inductor_train_info
-
-            @torch._dynamo.disable
-            def _disabled_triton_scan(*_args):
-                return _FSF.apply(_inf_k, _fwd_k, _bwd_k, _info, *_args)
-
-            self._triton_scan_disabled = _disabled_triton_scan
-        else:
-            self._triton_scan_disabled = None
+        self._inductor_handle = None
+        self._inductor_inference_available = self._inductor_scan_kernel is not None
+        self._inductor_training_available = self._inductor_fwd_kernel is not None
+        if (
+            backend == "inductor"
+            and register_flexsn_kernel_handle is not None
+            and (self._inductor_inference_available or self._inductor_training_available)
+        ):
+            self._inductor_handle = register_flexsn_kernel_handle(
+                inference_kernel=self._inductor_scan_kernel,
+                inference_info=self._inductor_scan_info,
+                forward_kernel=self._inductor_fwd_kernel,
+                backward_kernel=self._inductor_bwd_kernel,
+                training_info=self._inductor_train_info,
+            )
 
         # register states as memory buffers
         self.register_memory("states", None)
@@ -434,66 +436,48 @@ class FlexSN(base.MemoryModule):
             return output_seqs
 
         elif self.backend == "inductor":
-            # M3.b: no-grad path uses the pre-built single Triton scan kernel
-            # (one launch, tl.static_range(T) — fixes T=32 perf regression).
-            # Training path keeps eager_scan so BPTT backward is correct.
             _no_grad = not torch.is_grad_enabled() or not any(
                 a.requires_grad for a in (*args, *self.states)
             )
-            if _no_grad and self._inductor_scan_kernel is not None and args[0].is_cuda:
-                # Inference fast path: single tl.static_range(T) kernel
-                from ..triton_kernel.flexsn.wrapper import flexsn_inference
+            flat_args = [*(a.contiguous() for a in args), *(s.contiguous() for s in self.states)]
+            if self._inductor_handle is not None and args[0].is_cuda:
+                from ..triton_kernel.flex_sn_inductor.custom_ops import (
+                    flexsn_inductor_inference,
+                    flexsn_inductor_training,
+                )
 
-                result_seqs = flexsn_inference(
-                    self._inductor_scan_kernel,
-                    self._inductor_scan_info,
-                    *(a.contiguous() for a in args),
-                    *(s.contiguous() for s in self.states),
-                )
-            elif (not _no_grad
-                  and self._triton_scan_disabled is not None
-                  and args[0].is_cuda):
-                # Training: @torch._dynamo.disable-wrapped Triton fwd+bwd scan.
-                # Under torch.compile (no fullgraph) Dynamo creates a graph break
-                # here; surrounding layers are still compiled, FlexSN stays fast.
-                result_seqs = self._triton_scan_disabled(
-                    *(a.contiguous() for a in args),
-                    *(s.contiguous() for s in self.states),
-                )
+                if _no_grad and self._inductor_inference_available:
+                    result_seqs = flexsn_inductor_inference(
+                        self._inductor_handle, flat_args
+                    )
+                elif (not _no_grad) and self._inductor_training_available:
+                    result_seqs = flexsn_inductor_training(
+                        self._inductor_handle, flat_args
+                    )
+                    result_seqs = result_seqs[: self.num_outputs + self.num_states]
+                else:
+                    result_seqs = None
             else:
-                # CPU / training kernel unavailable: eager_scan fallback
-                from ..triton_kernel.flex_sn_inductor import eager_scan
+                result_seqs = None
 
-                # eager_scan and flex_sn_scan are both None when the whole
-                # flex_sn_inductor module fails to import; check once here
-                # so both branches get a clear RuntimeError instead of
-                # a confusing TypeError: 'NoneType' is not callable.
+            if result_seqs is None:
+                from ..triton_kernel.flex_sn_inductor import eager_scan, flex_sn_scan
+
                 if eager_scan is None:
                     raise RuntimeError(
                         "FlexSN inductor backend is unavailable: "
                         "eager_scan failed to import. "
                         "See logs from spikingjelly.activation_based.triton_kernel.flex_sn_inductor."
                     )
-                if torch.compiler.is_compiling():
-                    result_seqs = eager_scan(
-                        self.core,
-                        self.num_inputs,
-                        self.num_states,
-                        self.num_outputs,
-                        *args,
-                        *self.states,
-                    )
-                else:
-                    from ..triton_kernel.flex_sn_inductor import flex_sn_scan
-
-                    result_seqs = flex_sn_scan(
-                        self.core,
-                        self.num_inputs,
-                        self.num_states,
-                        self.num_outputs,
-                        *args,
-                        *self.states,
-                    )
+                scan_impl = flex_sn_scan if flex_sn_scan is not None else eager_scan
+                result_seqs = scan_impl(
+                    self.core,
+                    self.num_inputs,
+                    self.num_states,
+                    self.num_outputs,
+                    *args,
+                    *self.states,
+                )
             output_seqs = list(result_seqs[: self.num_outputs])
             state_seqs = list(result_seqs[self.num_outputs :])
             self.states = [v[-1] for v in state_seqs]

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -31,6 +31,11 @@ def _validate_scan_backend_contract(
 ):
     if num_inputs + num_states == 0:
         raise ValueError("FlexSN requires at least one input or state tensor.")
+    if num_inputs == 0:
+        raise ValueError(
+            "FlexSN triton/inductor scan backends require at least one input "
+            "sequence to derive T."
+        )
 
     if example_inputs is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -64,6 +69,14 @@ def _validate_scan_backend_contract(
                 "per-step output and updated state to have the same shape as "
                 f"the first example tensor {tuple(seq_template.shape)}, but "
                 f"return #{i} has shape {tuple(tensor.shape)}."
+            )
+        if tensor.dtype != seq_template.dtype or tensor.device != seq_template.device:
+            raise ValueError(
+                "FlexSN triton/inductor scan backends currently require every "
+                "per-step output and updated state to match the first example "
+                f"tensor's dtype/device ({seq_template.dtype}, "
+                f"{seq_template.device}), but return #{i} is "
+                f"({tensor.dtype}, {tensor.device})."
             )
 
 

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -136,6 +136,15 @@ def _make_seq_outputs_like(
     return [seq_template.new_empty(seq_template.shape) for _ in range(n)]
 
 
+def _template_spec(tensor: torch.Tensor):
+    return tuple(tensor.shape), tensor.dtype, tensor.device
+
+
+def _materialize_template(spec):
+    shape, dtype, device = spec
+    return torch.empty((), dtype=dtype, device=device).expand(shape)
+
+
 def _device_guard(tensors: list[torch.Tensor]):
     for tensor in tensors:
         if isinstance(tensor, torch.Tensor) and tensor.is_cuda:
@@ -242,6 +251,7 @@ def flexsn_inductor_backward(
     handle: int,
     grad_outputs: list[torch.Tensor],
     saved_tensors: list[torch.Tensor],
+    input_templates: list[torch.Tensor],
 ) -> list[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if bundle.backward_kernel is None or bundle.training_info is None:
@@ -254,14 +264,18 @@ def _flexsn_inductor_backward_fake(
     handle: int,
     grad_outputs: list[torch.Tensor],
     saved_tensors: list[torch.Tensor],
+    input_templates: list[torch.Tensor],
 ) -> list[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if bundle.training_info is None:
         raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
-    seq_grads = _make_seq_tensor_list_like(grad_outputs, bundle.training_info.num_inputs)
-    state_offset = bundle.training_info.num_outputs
+    seq_grads = [
+        input_templates[i].new_empty(input_templates[i].shape)
+        for i in range(bundle.training_info.num_inputs)
+    ]
+    state_offset = bundle.training_info.num_inputs
     state_grads = [
-        grad_outputs[state_offset + i][0].new_empty(grad_outputs[state_offset + i][0].shape)
+        input_templates[state_offset + i].new_empty(input_templates[state_offset + i].shape)
         for i in range(bundle.training_info.num_states)
     ]
     return [*seq_grads, *state_grads]
@@ -273,8 +287,15 @@ def _flexsn_training_setup_context(ctx, inputs, output):
     if bundle.training_info is None:
         raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
     retain_flexsn_kernel_handle(handle)
+    ctx._active_ref_finalizer = weakref.finalize(
+        ctx, release_active_flexsn_kernel_handle, handle
+    )
     ctx.handle = handle
-    ctx.output_templates = output[: bundle.training_info.num_outputs + bundle.training_info.num_states]
+    ctx.input_template_specs = [_template_spec(t) for t in inputs[1]]
+    ctx.output_template_specs = [
+        _template_spec(t)
+        for t in output[: bundle.training_info.num_outputs + bundle.training_info.num_states]
+    ]
     saved = [output[i] for i in bundle.training_info.c2k_return_mapping]
     ctx.save_for_backward(*saved)
 
@@ -288,15 +309,23 @@ def _flexsn_training_backward(ctx, grad_out: list[torch.Tensor | None]):
     grad_inputs = [
         grad_out[i]
         if grad_out[i] is not None
-        else torch.zeros_like(ctx.output_templates[i])
+        else torch.zeros(
+            ctx.output_template_specs[i][0],
+            dtype=ctx.output_template_specs[i][1],
+            device=ctx.output_template_specs[i][2],
+        )
         for i in range(required_grads)
     ]
+    input_templates = [_materialize_template(spec) for spec in ctx.input_template_specs]
     try:
+        if ctx._active_ref_finalizer.alive:
+            ctx._active_ref_finalizer.detach()
         grads = list(
             flexsn_inductor_backward(
                 ctx.handle,
                 grad_inputs,
                 list(ctx.saved_tensors),
+                input_templates,
             )
         )
     finally:

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -15,6 +15,7 @@ This module is the bridge between FlexSN's per-layer Triton kernels and
 
 from __future__ import annotations
 
+import contextlib
 from dataclasses import dataclass
 from itertools import count
 from threading import Lock
@@ -33,6 +34,8 @@ class FlexSNKernelHandle:
     forward_kernel: object | None
     backward_kernel: object | None
     training_info: FlexSNInfo | None
+    owner_refs: int = 1
+    active_refs: int = 0
 
 
 _KERNEL_REGISTRY: dict[int, FlexSNKernelHandle] = {}
@@ -65,6 +68,10 @@ def unregister_flexsn_kernel_handle(handle: int) -> None:
         bundle = _KERNEL_REGISTRY.pop(handle, None)
     if bundle is None:
         return
+    _cleanup_kernel_handle(bundle)
+
+
+def _cleanup_kernel_handle(bundle: FlexSNKernelHandle) -> None:
     for obj in (
         bundle.inference_kernel,
         bundle.forward_kernel,
@@ -82,6 +89,38 @@ def _lookup_kernel_handle(handle: int) -> FlexSNKernelHandle:
         raise RuntimeError(f"Unknown FlexSN kernel handle: {handle}") from e
 
 
+def retain_flexsn_kernel_handle(handle: int) -> None:
+    with _KERNEL_REGISTRY_LOCK:
+        bundle = _lookup_kernel_handle(handle)
+        bundle.active_refs += 1
+
+
+def release_flexsn_kernel_handle(handle: int) -> None:
+    with _KERNEL_REGISTRY_LOCK:
+        bundle = _KERNEL_REGISTRY.get(handle)
+        if bundle is None:
+            return
+        bundle.owner_refs = max(0, bundle.owner_refs - 1)
+        should_cleanup = bundle.owner_refs == 0 and bundle.active_refs == 0
+        if should_cleanup:
+            _KERNEL_REGISTRY.pop(handle, None)
+    if should_cleanup:
+        _cleanup_kernel_handle(bundle)
+
+
+def release_active_flexsn_kernel_handle(handle: int) -> None:
+    with _KERNEL_REGISTRY_LOCK:
+        bundle = _KERNEL_REGISTRY.get(handle)
+        if bundle is None:
+            return
+        bundle.active_refs = max(0, bundle.active_refs - 1)
+        should_cleanup = bundle.owner_refs == 0 and bundle.active_refs == 0
+        if should_cleanup:
+            _KERNEL_REGISTRY.pop(handle, None)
+    if should_cleanup:
+        _cleanup_kernel_handle(bundle)
+
+
 def _make_seq_tensor_list_like(xs: list[torch.Tensor], n: int) -> list[torch.Tensor]:
     if not xs:
         raise ValueError("Expected at least one template tensor.")
@@ -97,18 +136,65 @@ def _make_seq_outputs_like(
     return [seq_template.new_empty(seq_template.shape) for _ in range(n)]
 
 
+def _device_guard(tensors: list[torch.Tensor]):
+    for tensor in tensors:
+        if isinstance(tensor, torch.Tensor) and tensor.is_cuda:
+            return torch.cuda.device(tensor.device)
+    return contextlib.nullcontext()
+
+
+def _flexsn_inductor_inference_impl(
+    bundle: FlexSNKernelHandle, flat_args: list[torch.Tensor]
+) -> list[torch.Tensor]:
+    args = [arg.contiguous() for arg in flat_args]
+    with _device_guard(args):
+        return list(
+            flexsn_inference(
+                bundle.inference_kernel,
+                bundle.inference_info,
+                *args,
+            )
+        )
+
+
+def _flexsn_inductor_training_impl(
+    bundle: FlexSNKernelHandle, flat_args: list[torch.Tensor]
+) -> list[torch.Tensor]:
+    args = [arg.contiguous() for arg in flat_args]
+    with _device_guard(args):
+        return list(
+            flexsn_forward(
+                bundle.forward_kernel,
+                bundle.training_info,
+                *args,
+            )
+        )
+
+
+def _flexsn_inductor_backward_impl(
+    bundle: FlexSNKernelHandle,
+    grad_outputs: list[torch.Tensor],
+    saved_tensors: list[torch.Tensor],
+) -> list[torch.Tensor]:
+    grads = [grad.contiguous() for grad in grad_outputs]
+    saved = [tensor.contiguous() for tensor in saved_tensors]
+    with _device_guard([*grads, *saved]):
+        return list(
+            flexsn_backward(
+                bundle.backward_kernel,
+                bundle.training_info,
+                *grads,
+                *saved,
+            )
+        )
+
+
 @torch.library.custom_op("sj::flexsn_inductor_inference", mutates_args=())
 def flexsn_inductor_inference(handle: int, flat_args: list[torch.Tensor]) -> list[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if bundle.inference_kernel is None or bundle.inference_info is None:
         raise RuntimeError("FlexSN inference kernel is unavailable for this handle.")
-    return list(
-        flexsn_inference(
-            bundle.inference_kernel,
-            bundle.inference_info,
-            *(arg.contiguous() for arg in flat_args),
-        )
-    )
+    return _flexsn_inductor_inference_impl(bundle, flat_args)
 
 
 @torch.library.register_fake("sj::flexsn_inductor_inference")
@@ -134,13 +220,7 @@ def flexsn_inductor_training(handle: int, flat_args: list[torch.Tensor]) -> list
         or bundle.training_info is None
     ):
         raise RuntimeError("FlexSN training kernels are unavailable for this handle.")
-    return list(
-        flexsn_forward(
-            bundle.forward_kernel,
-            bundle.training_info,
-            *(arg.contiguous() for arg in flat_args),
-        )
-    )
+    return _flexsn_inductor_training_impl(bundle, flat_args)
 
 
 @torch.library.register_fake("sj::flexsn_inductor_training")
@@ -166,14 +246,7 @@ def flexsn_inductor_backward(
     bundle = _lookup_kernel_handle(handle)
     if bundle.backward_kernel is None or bundle.training_info is None:
         raise RuntimeError("FlexSN backward kernel is unavailable for this handle.")
-    return list(
-        flexsn_backward(
-            bundle.backward_kernel,
-            bundle.training_info,
-            *(grad.contiguous() for grad in grad_outputs),
-            *(tensor.contiguous() for tensor in saved_tensors),
-        )
-    )
+    return _flexsn_inductor_backward_impl(bundle, grad_outputs, saved_tensors)
 
 
 @torch.library.register_fake("sj::flexsn_inductor_backward")
@@ -199,6 +272,7 @@ def _flexsn_training_setup_context(ctx, inputs, output):
     bundle = _lookup_kernel_handle(handle)
     if bundle.training_info is None:
         raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
+    retain_flexsn_kernel_handle(handle)
     ctx.handle = handle
     ctx.output_templates = output[: bundle.training_info.num_outputs + bundle.training_info.num_states]
     saved = [output[i] for i in bundle.training_info.c2k_return_mapping]
@@ -212,19 +286,21 @@ def _flexsn_training_backward(ctx, grad_out: list[torch.Tensor | None]):
 
     required_grads = bundle.training_info.num_outputs + bundle.training_info.num_states
     grad_inputs = [
-        grad_out[i].contiguous()
+        grad_out[i]
         if grad_out[i] is not None
         else torch.zeros_like(ctx.output_templates[i])
         for i in range(required_grads)
     ]
-    saved = [tensor.contiguous() for tensor in ctx.saved_tensors]
-    grads = list(
-        flexsn_inductor_backward(
-            ctx.handle,
-            grad_inputs,
-            saved,
+    try:
+        grads = list(
+            flexsn_inductor_backward(
+                ctx.handle,
+                grad_inputs,
+                list(ctx.saved_tensors),
+            )
         )
-    )
+    finally:
+        release_active_flexsn_kernel_handle(ctx.handle)
     return None, grads
 
 
@@ -236,4 +312,4 @@ torch.library.register_autograd(
 
 
 def attach_flexsn_handle_finalizer(owner, handle: int):
-    return weakref.finalize(owner, unregister_flexsn_kernel_handle, handle)
+    return weakref.finalize(owner, release_flexsn_kernel_handle, handle)

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from itertools import count
 from threading import Lock
+import weakref
 
 import torch
 
@@ -59,6 +60,21 @@ def register_flexsn_kernel_handle(
     return handle
 
 
+def unregister_flexsn_kernel_handle(handle: int) -> None:
+    with _KERNEL_REGISTRY_LOCK:
+        bundle = _KERNEL_REGISTRY.pop(handle, None)
+    if bundle is None:
+        return
+    for obj in (
+        bundle.inference_kernel,
+        bundle.forward_kernel,
+        bundle.backward_kernel,
+    ):
+        closer = getattr(obj, "close", None)
+        if callable(closer):
+            closer()
+
+
 def _lookup_kernel_handle(handle: int) -> FlexSNKernelHandle:
     try:
         return _KERNEL_REGISTRY[handle]
@@ -67,8 +83,21 @@ def _lookup_kernel_handle(handle: int) -> FlexSNKernelHandle:
 
 
 def _make_seq_tensor_list_like(xs: list[torch.Tensor], n: int) -> list[torch.Tensor]:
-    x_example = xs[0]
-    return [x_example.new_empty(x_example.shape) for _ in range(n)]
+    if not xs:
+        raise ValueError("Expected at least one template tensor.")
+    return [xs[min(i, len(xs) - 1)].new_empty(xs[min(i, len(xs) - 1)].shape) for i in range(n)]
+
+
+def _make_seq_outputs_like(
+    info: FlexSNInfo, flat_args: list[torch.Tensor], n: int
+) -> list[torch.Tensor]:
+    if info.num_inputs > 0 and flat_args:
+        seq_template = flat_args[0]
+    elif flat_args:
+        seq_template = flat_args[0].unsqueeze(0)
+    else:
+        raise ValueError("Expected at least one FlexSN argument tensor.")
+    return [seq_template.new_empty(seq_template.shape) for _ in range(n)]
 
 
 @torch.library.custom_op("sj::flexsn_inductor_inference", mutates_args=())
@@ -92,8 +121,10 @@ def _flexsn_inductor_inference_fake(
     bundle = _lookup_kernel_handle(handle)
     if bundle.inference_info is None:
         raise RuntimeError("FlexSN inference metadata is unavailable for this handle.")
-    return _make_seq_tensor_list_like(
-        flat_args, bundle.inference_info.num_outputs + bundle.inference_info.num_states
+    return _make_seq_outputs_like(
+        bundle.inference_info,
+        flat_args,
+        bundle.inference_info.num_outputs + bundle.inference_info.num_states,
     )
 
 
@@ -122,8 +153,10 @@ def _flexsn_inductor_training_fake(
     bundle = _lookup_kernel_handle(handle)
     if bundle.training_info is None:
         raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
-    return _make_seq_tensor_list_like(
-        flat_args, bundle.training_info.num_fwd_kernel_returns
+    return _make_seq_outputs_like(
+        bundle.training_info,
+        flat_args,
+        bundle.training_info.num_fwd_kernel_returns,
     )
 
 
@@ -155,13 +188,11 @@ def _flexsn_inductor_backward_fake(
     bundle = _lookup_kernel_handle(handle)
     if bundle.training_info is None:
         raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
-    seq_grads = _make_seq_tensor_list_like(
-        grad_outputs, bundle.training_info.num_inputs
-    )
-    state_example = grad_outputs[0][0]
+    seq_grads = _make_seq_tensor_list_like(grad_outputs, bundle.training_info.num_inputs)
+    state_offset = bundle.training_info.num_outputs
     state_grads = [
-        state_example.new_empty(state_example.shape)
-        for _ in range(bundle.training_info.num_states)
+        grad_outputs[state_offset + i][0].new_empty(grad_outputs[state_offset + i][0].shape)
+        for i in range(bundle.training_info.num_states)
     ]
     return [*seq_grads, *state_grads]
 
@@ -172,7 +203,7 @@ def _flexsn_training_setup_context(ctx, inputs, output):
     if bundle.training_info is None:
         raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
     ctx.handle = handle
-    ctx.output_template = output[0]
+    ctx.output_templates = output[: bundle.training_info.num_outputs + bundle.training_info.num_states]
     saved = [output[i] for i in bundle.training_info.c2k_return_mapping]
     ctx.save_for_backward(*saved)
 
@@ -183,9 +214,10 @@ def _flexsn_training_backward(ctx, grad_out: list[torch.Tensor | None]):
         raise RuntimeError("FlexSN backward kernel is unavailable for this handle.")
 
     required_grads = bundle.training_info.num_outputs + bundle.training_info.num_states
-    zero = torch.zeros_like(ctx.output_template)
     grad_inputs = [
-        grad_out[i].contiguous() if grad_out[i] is not None else zero
+        grad_out[i].contiguous()
+        if grad_out[i] is not None
+        else torch.zeros_like(ctx.output_templates[i])
         for i in range(required_grads)
     ]
     saved = [tensor.contiguous() for tensor in ctx.saved_tensors]
@@ -204,3 +236,7 @@ torch.library.register_autograd(
     _flexsn_training_backward,
     setup_context=_flexsn_training_setup_context,
 )
+
+
+def attach_flexsn_handle_finalizer(owner, handle: int):
+    return weakref.finalize(owner, unregister_flexsn_kernel_handle, handle)

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -95,6 +95,12 @@ def retain_flexsn_kernel_handle(handle: int) -> None:
         bundle.active_refs += 1
 
 
+def retain_owner_flexsn_kernel_handle(handle: int) -> None:
+    with _KERNEL_REGISTRY_LOCK:
+        bundle = _lookup_kernel_handle(handle)
+        bundle.owner_refs += 1
+
+
 def release_flexsn_kernel_handle(handle: int) -> None:
     with _KERNEL_REGISTRY_LOCK:
         bundle = _KERNEL_REGISTRY.get(handle)

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -121,17 +121,14 @@ def release_active_flexsn_kernel_handle(handle: int) -> None:
         _cleanup_kernel_handle(bundle)
 
 
-def _make_seq_tensor_list_like(xs: list[torch.Tensor], n: int) -> list[torch.Tensor]:
-    if not xs:
-        raise ValueError("Expected at least one template tensor.")
-    return [xs[min(i, len(xs) - 1)].new_empty(xs[min(i, len(xs) - 1)].shape) for i in range(n)]
-
-
 def _make_seq_outputs_like(
     info: FlexSNInfo, flat_args: list[torch.Tensor], n: int
 ) -> list[torch.Tensor]:
     if not flat_args:
         raise ValueError("Expected at least one FlexSN argument tensor.")
+    # The underlying FlexSN Triton wrappers allocate all sequence outputs with
+    # ``empty_like(flat_args[0])``. Keep fake tensors aligned with that runtime
+    # contract so Dynamo/AOTAutograd sees the same shapes during tracing.
     seq_template = flat_args[0]
     return [seq_template.new_empty(seq_template.shape) for _ in range(n)]
 

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -1,3 +1,18 @@
+"""Opaque custom ops for FlexSN inductor kernels.
+
+This module is the bridge between FlexSN's per-layer Triton kernels and
+``torch.compile``:
+
+* Triton kernels and metadata are stored in a Python-side registry and
+  referenced from graphs by a lightweight integer handle.
+* Forward and backward are exposed as opaque ``torch.library`` custom ops so
+  Dynamo / AOTAutograd no longer trace into Python kernel objects or Triton
+  launcher internals.
+* Tensor inputs/outputs are passed as ``list[Tensor]`` because FlexSN has a
+  variable number of inputs, outputs, and states while ``custom_op`` does not
+  support ``*args`` schemas.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import count
+from threading import Lock
+
+import torch
+
+from ..flexsn.wrapper import flexsn_backward, flexsn_forward, flexsn_inference
+from ..flexsn.info import FlexSNInfo
+
+
+@dataclass
+class FlexSNKernelHandle:
+    inference_kernel: object | None
+    inference_info: FlexSNInfo | None
+    forward_kernel: object | None
+    backward_kernel: object | None
+    training_info: FlexSNInfo | None
+
+
+_KERNEL_REGISTRY: dict[int, FlexSNKernelHandle] = {}
+_KERNEL_REGISTRY_LOCK = Lock()
+_KERNEL_ID_GEN = count(1)
+
+
+def register_flexsn_kernel_handle(
+    *,
+    inference_kernel,
+    inference_info,
+    forward_kernel,
+    backward_kernel,
+    training_info,
+) -> int:
+    with _KERNEL_REGISTRY_LOCK:
+        handle = next(_KERNEL_ID_GEN)
+        _KERNEL_REGISTRY[handle] = FlexSNKernelHandle(
+            inference_kernel=inference_kernel,
+            inference_info=inference_info,
+            forward_kernel=forward_kernel,
+            backward_kernel=backward_kernel,
+            training_info=training_info,
+        )
+    return handle
+
+
+def _lookup_kernel_handle(handle: int) -> FlexSNKernelHandle:
+    try:
+        return _KERNEL_REGISTRY[handle]
+    except KeyError as e:
+        raise RuntimeError(f"Unknown FlexSN kernel handle: {handle}") from e
+
+
+def _make_seq_tensor_list_like(xs: list[torch.Tensor], n: int) -> list[torch.Tensor]:
+    x_example = xs[0]
+    return [x_example.new_empty(x_example.shape) for _ in range(n)]
+
+
+@torch.library.custom_op("sj::flexsn_inductor_inference", mutates_args=())
+def flexsn_inductor_inference(handle: int, flat_args: list[torch.Tensor]) -> list[torch.Tensor]:
+    bundle = _lookup_kernel_handle(handle)
+    if bundle.inference_kernel is None or bundle.inference_info is None:
+        raise RuntimeError("FlexSN inference kernel is unavailable for this handle.")
+    return list(
+        flexsn_inference(
+            bundle.inference_kernel,
+            bundle.inference_info,
+            *(arg.contiguous() for arg in flat_args),
+        )
+    )
+
+
+@torch.library.register_fake("sj::flexsn_inductor_inference")
+def _flexsn_inductor_inference_fake(
+    handle: int, flat_args: list[torch.Tensor]
+) -> list[torch.Tensor]:
+    bundle = _lookup_kernel_handle(handle)
+    if bundle.inference_info is None:
+        raise RuntimeError("FlexSN inference metadata is unavailable for this handle.")
+    return _make_seq_tensor_list_like(
+        flat_args, bundle.inference_info.num_outputs + bundle.inference_info.num_states
+    )
+
+
+@torch.library.custom_op("sj::flexsn_inductor_training", mutates_args=())
+def flexsn_inductor_training(handle: int, flat_args: list[torch.Tensor]) -> list[torch.Tensor]:
+    bundle = _lookup_kernel_handle(handle)
+    if (
+        bundle.forward_kernel is None
+        or bundle.backward_kernel is None
+        or bundle.training_info is None
+    ):
+        raise RuntimeError("FlexSN training kernels are unavailable for this handle.")
+    return list(
+        flexsn_forward(
+            bundle.forward_kernel,
+            bundle.training_info,
+            *(arg.contiguous() for arg in flat_args),
+        )
+    )
+
+
+@torch.library.register_fake("sj::flexsn_inductor_training")
+def _flexsn_inductor_training_fake(
+    handle: int, flat_args: list[torch.Tensor]
+) -> list[torch.Tensor]:
+    bundle = _lookup_kernel_handle(handle)
+    if bundle.training_info is None:
+        raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
+    return _make_seq_tensor_list_like(
+        flat_args, bundle.training_info.num_fwd_kernel_returns
+    )
+
+
+@torch.library.custom_op("sj::flexsn_inductor_backward", mutates_args=())
+def flexsn_inductor_backward(
+    handle: int,
+    grad_outputs: list[torch.Tensor],
+    saved_tensors: list[torch.Tensor],
+) -> list[torch.Tensor]:
+    bundle = _lookup_kernel_handle(handle)
+    if bundle.backward_kernel is None or bundle.training_info is None:
+        raise RuntimeError("FlexSN backward kernel is unavailable for this handle.")
+    return list(
+        flexsn_backward(
+            bundle.backward_kernel,
+            bundle.training_info,
+            *(grad.contiguous() for grad in grad_outputs),
+            *(tensor.contiguous() for tensor in saved_tensors),
+        )
+    )
+
+
+@torch.library.register_fake("sj::flexsn_inductor_backward")
+def _flexsn_inductor_backward_fake(
+    handle: int,
+    grad_outputs: list[torch.Tensor],
+    saved_tensors: list[torch.Tensor],
+) -> list[torch.Tensor]:
+    bundle = _lookup_kernel_handle(handle)
+    if bundle.training_info is None:
+        raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
+    seq_grads = _make_seq_tensor_list_like(
+        grad_outputs, bundle.training_info.num_inputs
+    )
+    state_example = grad_outputs[0][0]
+    state_grads = [
+        state_example.new_empty(state_example.shape)
+        for _ in range(bundle.training_info.num_states)
+    ]
+    return [*seq_grads, *state_grads]
+
+
+def _flexsn_training_setup_context(ctx, inputs, output):
+    handle = inputs[0]
+    bundle = _lookup_kernel_handle(handle)
+    if bundle.training_info is None:
+        raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
+    ctx.handle = handle
+    ctx.output_template = output[0]
+    saved = [output[i] for i in bundle.training_info.c2k_return_mapping]
+    ctx.save_for_backward(*saved)
+
+
+def _flexsn_training_backward(ctx, grad_out: list[torch.Tensor | None]):
+    bundle = _lookup_kernel_handle(ctx.handle)
+    if bundle.backward_kernel is None or bundle.training_info is None:
+        raise RuntimeError("FlexSN backward kernel is unavailable for this handle.")
+
+    required_grads = bundle.training_info.num_outputs + bundle.training_info.num_states
+    zero = torch.zeros_like(ctx.output_template)
+    grad_inputs = [
+        grad_out[i].contiguous() if grad_out[i] is not None else zero
+        for i in range(required_grads)
+    ]
+    saved = [tensor.contiguous() for tensor in ctx.saved_tensors]
+    grads = list(
+        flexsn_inductor_backward(
+            ctx.handle,
+            grad_inputs,
+            saved,
+        )
+    )
+    return None, grads
+
+
+torch.library.register_autograd(
+    "sj::flexsn_inductor_training",
+    _flexsn_training_backward,
+    setup_context=_flexsn_training_setup_context,
+)

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -91,12 +91,9 @@ def _make_seq_tensor_list_like(xs: list[torch.Tensor], n: int) -> list[torch.Ten
 def _make_seq_outputs_like(
     info: FlexSNInfo, flat_args: list[torch.Tensor], n: int
 ) -> list[torch.Tensor]:
-    if info.num_inputs > 0 and flat_args:
-        seq_template = flat_args[0]
-    elif flat_args:
-        seq_template = flat_args[0].unsqueeze(0)
-    else:
+    if not flat_args:
         raise ValueError("Expected at least one FlexSN argument tensor.")
+    seq_template = flat_args[0]
     return [seq_template.new_empty(seq_template.shape) for _ in range(n)]
 
 


### PR DESCRIPTION
## 概述

这个 PR 主要完成了两部分工作：

1. 继续完善通用 SNN 训练加速路径
2. 为 `FlexSN/inductor + torch.compile` 打通一条真正可用、可训练、对 Dynamo 更友好的主路径

## 主要改动

### 1. 通用训练加速整理

- 在 `train_classify.py` 中修正训练日志里的 `samples/s` 统计口径
- 训练汇总现在输出真实的平均吞吐，而不是最近窗口值，便于后续稳定评估 compile/eager 的长期表现

### 2. FlexSN inductor compile-friendly 路径

- 为 `FlexSN` 新增基于 `torch.library` 的 opaque custom op 路径
- 新增 `kernel handle registry`，将 Triton kernel/info 从 Dynamo 图中隔离出去
- 训练与推理分别通过 custom op 暴露：
  - inference
  - training
  - backward
- `FlexSN.multi_step_forward` 的 `backend="inductor"` 路径改为优先走 custom op，而不是 `@torch._dynamo.disable`

这部分的目标是减少 graph break 和 Python object guard，避免每层 `FlexSN` 都把训练图打碎。

## 效果

在服务器上的 `SpikingVGG + FlexSN(inductor)` 训练测试中：

- 之前：`graph_count=24 / graph_break_count=23`
- 现在：`graph_count=2 / graph_break_count=1`

也就是说，`FlexSN` 周围层的图碎片化已经基本被消掉。

训练性能上，`torch.compile` 也已经从慢于 eager 变成快于 eager：

- `flexsn_inductor_eager`: `27.24 ms/iter`
- `flexsn_inductor_compile`: `24.65 ms/iter`

### 3. 新增可用训练脚本

新增：

- `spikingjelly/activation_based/model/train_flexsn_inductor_example.py`

这个脚本风格与现有 `train_imagenet_example.py` 保持一致，但模型改为 `spiking_vgg + FlexSN(backend="inductor")`，并默认启用 `torch.compile`。

我已经在服务器上用真实训练入口跑通过 1 epoch smoke test，训练、验证、checkpoint 都正常。

## 说明

- `workspace/` 中我另外整理了一份 HOP 路径的 TODO 设计清单，但该目录目前被 `.gitignore` 忽略，所以没有放进这次 PR。
- 当前建议把 `custom op` 路径作为主线实现，HOP 路径作为后续独立课题推进。

## 后续建议

后续可以继续做两件事：

1. 扩展更多 `FlexSN/inductor` 模型和训练配置验证
2. 单独推进 HOP 路径，把它作为下一阶段编译器集成工作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional runtime model compilation, new FlexSN inductor/triton kernel support, FlexSN training entrypoint, and a new throughput meter for samples/sec.

* **Performance Improvements**
  * Reduced memory by broadcasting time-steps instead of duplicating tensors; DataLoader knobs for persistent workers and prefetch tuning.

* **Refactor**
  * Centralized device-transfer and reordered compile/eval/model wrapping; simplified multi-step layer execution for time-batched inputs.

* **Bug Fixes**
  * Safer tensor/state initialization and more robust memory/state reset semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->