### PR TITLE
Advance FlexSN HOP and improve compile training performance

### DIFF
--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -56,7 +56,7 @@ def _matches_module_pattern(pattern, node: fx.Node, modules) -> bool:
             return False
         if current_node.target not in modules:
             return False
-        if type(modules[current_node.target]) is not expected_type:
+        if not isinstance(modules[current_node.target], expected_type):
             return False
     return True
 
@@ -78,6 +78,7 @@ def _collect_conv_bn_matches(fx_model: fx.GraphModule, modules, patterns):
     pair_to_nodes = {}
     conv_to_bn_targets = {}
     conv_target_call_counts = {}
+    matched_bn_nodes = set()
     for node in fx_model.graph.nodes:
         if node.op == "call_module":
             conv_target_call_counts[node.target] = (
@@ -85,6 +86,8 @@ def _collect_conv_bn_matches(fx_model: fx.GraphModule, modules, patterns):
             )
     for pattern in patterns:
         for node in list(fx_model.graph.nodes):
+            if node in matched_bn_nodes:
+                continue
             if not _matches_module_pattern(pattern, node, modules):
                 continue
             conv_node = node.args[0]
@@ -94,6 +97,7 @@ def _collect_conv_bn_matches(fx_model: fx.GraphModule, modules, patterns):
             pair = (conv_node.target, node.target)
             pair_to_nodes.setdefault(pair, []).append(node)
             conv_to_bn_targets.setdefault(conv_node.target, set()).add(node.target)
+            matched_bn_nodes.add(node)
 
     ambiguous_conv_targets = {
         conv_target
@@ -226,12 +230,12 @@ def fuse_conv_bn_eval_modules(net: nn.Module) -> fx.GraphModule:
     fx_model = fx.GraphModule(tracer.root, graph)
     modules = dict(fx_model.named_modules())
     patterns = [
-        (nn.Conv1d, nn.BatchNorm1d),
-        (nn.Conv2d, nn.BatchNorm2d),
-        (nn.Conv3d, nn.BatchNorm3d),
         (layer.Conv1d, layer.BatchNorm1d),
         (layer.Conv2d, layer.BatchNorm2d),
         (layer.Conv3d, layer.BatchNorm3d),
+        (nn.Conv1d, nn.BatchNorm1d),
+        (nn.Conv2d, nn.BatchNorm2d),
+        (nn.Conv3d, nn.BatchNorm3d),
     ]
 
     for (conv_target, bn_target), matched_nodes in _collect_conv_bn_matches(
@@ -305,12 +309,12 @@ def pack_conv_bn_train_modules(net: nn.Module) -> fx.GraphModule:
     fx_model = fx.GraphModule(tracer.root, graph)
     modules = dict(fx_model.named_modules())
     patterns = [
-        (nn.Conv1d, nn.BatchNorm1d),
-        (nn.Conv2d, nn.BatchNorm2d),
-        (nn.Conv3d, nn.BatchNorm3d),
         (layer.Conv1d, layer.BatchNorm1d),
         (layer.Conv2d, layer.BatchNorm2d),
         (layer.Conv3d, layer.BatchNorm3d),
+        (nn.Conv1d, nn.BatchNorm1d),
+        (nn.Conv2d, nn.BatchNorm2d),
+        (nn.Conv3d, nn.BatchNorm3d),
     ]
 
     for (conv_target, bn_target), matched_nodes in _collect_conv_bn_matches(

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -37,6 +37,14 @@ _TRAIN_PACK_BN_TYPES = (
     layer.BatchNorm2d,
     layer.BatchNorm3d,
 )
+_CONV_BN_PATTERNS = [
+    (layer.Conv1d, layer.BatchNorm1d),
+    (layer.Conv2d, layer.BatchNorm2d),
+    (layer.Conv3d, layer.BatchNorm3d),
+    (nn.Conv1d, nn.BatchNorm1d),
+    (nn.Conv2d, nn.BatchNorm2d),
+    (nn.Conv3d, nn.BatchNorm3d),
+]
 
 
 def _matches_module_pattern(pattern, node: fx.Node, modules) -> bool:
@@ -229,17 +237,9 @@ def fuse_conv_bn_eval_modules(net: nn.Module) -> fx.GraphModule:
     graph = tracer.trace(net)
     fx_model = fx.GraphModule(tracer.root, graph)
     modules = dict(fx_model.named_modules())
-    patterns = [
-        (layer.Conv1d, layer.BatchNorm1d),
-        (layer.Conv2d, layer.BatchNorm2d),
-        (layer.Conv3d, layer.BatchNorm3d),
-        (nn.Conv1d, nn.BatchNorm1d),
-        (nn.Conv2d, nn.BatchNorm2d),
-        (nn.Conv3d, nn.BatchNorm3d),
-    ]
 
     for (conv_target, bn_target), matched_nodes in _collect_conv_bn_matches(
-        fx_model, modules, patterns
+        fx_model, modules, _CONV_BN_PATTERNS
     ).items():
         conv = modules[conv_target]
         bn = modules[bn_target]
@@ -308,17 +308,9 @@ def pack_conv_bn_train_modules(net: nn.Module) -> fx.GraphModule:
     graph = tracer.trace(net)
     fx_model = fx.GraphModule(tracer.root, graph)
     modules = dict(fx_model.named_modules())
-    patterns = [
-        (layer.Conv1d, layer.BatchNorm1d),
-        (layer.Conv2d, layer.BatchNorm2d),
-        (layer.Conv3d, layer.BatchNorm3d),
-        (nn.Conv1d, nn.BatchNorm1d),
-        (nn.Conv2d, nn.BatchNorm2d),
-        (nn.Conv3d, nn.BatchNorm3d),
-    ]
 
     for (conv_target, bn_target), matched_nodes in _collect_conv_bn_matches(
-        fx_model, modules, patterns
+        fx_model, modules, _CONV_BN_PATTERNS
     ).items():
         conv = modules[conv_target]
         bn = modules[bn_target]

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -21,6 +21,24 @@ __all__ = [
 ]
 
 
+_TRAIN_PACK_CONV_TYPES = (
+    nn.Conv1d,
+    nn.Conv2d,
+    nn.Conv3d,
+    layer.Conv1d,
+    layer.Conv2d,
+    layer.Conv3d,
+)
+_TRAIN_PACK_BN_TYPES = (
+    nn.BatchNorm1d,
+    nn.BatchNorm2d,
+    nn.BatchNorm3d,
+    layer.BatchNorm1d,
+    layer.BatchNorm2d,
+    layer.BatchNorm3d,
+)
+
+
 def _matches_module_pattern(pattern, node: fx.Node, modules) -> bool:
     if len(node.args) == 0:
         return False
@@ -127,30 +145,30 @@ class _TrainConvBnWrapper(nn.Module):
     def _packed_forward(self, x: Tensor) -> Tensor:
         t, n = x.shape[:2]
         x = x.flatten(0, 1)
-        if not isinstance(self.conv, (nn.Conv1d, nn.Conv2d, nn.Conv3d)):
+        if not isinstance(self.conv, _TRAIN_PACK_CONV_TYPES):
             raise TypeError(f"Unsupported packed conv type: {type(self.conv)!r}")
         with self._single_step_mode(self.conv):
             x = self.conv(x)
 
-        if not isinstance(self.bn, (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d)):
+        if not isinstance(self.bn, _TRAIN_PACK_BN_TYPES):
             raise TypeError(f"Unsupported packed batchnorm type: {type(self.bn)!r}")
         with self._single_step_mode(self.bn):
             x = self.bn(x)
         return x.view(t, n, *x.shape[1:])
 
     def _expects_multistep_input(self, x: Tensor) -> bool:
-        if isinstance(self.conv, nn.Conv1d):
+        if isinstance(self.conv, (nn.Conv1d, layer.Conv1d)):
             return x.dim() == 4
-        if isinstance(self.conv, nn.Conv2d):
+        if isinstance(self.conv, (nn.Conv2d, layer.Conv2d)):
             return x.dim() == 5
-        if isinstance(self.conv, nn.Conv3d):
+        if isinstance(self.conv, (nn.Conv3d, layer.Conv3d)):
             return x.dim() == 6
         return False
 
     def forward(self, x: Tensor) -> Tensor:
         if (
-            isinstance(self.conv, (nn.Conv1d, nn.Conv2d, nn.Conv3d))
-            and isinstance(self.bn, (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d))
+            isinstance(self.conv, _TRAIN_PACK_CONV_TYPES)
+            and isinstance(self.bn, _TRAIN_PACK_BN_TYPES)
             and getattr(self.conv, "step_mode", "m") == "m"
             and getattr(self.bn, "step_mode", "m") == "m"
             and self._expects_multistep_input(x)

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -54,6 +54,7 @@ def _replace_node_module(
 
 def _collect_conv_bn_matches(fx_model: fx.GraphModule, modules, patterns):
     pair_to_nodes = {}
+    conv_to_bn_targets = {}
     for pattern in patterns:
         for node in list(fx_model.graph.nodes):
             if not _matches_module_pattern(pattern, node, modules):
@@ -64,7 +65,21 @@ def _collect_conv_bn_matches(fx_model: fx.GraphModule, modules, patterns):
                 continue
             pair = (conv_node.target, node.target)
             pair_to_nodes.setdefault(pair, []).append(node)
-    return pair_to_nodes
+            conv_to_bn_targets.setdefault(conv_node.target, set()).add(node.target)
+
+    ambiguous_conv_targets = {
+        conv_target
+        for conv_target, bn_targets in conv_to_bn_targets.items()
+        if len(bn_targets) > 1
+    }
+    if not ambiguous_conv_targets:
+        return pair_to_nodes
+
+    return {
+        pair: matched_nodes
+        for pair, matched_nodes in pair_to_nodes.items()
+        if pair[0] not in ambiguous_conv_targets
+    }
 
 
 class _EvalFusionTracer(fx.Tracer):

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -63,7 +63,6 @@ class _EvalFusionTracer(fx.Tracer):
                 layer.BatchNorm1d,
                 layer.BatchNorm2d,
                 layer.BatchNorm3d,
-                base.StepModule,
                 base.MemoryModule,
                 neuron.BaseNode,
             ),

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -16,6 +16,7 @@ __all__ = [
     "kaiming_normal_conv_linear_weight",
     "delay",
     "fuse_conv_bn_eval_modules",
+    "pack_conv_bn_train_modules",
 ]
 
 
@@ -68,6 +69,45 @@ class _EvalFusionTracer(fx.Tracer):
         ):
             return True
         return super().is_leaf_module(m, module_qualified_name)
+
+
+class _TrainPackTracer(_EvalFusionTracer):
+    pass
+
+
+class _TrainConvBnWrapper(nn.Module):
+    def __init__(self, conv: nn.Module, bn: nn.Module):
+        super().__init__()
+        self.conv = conv
+        self.bn = bn
+
+    def _packed_forward(self, x: Tensor) -> Tensor:
+        t, n = x.shape[:2]
+        x = x.flatten(0, 1)
+        if isinstance(self.conv, layer.Conv1d):
+            x = nn.Conv1d.forward(self.conv, x)
+        elif isinstance(self.conv, layer.Conv2d):
+            x = nn.Conv2d.forward(self.conv, x)
+        elif isinstance(self.conv, layer.Conv3d):
+            x = nn.Conv3d.forward(self.conv, x)
+        else:
+            raise TypeError(f"Unsupported packed conv type: {type(self.conv)!r}")
+
+        if isinstance(self.bn, (layer.BatchNorm1d, layer.BatchNorm2d, layer.BatchNorm3d)):
+            x = self.bn.super_forward(x)
+        else:
+            x = self.bn(x)
+        return x.view(t, n, *x.shape[1:])
+
+    def forward(self, x: Tensor) -> Tensor:
+        if (
+            isinstance(self.conv, (layer.Conv1d, layer.Conv2d, layer.Conv3d))
+            and isinstance(self.bn, (layer.BatchNorm1d, layer.BatchNorm2d, layer.BatchNorm3d))
+            and getattr(self.conv, "step_mode", None) == "m"
+            and getattr(self.bn, "step_mode", None) == "m"
+        ):
+            return self._packed_forward(x)
+        return self.bn(self.conv(x))
 
 
 def fuse_conv_bn_eval_modules(net: nn.Module) -> fx.GraphModule:
@@ -131,6 +171,83 @@ def fuse_conv_bn_eval_modules(net: nn.Module) -> fx.GraphModule:
             bn = modules[node.target]
             fused_conv = fuse_conv_bn_eval(conv, bn)
             _replace_node_module(node.args[0], modules, fused_conv)
+            node.replace_all_uses_with(node.args[0])
+            fx_model.graph.erase_node(node)
+
+    fx_model.graph.lint()
+    fx_model.delete_all_unused_submodules()
+    fx_model.recompile()
+    return fx_model
+
+
+def pack_conv_bn_train_modules(net: nn.Module) -> fx.GraphModule:
+    """
+    **API Language:**
+    :ref:`中文 <pack_conv_bn_train_modules-cn>` | :ref:`English <pack_conv_bn_train_modules-en>`
+
+    ----
+
+    .. _pack_conv_bn_train_modules-cn:
+
+    * **中文**
+
+    将训练模式下模型中的相邻 ``Conv*`` 与 ``BatchNorm*`` 模块打包为单个 wrapper，
+    以减少多步 ``Conv -> BatchNorm`` 路径中的 ``view/flatten`` 往返。
+
+    该函数不会像 ``fuse_conv_bn_eval_modules`` 那样融合权重；它只是将相邻层包装成一个
+    compile-friendly 的训练模块。当前同时支持原生 ``torch.nn`` 的 ``Conv*`` / ``BatchNorm*``
+    模块，以及 SpikingJelly activation-based ``layer.Conv*`` / ``layer.BatchNorm*`` 模块。
+
+    输入模型必须处于 ``train()`` 模式。返回值是变换后的 ``fx.GraphModule``。
+
+    .. _pack_conv_bn_train_modules-en:
+
+    * **English**
+
+    Pack adjacent ``Conv*`` and ``BatchNorm*`` modules in a training-mode model into
+    a single wrapper to reduce redundant ``view/flatten`` hops along multi-step
+    ``Conv -> BatchNorm`` paths.
+
+    Unlike ``fuse_conv_bn_eval_modules``, this transform does not fuse weights. It
+    only rewrites the module graph into a more compile-friendly training structure.
+    Both native ``torch.nn`` layers and SpikingJelly activation-based
+    ``layer.Conv*`` / ``layer.BatchNorm*`` wrappers are supported.
+
+    The input model must be in ``train()`` mode. The returned value is the packed
+    ``fx.GraphModule``.
+    """
+    if not net.training:
+        raise ValueError("pack_conv_bn_train_modules only supports train() models.")
+
+    tracer = _TrainPackTracer()
+    graph = tracer.trace(net)
+    fx_model = fx.GraphModule(tracer.root, graph)
+    modules = dict(fx_model.named_modules())
+    patterns = [
+        (nn.Conv1d, nn.BatchNorm1d),
+        (nn.Conv2d, nn.BatchNorm2d),
+        (nn.Conv3d, nn.BatchNorm3d),
+        (layer.Conv1d, layer.BatchNorm1d),
+        (layer.Conv2d, layer.BatchNorm2d),
+        (layer.Conv3d, layer.BatchNorm3d),
+    ]
+
+    for pattern in patterns:
+        for node in list(fx_model.graph.nodes):
+            if not _matches_module_pattern(pattern, node, modules):
+                continue
+            if len(node.args[0].users) > 1:
+                continue
+            conv = modules[node.args[0].target]
+            bn = modules[node.target]
+            if (
+                isinstance(conv, (layer.Conv1d, layer.Conv2d, layer.Conv3d))
+                and isinstance(bn, (layer.BatchNorm1d, layer.BatchNorm2d, layer.BatchNorm3d))
+                and getattr(conv, "step_mode", None) != getattr(bn, "step_mode", None)
+            ):
+                continue
+            packed = _TrainConvBnWrapper(conv, bn)
+            _replace_node_module(node.args[0], modules, packed)
             node.replace_all_uses_with(node.args[0])
             fx_model.graph.erase_node(node)
 

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -151,13 +151,9 @@ class _TrainConvBnWrapper(nn.Module):
     def _packed_forward(self, x: Tensor) -> Tensor:
         t, n = x.shape[:2]
         x = x.flatten(0, 1)
-        if not isinstance(self.conv, _TRAIN_PACK_CONV_TYPES):
-            raise TypeError(f"Unsupported packed conv type: {type(self.conv)!r}")
         with self._single_step_mode(self.conv):
             x = self.conv(x)
 
-        if not isinstance(self.bn, _TRAIN_PACK_BN_TYPES):
-            raise TypeError(f"Unsupported packed batchnorm type: {type(self.bn)!r}")
         with self._single_step_mode(self.bn):
             x = self.bn(x)
         return x.view(t, n, *x.shape[1:])

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -218,12 +218,12 @@ def pack_conv_bn_train_modules(net: nn.Module) -> fx.GraphModule:
 
     * **中文**
 
-    将训练模式下模型中的相邻 ``Conv*`` 与 ``BatchNorm*`` 模块打包为单个 wrapper，
+    将训练模式下模型中的相邻 ``Conv*`` 与 ``BatchNorm*`` 模块打包为单个 wrapper,
     以减少多步 ``Conv -> BatchNorm`` 路径中的 ``view/flatten`` 往返。
 
-    该函数不会像 ``fuse_conv_bn_eval_modules`` 那样融合权重；它只是将相邻层包装成一个
+    该函数不会像 ``fuse_conv_bn_eval_modules`` 那样融合权重; 它只是将相邻层包装成一个
     compile-friendly 的训练模块。当前同时支持原生 ``torch.nn`` 的 ``Conv*`` / ``BatchNorm*``
-    模块，以及 SpikingJelly activation-based ``layer.Conv*`` / ``layer.BatchNorm*`` 模块。
+    模块, 以及 SpikingJelly activation-based ``layer.Conv*`` / ``layer.BatchNorm*`` 模块。
 
     输入模型必须处于 ``train()`` 模式。返回值是变换后的 ``fx.GraphModule``。
 

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -45,7 +45,9 @@ def _matches_module_pattern(pattern, node: fx.Node, modules) -> bool:
     nodes = (node.args[0], node)
     if len(pattern) != len(nodes):
         return False
-    for expected_type, current_node in zip(pattern, nodes):
+    for i in range(len(pattern)):
+        expected_type = pattern[i]
+        current_node = nodes[i]
         if not isinstance(current_node, fx.Node):
             return False
         if current_node.op != "call_module":

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -85,11 +85,11 @@ class _TrainConvBnWrapper(nn.Module):
     def _packed_forward(self, x: Tensor) -> Tensor:
         t, n = x.shape[:2]
         x = x.flatten(0, 1)
-        if isinstance(self.conv, layer.Conv1d):
+        if isinstance(self.conv, nn.Conv1d):
             x = nn.Conv1d.forward(self.conv, x)
-        elif isinstance(self.conv, layer.Conv2d):
+        elif isinstance(self.conv, nn.Conv2d):
             x = nn.Conv2d.forward(self.conv, x)
-        elif isinstance(self.conv, layer.Conv3d):
+        elif isinstance(self.conv, nn.Conv3d):
             x = nn.Conv3d.forward(self.conv, x)
         else:
             raise TypeError(f"Unsupported packed conv type: {type(self.conv)!r}")
@@ -100,12 +100,22 @@ class _TrainConvBnWrapper(nn.Module):
             x = self.bn(x)
         return x.view(t, n, *x.shape[1:])
 
+    def _expects_multistep_input(self, x: Tensor) -> bool:
+        if isinstance(self.conv, nn.Conv1d):
+            return x.dim() == 4
+        if isinstance(self.conv, nn.Conv2d):
+            return x.dim() == 5
+        if isinstance(self.conv, nn.Conv3d):
+            return x.dim() == 6
+        return False
+
     def forward(self, x: Tensor) -> Tensor:
         if (
-            isinstance(self.conv, (layer.Conv1d, layer.Conv2d, layer.Conv3d))
-            and isinstance(self.bn, (layer.BatchNorm1d, layer.BatchNorm2d, layer.BatchNorm3d))
-            and getattr(self.conv, "step_mode", None) == "m"
-            and getattr(self.bn, "step_mode", None) == "m"
+            isinstance(self.conv, (nn.Conv1d, nn.Conv2d, nn.Conv3d))
+            and isinstance(self.bn, (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d))
+            and getattr(self.conv, "step_mode", "m") == "m"
+            and getattr(self.bn, "step_mode", "m") == "m"
+            and self._expects_multistep_input(x)
         ):
             return self._packed_forward(x)
         return self.bn(self.conv(x))

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -56,6 +56,7 @@ class _EvalFusionTracer(fx.Tracer):
         if isinstance(
             m,
             (
+                _TrainConvBnWrapper,
                 layer.Conv1d,
                 layer.Conv2d,
                 layer.Conv3d,

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -43,6 +43,8 @@ def _matches_module_pattern(pattern, node: fx.Node, modules) -> bool:
     if len(node.args) == 0:
         return False
     nodes = (node.args[0], node)
+    if len(pattern) != len(nodes):
+        return False
     for expected_type, current_node in zip(pattern, nodes):
         if not isinstance(current_node, fx.Node):
             return False
@@ -156,7 +158,7 @@ class _TrainConvBnWrapper(nn.Module):
 
         with self._single_step_mode(self.bn):
             x = self.bn(x)
-        return x.view(t, n, *x.shape[1:])
+        return x.reshape(t, n, *x.shape[1:])
 
     def _expects_multistep_input(self, x: Tensor) -> bool:
         if isinstance(self.conv, (nn.Conv1d, layer.Conv1d)):

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -43,7 +43,7 @@ def _matches_module_pattern(pattern, node: fx.Node, modules) -> bool:
     if len(node.args) == 0:
         return False
     nodes = (node.args[0], node)
-    for expected_type, current_node in zip(pattern, nodes, strict=True):
+    for expected_type, current_node in zip(pattern, nodes):
         if not isinstance(current_node, fx.Node):
             return False
         if current_node.op != "call_module":

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -73,6 +73,12 @@ def _replace_node_module(
 def _collect_conv_bn_matches(fx_model: fx.GraphModule, modules, patterns):
     pair_to_nodes = {}
     conv_to_bn_targets = {}
+    conv_target_call_counts = {}
+    for node in fx_model.graph.nodes:
+        if node.op == "call_module":
+            conv_target_call_counts[node.target] = (
+                conv_target_call_counts.get(node.target, 0) + 1
+            )
     for pattern in patterns:
         for node in list(fx_model.graph.nodes):
             if not _matches_module_pattern(pattern, node, modules):
@@ -90,13 +96,13 @@ def _collect_conv_bn_matches(fx_model: fx.GraphModule, modules, patterns):
         for conv_target, bn_targets in conv_to_bn_targets.items()
         if len(bn_targets) > 1
     }
-    if not ambiguous_conv_targets:
-        return pair_to_nodes
-
     return {
         pair: matched_nodes
         for pair, matched_nodes in pair_to_nodes.items()
-        if pair[0] not in ambiguous_conv_targets
+        if (
+            pair[0] not in ambiguous_conv_targets
+            and len(matched_nodes) == conv_target_call_counts[pair[0]]
+        )
     }
 
 

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 import math
+from contextlib import contextmanager
 from torch import fx
 from torch.nn.utils.fusion import fuse_conv_bn_eval
 
@@ -81,21 +82,29 @@ class _TrainConvBnWrapper(nn.Module):
         self.conv = conv
         self.bn = bn
 
+    @contextmanager
+    def _single_step_mode(self, module: nn.Module):
+        if isinstance(module, base.StepModule):
+            old_step_mode = module.step_mode
+            module.step_mode = "s"
+            try:
+                yield
+            finally:
+                module.step_mode = old_step_mode
+        else:
+            yield
+
     def _packed_forward(self, x: Tensor) -> Tensor:
         t, n = x.shape[:2]
         x = x.flatten(0, 1)
-        if isinstance(self.conv, nn.Conv1d):
-            x = nn.Conv1d.forward(self.conv, x)
-        elif isinstance(self.conv, nn.Conv2d):
-            x = nn.Conv2d.forward(self.conv, x)
-        elif isinstance(self.conv, nn.Conv3d):
-            x = nn.Conv3d.forward(self.conv, x)
-        else:
+        if not isinstance(self.conv, (nn.Conv1d, nn.Conv2d, nn.Conv3d)):
             raise TypeError(f"Unsupported packed conv type: {type(self.conv)!r}")
+        with self._single_step_mode(self.conv):
+            x = self.conv(x)
 
-        if isinstance(self.bn, (layer.BatchNorm1d, layer.BatchNorm2d, layer.BatchNorm3d)):
-            x = self.bn.super_forward(x)
-        else:
+        if not isinstance(self.bn, (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d)):
+            raise TypeError(f"Unsupported packed batchnorm type: {type(self.bn)!r}")
+        with self._single_step_mode(self.bn):
             x = self.bn(x)
         return x.view(t, n, *x.shape[1:])
 
@@ -131,16 +140,16 @@ def fuse_conv_bn_eval_modules(net: nn.Module) -> fx.GraphModule:
 
     * **中文**
 
-    将评估模式下模型中的相邻 ``Conv*`` 与 ``BatchNorm*`` 模块融合为单个卷积模块。
+    将评估模式下模型中的相邻 ``Conv*`` 与 ``BatchNorm*`` 模块融合为单个卷积模块.
     该函数同时支持原生 ``torch.nn`` 模块以及 SpikingJelly 的
     :class:`spikingjelly.activation_based.layer.Conv1d`,
     :class:`spikingjelly.activation_based.layer.Conv2d`,
     :class:`spikingjelly.activation_based.layer.Conv3d`,
     :class:`spikingjelly.activation_based.layer.BatchNorm1d`,
     :class:`spikingjelly.activation_based.layer.BatchNorm2d`,
-    :class:`spikingjelly.activation_based.layer.BatchNorm3d`。
+    :class:`spikingjelly.activation_based.layer.BatchNorm3d`.
 
-    输入模型必须处于 ``eval()`` 模式。返回值是融合后的 ``fx.GraphModule``。
+    输入模型必须处于 ``eval()`` 模式; 返回值是融合后的 ``fx.GraphModule``.
 
     .. _fuse_conv_bn_eval_modules-en:
 
@@ -179,6 +188,14 @@ def fuse_conv_bn_eval_modules(net: nn.Module) -> fx.GraphModule:
                 continue
             conv = modules[node.args[0].target]
             bn = modules[node.target]
+            if (
+                getattr(bn, "track_running_stats", True) is False
+                or bn.running_mean is None
+                or bn.running_var is None
+            ):
+                raise ValueError(
+                    f"Cannot fuse {node.target}: BatchNorm must track running stats."
+                )
             fused_conv = fuse_conv_bn_eval(conv, bn)
             _replace_node_module(node.args[0], modules, fused_conv)
             node.replace_all_uses_with(node.args[0])

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -52,6 +52,21 @@ def _replace_node_module(
     setattr(modules[parent], name, new_module)
 
 
+def _collect_conv_bn_matches(fx_model: fx.GraphModule, modules, patterns):
+    pair_to_nodes = {}
+    for pattern in patterns:
+        for node in list(fx_model.graph.nodes):
+            if not _matches_module_pattern(pattern, node, modules):
+                continue
+            conv_node = node.args[0]
+            assert isinstance(conv_node, fx.Node)
+            if len(conv_node.users) > 1:
+                continue
+            pair = (conv_node.target, node.target)
+            pair_to_nodes.setdefault(pair, []).append(node)
+    return pair_to_nodes
+
+
 class _EvalFusionTracer(fx.Tracer):
     def is_leaf_module(self, m: nn.Module, module_qualified_name: str) -> bool:
         if isinstance(
@@ -180,24 +195,24 @@ def fuse_conv_bn_eval_modules(net: nn.Module) -> fx.GraphModule:
         (layer.Conv3d, layer.BatchNorm3d),
     ]
 
-    for pattern in patterns:
-        for node in list(fx_model.graph.nodes):
-            if not _matches_module_pattern(pattern, node, modules):
-                continue
-            if len(node.args[0].users) > 1:
-                continue
-            conv = modules[node.args[0].target]
-            bn = modules[node.target]
-            if (
-                getattr(bn, "track_running_stats", True) is False
-                or bn.running_mean is None
-                or bn.running_var is None
-            ):
-                raise ValueError(
-                    f"Cannot fuse {node.target}: BatchNorm must track running stats."
-                )
-            fused_conv = fuse_conv_bn_eval(conv, bn)
-            _replace_node_module(node.args[0], modules, fused_conv)
+    for (conv_target, bn_target), matched_nodes in _collect_conv_bn_matches(
+        fx_model, modules, patterns
+    ).items():
+        conv = modules[conv_target]
+        bn = modules[bn_target]
+        if (
+            getattr(bn, "track_running_stats", True) is False
+            or bn.running_mean is None
+            or bn.running_var is None
+        ):
+            raise ValueError(
+                f"Cannot fuse {bn_target}: BatchNorm must track running stats."
+            )
+        fused_conv = fuse_conv_bn_eval(conv, bn)
+        conv_node = matched_nodes[0].args[0]
+        assert isinstance(conv_node, fx.Node)
+        _replace_node_module(conv_node, modules, fused_conv)
+        for node in matched_nodes:
             node.replace_all_uses_with(node.args[0])
             fx_model.graph.erase_node(node)
 
@@ -259,22 +274,24 @@ def pack_conv_bn_train_modules(net: nn.Module) -> fx.GraphModule:
         (layer.Conv3d, layer.BatchNorm3d),
     ]
 
-    for pattern in patterns:
-        for node in list(fx_model.graph.nodes):
-            if not _matches_module_pattern(pattern, node, modules):
-                continue
-            if len(node.args[0].users) > 1:
-                continue
-            conv = modules[node.args[0].target]
-            bn = modules[node.target]
-            if (
-                isinstance(conv, (layer.Conv1d, layer.Conv2d, layer.Conv3d))
-                and isinstance(bn, (layer.BatchNorm1d, layer.BatchNorm2d, layer.BatchNorm3d))
-                and getattr(conv, "step_mode", None) != getattr(bn, "step_mode", None)
-            ):
-                continue
-            packed = _TrainConvBnWrapper(conv, bn)
-            _replace_node_module(node.args[0], modules, packed)
+    for (conv_target, bn_target), matched_nodes in _collect_conv_bn_matches(
+        fx_model, modules, patterns
+    ).items():
+        conv = modules[conv_target]
+        bn = modules[bn_target]
+        if (
+            isinstance(conv, (layer.Conv1d, layer.Conv2d, layer.Conv3d))
+            and isinstance(
+                bn, (layer.BatchNorm1d, layer.BatchNorm2d, layer.BatchNorm3d)
+            )
+            and getattr(conv, "step_mode", None) != getattr(bn, "step_mode", None)
+        ):
+            continue
+        packed = _TrainConvBnWrapper(conv, bn)
+        conv_node = matched_nodes[0].args[0]
+        assert isinstance(conv_node, fx.Node)
+        _replace_node_module(conv_node, modules, packed)
+        for node in matched_nodes:
             node.replace_all_uses_with(node.args[0])
             fx_model.graph.erase_node(node)
 

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -3,8 +3,10 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 import math
+from torch import fx
+from torch.nn.utils.fusion import fuse_conv_bn_eval
 
-from .. import neuron
+from .. import base, layer, neuron
 
 
 __all__ = [
@@ -13,7 +15,129 @@ __all__ = [
     "first_spike_index",
     "kaiming_normal_conv_linear_weight",
     "delay",
+    "fuse_conv_bn_eval_modules",
 ]
+
+
+def _matches_module_pattern(pattern, node: fx.Node, modules) -> bool:
+    if len(node.args) == 0:
+        return False
+    nodes = (node.args[0], node)
+    for expected_type, current_node in zip(pattern, nodes):
+        if not isinstance(current_node, fx.Node):
+            return False
+        if current_node.op != "call_module":
+            return False
+        if not isinstance(current_node.target, str):
+            return False
+        if current_node.target not in modules:
+            return False
+        if type(modules[current_node.target]) is not expected_type:
+            return False
+    return True
+
+
+def _replace_node_module(
+    node: fx.Node, modules, new_module: torch.nn.Module
+) -> None:
+    def parent_name(target: str):
+        *parent, name = target.rsplit(".", 1)
+        return parent[0] if parent else "", name
+
+    assert isinstance(node.target, str)
+    parent, name = parent_name(node.target)
+    modules[node.target] = new_module
+    setattr(modules[parent], name, new_module)
+
+
+class _EvalFusionTracer(fx.Tracer):
+    def is_leaf_module(self, m: nn.Module, module_qualified_name: str) -> bool:
+        if isinstance(
+            m,
+            (
+                layer.Conv1d,
+                layer.Conv2d,
+                layer.Conv3d,
+                layer.BatchNorm1d,
+                layer.BatchNorm2d,
+                layer.BatchNorm3d,
+                base.StepModule,
+                base.MemoryModule,
+                neuron.BaseNode,
+            ),
+        ):
+            return True
+        return super().is_leaf_module(m, module_qualified_name)
+
+
+def fuse_conv_bn_eval_modules(net: nn.Module) -> fx.GraphModule:
+    """
+    **API Language:**
+    :ref:`中文 <fuse_conv_bn_eval_modules-cn>` | :ref:`English <fuse_conv_bn_eval_modules-en>`
+
+    ----
+
+    .. _fuse_conv_bn_eval_modules-cn:
+
+    * **中文**
+
+    将评估模式下模型中的相邻 ``Conv*`` 与 ``BatchNorm*`` 模块融合为单个卷积模块。
+    该函数同时支持原生 ``torch.nn`` 模块以及 SpikingJelly 的
+    :class:`spikingjelly.activation_based.layer.Conv1d`,
+    :class:`spikingjelly.activation_based.layer.Conv2d`,
+    :class:`spikingjelly.activation_based.layer.Conv3d`,
+    :class:`spikingjelly.activation_based.layer.BatchNorm1d`,
+    :class:`spikingjelly.activation_based.layer.BatchNorm2d`,
+    :class:`spikingjelly.activation_based.layer.BatchNorm3d`。
+
+    输入模型必须处于 ``eval()`` 模式。返回值是融合后的 ``fx.GraphModule``。
+
+    .. _fuse_conv_bn_eval_modules-en:
+
+    * **English**
+
+    Fuse adjacent ``Conv*`` and ``BatchNorm*`` modules in an evaluation-mode model
+    into a single convolution module. Both native ``torch.nn`` layers and
+    SpikingJelly activation-based ``layer.Conv*`` / ``layer.BatchNorm*`` wrappers
+    are supported.
+
+    The input model must be in ``eval()`` mode. The returned value is a fused
+    ``fx.GraphModule``.
+    """
+
+    if net.training:
+        raise ValueError("fuse_conv_bn_eval_modules only supports eval() models.")
+
+    tracer = _EvalFusionTracer()
+    graph = tracer.trace(net)
+    fx_model = fx.GraphModule(tracer.root, graph)
+    modules = dict(fx_model.named_modules())
+    patterns = [
+        (nn.Conv1d, nn.BatchNorm1d),
+        (nn.Conv2d, nn.BatchNorm2d),
+        (nn.Conv3d, nn.BatchNorm3d),
+        (layer.Conv1d, layer.BatchNorm1d),
+        (layer.Conv2d, layer.BatchNorm2d),
+        (layer.Conv3d, layer.BatchNorm3d),
+    ]
+
+    for pattern in patterns:
+        for node in list(fx_model.graph.nodes):
+            if not _matches_module_pattern(pattern, node, modules):
+                continue
+            if len(node.args[0].users) > 1:
+                continue
+            conv = modules[node.args[0].target]
+            bn = modules[node.target]
+            fused_conv = fuse_conv_bn_eval(conv, bn)
+            _replace_node_module(node.args[0], modules, fused_conv)
+            node.replace_all_uses_with(node.args[0])
+            fx_model.graph.erase_node(node)
+
+    fx_model.graph.lint()
+    fx_model.delete_all_unused_submodules()
+    fx_model.recompile()
+    return fx_model
 
 
 def set_threshold_margin(

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -24,7 +24,7 @@ def _matches_module_pattern(pattern, node: fx.Node, modules) -> bool:
     if len(node.args) == 0:
         return False
     nodes = (node.args[0], node)
-    for expected_type, current_node in zip(pattern, nodes):
+    for expected_type, current_node in zip(pattern, nodes, strict=True):
         if not isinstance(current_node, fx.Node):
             return False
         if current_node.op != "call_module":

--- a/spikingjelly/activation_based/memopt/compress.py
+++ b/spikingjelly/activation_based/memopt/compress.py
@@ -43,7 +43,7 @@ else:
         return s_seq_compressed
 
     def bit_spike_decompress(s_seq_compressed: torch.Tensor, shape) -> torch.Tensor:
-        decompressed_len = shape.numel()
+        decompressed_len = torch.Size(shape).numel()
         s_seq_decompressed = torch.zeros(
             decompressed_len, dtype=torch.bool, device=s_seq_compressed.device
         )
@@ -456,7 +456,7 @@ class SparseSpikeCompressor(BaseSpikeCompressor):
 
     def _decompress(self, s_seq: torch.Tensor, shape) -> torch.Tensor:
         s_seq_decompressed = torch.zeros(
-            shape.numel(), dtype=self.s_seq_dtype, device=s_seq.device
+            torch.Size(shape).numel(), dtype=self.s_seq_dtype, device=s_seq.device
         )
         s_seq_decompressed = s_seq_decompressed.scatter_(
             dim=0,

--- a/spikingjelly/activation_based/memopt/pipeline.py
+++ b/spikingjelly/activation_based/memopt/pipeline.py
@@ -434,15 +434,12 @@ def _inference_time_profile_worker(net, dummy_input, q, device, N=50):
     dummy_input = _dummy_input_to_device(dummy_input, device)
 
     net.eval()
-    with (
-        torch.no_grad(),
-        LayerWiseFPCUDATimeProfiler(
-            (net,),
-            model_names=("net",),
-            search_mode=("submodules",),
-            instances=(GCContainer,),
-        ) as prof,
-    ):
+    with torch.no_grad(), LayerWiseFPCUDATimeProfiler(
+        (net,),
+        model_names=("net",),
+        search_mode=("submodules",),
+        instances=(GCContainer,),
+    ) as prof:
         for _ in range(N):
             _ = net(*dummy_input)
             functional.reset_net(net)

--- a/spikingjelly/activation_based/model/tv_ref_classify/utils.py
+++ b/spikingjelly/activation_based/model/tv_ref_classify/utils.py
@@ -517,6 +517,5 @@ def reduce_across_processes(val, op=dist.ReduceOp.SUM, dtype=None):
     else:
         device = torch.device("cpu")
     t = torch.tensor(val, device=device, dtype=dtype)
-    dist.barrier()
     dist.all_reduce(t, op=op)
     return t

--- a/spikingjelly/activation_based/model/tv_ref_classify/utils.py
+++ b/spikingjelly/activation_based/model/tv_ref_classify/utils.py
@@ -512,7 +512,10 @@ def reduce_across_processes(val, op=dist.ReduceOp.SUM, dtype=None):
         return torch.tensor(val, dtype=dtype)
 
     backend = dist.get_backend()
-    if backend == "nccl":
+    backend_name = (
+        backend if isinstance(backend, str) else getattr(backend, "value", str(backend))
+    )
+    if "nccl" in backend_name.lower():
         device = torch.device("cuda", torch.cuda.current_device())
     else:
         device = torch.device("cpu")

--- a/spikingjelly/activation_based/model/tv_ref_classify/utils.py
+++ b/spikingjelly/activation_based/model/tv_ref_classify/utils.py
@@ -97,7 +97,11 @@ class ThroughputValue:
         if not is_dist_avail_and_initialized():
             return
 
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        backend = dist.get_backend()
+        if backend == "nccl":
+            device = torch.device("cuda", torch.cuda.current_device())
+        else:
+            device = torch.device("cpu")
         samples = torch.tensor(self.total_samples, device=device, dtype=torch.float64)
         elapsed = torch.tensor(self.total_time, device=device, dtype=torch.float64)
         dist.barrier()

--- a/spikingjelly/activation_based/model/tv_ref_classify/utils.py
+++ b/spikingjelly/activation_based/model/tv_ref_classify/utils.py
@@ -97,16 +97,12 @@ class ThroughputValue:
         if not is_dist_avail_and_initialized():
             return
 
-        backend = dist.get_backend()
-        if backend == "nccl":
-            device = torch.device("cuda", torch.cuda.current_device())
-        else:
-            device = torch.device("cpu")
-        samples = torch.tensor(self.total_samples, device=device, dtype=torch.float64)
-        elapsed = torch.tensor(self.total_time, device=device, dtype=torch.float64)
-        dist.barrier()
-        dist.all_reduce(samples, op=dist.ReduceOp.SUM)
-        dist.all_reduce(elapsed, op=dist.ReduceOp.MAX)
+        samples = reduce_across_processes(
+            self.total_samples, op=dist.ReduceOp.SUM, dtype=torch.float64
+        )
+        elapsed = reduce_across_processes(
+            self.total_time, op=dist.ReduceOp.MAX, dtype=torch.float64
+        )
         self.total_samples = samples.item()
         self.total_time = elapsed.item()
 
@@ -510,12 +506,17 @@ def store_model_weights(model, checkpoint_path, checkpoint_key="model", strict=T
     return output_path
 
 
-def reduce_across_processes(val):
+def reduce_across_processes(val, op=dist.ReduceOp.SUM, dtype=None):
     if not is_dist_avail_and_initialized():
         # nothing to sync, but we still convert to tensor for consistency with the distributed case.
-        return torch.tensor(val)
+        return torch.tensor(val, dtype=dtype)
 
-    t = torch.tensor(val, device="cuda")
+    backend = dist.get_backend()
+    if backend == "nccl":
+        device = torch.device("cuda", torch.cuda.current_device())
+    else:
+        device = torch.device("cpu")
+    t = torch.tensor(val, device=device, dtype=dtype)
     dist.barrier()
-    dist.all_reduce(t)
+    dist.all_reduce(t, op=op)
     return t

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -261,22 +261,6 @@ def _empty_multistep_outputs(
     return [_empty_output(i) for i in range(num_outputs)]
 
 
-def _infer_empty_output_templates(
-    core: Callable,
-    args: Tuple[torch.Tensor, ...],
-    states: List[torch.Tensor],
-    num_outputs: int,
-) -> List[torch.Tensor]:
-    step_inputs = tuple(arg.new_empty(arg.shape[1:]) for arg in args)
-    with torch.no_grad():
-        results = _as_tuple(core(*step_inputs, *states))
-    if len(results) < num_outputs:
-        raise ValueError(
-            f"FlexSN core returned {len(results)} values, expected at least {num_outputs} outputs."
-        )
-    return [result.new_empty((0, *result.shape)) for result in results[:num_outputs]]
-
-
 def _core_requires_grad(core: Callable) -> bool:
     if isinstance(core, functools.partial):
         return (
@@ -891,14 +875,9 @@ class FlexSN(base.MemoryModule):
         if T == 0 and self.backend != "hop":
             if self.states is None:
                 self.states = self.init_states(self.num_states, self.step_mode, *args)
-            if self.backend == "torch":
-                output_seqs = _infer_empty_output_templates(
-                    self.core, args, self.states, self.num_outputs
-                )
-            else:
-                output_seqs = _empty_multistep_outputs(
-                    args, self.states, self.num_outputs
-                )
+            output_seqs = _empty_multistep_outputs(
+                args, self.states, self.num_outputs
+            )
             if self.store_state_seqs:
                 self.state_seqs = [
                     s.new_empty((0, *s.shape)) for s in self.states

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -123,6 +123,14 @@ def _make_inductor_final_state_warmup_args(info, device, warmup_specs):
     return warm_args
 
 
+def _first_cuda_device(tensors):
+    if tensors is not None:
+        for tensor in tensors:
+            if isinstance(tensor, torch.Tensor) and tensor.device.type == "cuda":
+                return tensor.device
+    return None
+
+
 def _as_tuple(outputs):
     if isinstance(outputs, torch.Tensor):
         return (outputs,)
@@ -634,9 +642,9 @@ class FlexSN(base.MemoryModule):
         register_flexsn_kernel_handle = None
 
         if backend == "inductor" and torch.cuda.is_available():
-            self._inductor_scan_final_state_device = torch.device(
-                "cuda", torch.cuda.current_device()
-            )
+            self._inductor_scan_final_state_device = _first_cuda_device(
+                example_inputs
+            ) or torch.device("cuda", torch.cuda.current_device())
             try:
                 from ..triton_kernel.flex_sn_inductor.kernel import (
                     build_inference_kernel, build_inference_final_state_kernel, build_training_kernels,

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -376,7 +376,7 @@ class FlexSN(base.MemoryModule):
         :type step_mode: str
 
         :param backend: 使用的后端。``"triton"``、``"inductor"`` 和 ``"hop"`` 仅在
-            ``step_mode="m"`` 时可用；``"torch"`` 始终可用。默认 ``"triton"``。
+            ``step_mode="m"`` 时可用; ``"torch"`` 始终可用。默认 ``"triton"``。
         :type backend: str
 
         :param store_state_seqs: 是否保存状态序列。如果为 ``True``，用户可以通过 ``state_seqs`` 属性访问。
@@ -682,7 +682,9 @@ class FlexSN(base.MemoryModule):
         if step_mode == "s":
             return [torch.zeros_like(args[0]) for _ in range(num_states)]
         elif step_mode == "m":
-            return [torch.zeros_like(args[0][0]) for _ in range(num_states)]
+            if args[0].shape[0] > 0:
+                return [torch.zeros_like(args[0][0]) for _ in range(num_states)]
+            return [args[0].new_zeros(args[0].shape[1:]) for _ in range(num_states)]
         else:
             raise ValueError(f"Unsupported step mode: {step_mode}")
 
@@ -695,6 +697,20 @@ class FlexSN(base.MemoryModule):
     def multi_step_forward(self, *args):
         if self.backend == "torch":
             T = args[0].shape[0]
+            if T == 0:
+                step_inputs = tuple(arg.new_empty(arg.shape[1:]) for arg in args)
+                with torch.no_grad():
+                    step_results = _as_tuple(self.core(*step_inputs, *self.states))
+                output_seqs = [
+                    y.new_empty((0, *y.shape))
+                    for y in step_results[: self.num_outputs]
+                ]
+                if self.store_state_seqs:
+                    self.state_seqs = [
+                        s.new_empty((0, *s.shape)) for s in step_results[self.num_outputs :]
+                    ]
+                return output_seqs
+
             output_seqs = [[] for _ in range(self.num_outputs)]
             if self.store_state_seqs:
                 state_seqs = [[] for _ in range(self.num_states)]
@@ -778,6 +794,7 @@ class FlexSN(base.MemoryModule):
                         result_seqs = flexsn_inductor_inference(
                             self._inductor_handle, flat_args
                         )
+                        result_has_state_seqs = True
                 elif (not _no_grad) and self._inductor_training_available:
                     if not self.store_state_seqs:
                         result_seqs = flexsn_inductor_training_final_state(
@@ -799,6 +816,7 @@ class FlexSN(base.MemoryModule):
             else:
                 result_seqs = None
 
+            result_has_state_seqs = self.store_state_seqs
             if result_seqs is None:
                 if self.states is None:
                     self.states = self.init_states(self.num_states, self.step_mode, *args)
@@ -811,11 +829,13 @@ class FlexSN(base.MemoryModule):
                     *args,
                     *self.states,
                 )
+                result_has_state_seqs = self.store_state_seqs
             output_seqs = list(result_seqs[: self.num_outputs])
             state_seqs = list(result_seqs[self.num_outputs :])
-            if self.store_state_seqs:
+            if result_has_state_seqs:
                 self.states = [v[-1] for v in state_seqs]
-                self.state_seqs = state_seqs
+                if self.store_state_seqs:
+                    self.state_seqs = state_seqs
             else:
                 self.states = state_seqs
             return output_seqs

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -12,6 +12,14 @@ except BaseException as e:
     logging.info(f"spikingjelly.activation_based.neuron: {e}")
     triton_kernel = None
 
+try:
+    from ..triton_kernel.flex_sn_inductor import eager_scan as _flexsn_eager_scan
+    from ..triton_kernel.flex_sn_inductor import flex_sn_scan as _flexsn_hop_scan
+except BaseException as e:
+    logging.info(f"spikingjelly.activation_based.neuron.flexsn: {e}")
+    _flexsn_eager_scan = None
+    _flexsn_hop_scan = None
+
 
 __all__ = ["FlexSNKernel", "FlexSN"]
 
@@ -43,19 +51,17 @@ def _run_hop_scan(
     num_outputs: int,
     *flat_args: torch.Tensor,
 ):
-    from ..triton_kernel.flex_sn_inductor import eager_scan, flex_sn_scan
-
-    if eager_scan is None:
+    if _flexsn_eager_scan is None:
         raise RuntimeError(
             "FlexSN HOP backend is unavailable: eager_scan failed to import. "
             "See logs from "
             "spikingjelly.activation_based.triton_kernel.flex_sn_inductor."
         )
 
-    if _is_compiling() or flex_sn_scan is None:
-        scan_impl = eager_scan
+    if _is_compiling() or _flexsn_hop_scan is None:
+        scan_impl = _flexsn_eager_scan
     else:
-        scan_impl = flex_sn_scan
+        scan_impl = _flexsn_hop_scan
 
     return scan_impl(
         core,

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -10,7 +10,7 @@ from .. import base
 
 try:
     from .. import triton_kernel
-except BaseException as e:
+except (ImportError, AttributeError) as e:
     logging.info(f"spikingjelly.activation_based.neuron: {e}")
     triton_kernel = None
 
@@ -36,7 +36,7 @@ try:
     from ..triton_kernel.flex_sn_inductor import (
         lowerable_while_loop_available as _flexsn_lowerable_while_loop_available,
     )
-except BaseException as e:
+except (ImportError, AttributeError) as e:
     logging.info(f"spikingjelly.activation_based.neuron.flexsn: {e}")
     _flexsn_eager_scan = None
     _flexsn_eager_scan_final_state = None

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -273,8 +273,8 @@ def _empty_multistep_outputs(
             else:
                 shape, dtype, device = spec
             return torch.empty((0, *shape), dtype=dtype, device=device)
-        if i < len(args):
-            ref = args[i].new_empty(args[i].shape[1:])
+        if args:
+            ref = args[0].new_empty(args[0].shape[1:])
         elif states:
             ref = states[-1]
         else:

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -73,10 +73,11 @@ def _warmup_inductor_inference_final_state_kernel(module: "FlexSN") -> None:
                     break
     if device is None:
         device = torch.device("cuda", torch.cuda.current_device())
-    seq_template = torch.zeros((1, 1), device=device)
-    state_template = seq_template[0].clone()
-    warm_args = [seq_template.clone() for _ in range(info.num_inputs)]
-    warm_args.extend(state_template.clone() for _ in range(info.num_states))
+    warm_args = _make_inductor_final_state_warmup_args(
+        info,
+        device,
+        getattr(module, "_inductor_scan_final_state_warmup_specs", None),
+    )
 
     with torch.no_grad():
         flexsn_inference_final_state(
@@ -84,6 +85,38 @@ def _warmup_inductor_inference_final_state_kernel(module: "FlexSN") -> None:
             info,
             *warm_args,
         )
+
+
+def _make_inductor_final_state_warmup_specs(
+    example_inputs: Optional[Tuple[torch.Tensor, ...]],
+    expected: int,
+):
+    if example_inputs is None or len(example_inputs) < expected:
+        return None
+    return tuple(
+        (tuple(tensor.shape), tensor.dtype)
+        for tensor in example_inputs[:expected]
+    )
+
+
+def _make_inductor_final_state_warmup_args(info, device, warmup_specs):
+    expected = info.num_inputs + info.num_states
+    if warmup_specs is not None and len(warmup_specs) >= expected:
+        warm_args = [
+            torch.zeros((1, *shape), dtype=dtype, device=device)
+            for shape, dtype in warmup_specs[: info.num_inputs]
+        ]
+        warm_args.extend(
+            torch.zeros(shape, dtype=dtype, device=device)
+            for shape, dtype in warmup_specs[info.num_inputs : expected]
+        )
+        return warm_args
+
+    seq_template = torch.zeros((1, 1), device=device)
+    state_template = seq_template[0].clone()
+    warm_args = [seq_template.clone() for _ in range(info.num_inputs)]
+    warm_args.extend(state_template.clone() for _ in range(info.num_states))
+    return warm_args
 
 
 def _as_tuple(outputs):
@@ -554,6 +587,12 @@ class FlexSN(base.MemoryModule):
         self.step_mode = step_mode
         self.backend = backend
         self.store_state_seqs = store_state_seqs
+        self._inductor_scan_final_state_warmup_specs = (
+            _make_inductor_final_state_warmup_specs(
+                example_inputs,
+                num_inputs + num_states,
+            )
+        )
 
         if backend in ("triton", "inductor"):
             _validate_scan_backend_contract(

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -1,4 +1,5 @@
 import copy
+import contextlib
 import functools
 import os
 from typing import Callable, Optional, Tuple, List
@@ -83,7 +84,12 @@ def _warmup_inductor_inference_final_state_kernel(module: "FlexSN") -> None:
         getattr(module, "_inductor_scan_final_state_warmup_specs", None),
     )
 
-    with torch.no_grad():
+    device_guard = (
+        torch.cuda.device(device)
+        if device.type == "cuda"
+        else contextlib.nullcontext()
+    )
+    with torch.no_grad(), device_guard:
         flexsn_inference_final_state(
             module._inductor_scan_final_state_kernel,
             info,
@@ -333,10 +339,16 @@ def _core_requires_grad(core: Callable) -> bool:
         return True
     if bound_self is not None:
         bound_self_dict = getattr(bound_self, "__dict__", None)
-        if bound_self_dict is not None and any(
-            _value_requires_grad(value) for value in bound_self_dict.values()
-        ):
-            return True
+        if bound_self_dict is not None:
+            values = bound_self_dict.values()
+            if isinstance(bound_self, torch.nn.Module):
+                values = (
+                    value
+                    for key, value in bound_self_dict.items()
+                    if key not in {"_parameters", "_buffers", "_modules"}
+                )
+            if any(_value_requires_grad(value) for value in values):
+                return True
 
     if isinstance(core, torch.nn.Module):
         for tensor in [*core.parameters(), *core.buffers()]:

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -269,15 +269,18 @@ def _empty_multistep_outputs(
             spec = output_template_specs[i]
             if len(spec) == 2:
                 shape, dtype = spec
+                device = args[0].device
             else:
-                shape, dtype, _ = spec
-            return torch.empty((0, *shape), dtype=dtype, device=args[0].device)
+                shape, dtype, device = spec
+            return torch.empty((0, *shape), dtype=dtype, device=device)
         if args:
             ref = args[0].new_empty(args[0].shape[1:])
         elif states:
             ref = states[-1]
         else:
-            ref = args[0].new_empty(args[0].shape[1:])
+            raise ValueError(
+                "FlexSN empty output fallback requires at least one input or state."
+            )
         return ref.new_empty((0, *ref.shape))
 
     return [_empty_output(i) for i in range(num_outputs)]

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -102,6 +102,12 @@ def _run_hop_scan(
     store_state_seqs: bool,
     *flat_args: torch.Tensor,
 ):
+    enable_lowerable_while_loop = (
+        os.environ.get("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP", "0") == "1"
+    )
+    enable_lowerable_scan = (
+        os.environ.get("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_SCAN", "0") == "1"
+    )
     if _flexsn_eager_scan is None:
         raise RuntimeError(
             "FlexSN HOP backend is unavailable: eager_scan failed to import. "
@@ -115,7 +121,7 @@ def _run_hop_scan(
         and callable(_flexsn_lowerable_while_loop_available)
         and _flexsn_lowerable_while_loop_available()
         and (not torch.is_grad_enabled())
-        and os.getenv("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP", "0") == "1"
+        and enable_lowerable_while_loop
     )
     use_lowerable_scan = (
         _is_compiling()
@@ -123,7 +129,7 @@ def _run_hop_scan(
         and callable(_flexsn_lowerable_scan_available)
         and _flexsn_lowerable_scan_available()
         and (not torch.is_grad_enabled())
-        and os.getenv("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_SCAN", "0") == "1"
+        and enable_lowerable_scan
     )
 
     if use_lowerable_while_loop:
@@ -698,16 +704,19 @@ class FlexSN(base.MemoryModule):
         if self.backend == "torch":
             T = args[0].shape[0]
             if T == 0:
-                step_inputs = tuple(arg.new_empty(arg.shape[1:]) for arg in args)
-                with torch.no_grad():
-                    step_results = _as_tuple(self.core(*step_inputs, *self.states))
-                output_seqs = [
-                    y.new_empty((0, *y.shape))
-                    for y in step_results[: self.num_outputs]
-                ]
+                def _empty_output(i: int) -> torch.Tensor:
+                    if i < len(self.states):
+                        ref = self.states[i]
+                    elif self.states:
+                        ref = self.states[-1]
+                    else:
+                        ref = args[0].new_empty(args[0].shape[1:])
+                    return ref.new_empty((0, *ref.shape))
+
+                output_seqs = [_empty_output(i) for i in range(self.num_outputs)]
                 if self.store_state_seqs:
                     self.state_seqs = [
-                        s.new_empty((0, *s.shape)) for s in step_results[self.num_outputs :]
+                        s.new_empty((0, *s.shape)) for s in self.states
                     ]
                 return output_seqs
 
@@ -758,6 +767,7 @@ class FlexSN(base.MemoryModule):
             return output_seqs
 
         elif self.backend == "inductor":
+            result_has_state_seqs = self.store_state_seqs
             _no_grad = not torch.is_grad_enabled() or not any(
                 a.requires_grad for a in (
                     *args,
@@ -816,7 +826,6 @@ class FlexSN(base.MemoryModule):
             else:
                 result_seqs = None
 
-            result_has_state_seqs = self.store_state_seqs
             if result_seqs is None:
                 if self.states is None:
                     self.states = self.init_states(self.num_states, self.step_mode, *args)

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -278,11 +278,8 @@ def _make_output_template_specs_from_examples(
 ) -> Optional[Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]]:
     if example_inputs is None:
         return None
-    specs = []
-    for i in range(num_outputs):
-        ref = example_inputs[i] if i < len(example_inputs) else example_inputs[0]
-        specs.append((tuple(ref.shape), ref.dtype))
-    return tuple(specs)
+    ref = example_inputs[0]
+    return tuple((tuple(ref.shape), ref.dtype) for _ in range(num_outputs))
 
 
 def _make_output_template_specs_from_outputs(

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -248,10 +248,14 @@ def _empty_multistep_outputs(
     args: Tuple[torch.Tensor, ...],
     states: List[torch.Tensor],
     num_outputs: int,
+    output_template_specs: Optional[Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]] = None,
 ) -> List[torch.Tensor]:
     def _empty_output(i: int) -> torch.Tensor:
-        if i < len(states):
-            ref = states[i]
+        if output_template_specs is not None and i < len(output_template_specs):
+            shape, dtype = output_template_specs[i]
+            return torch.empty((0, *shape), dtype=dtype, device=args[0].device)
+        if i < len(args):
+            ref = args[i].new_empty(args[i].shape[1:])
         elif states:
             ref = states[-1]
         else:
@@ -259,6 +263,28 @@ def _empty_multistep_outputs(
         return ref.new_empty((0, *ref.shape))
 
     return [_empty_output(i) for i in range(num_outputs)]
+
+
+def _make_output_template_specs(
+    core: Callable,
+    num_outputs: int,
+    example_inputs: Optional[Tuple[torch.Tensor, ...]],
+) -> Optional[Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]]:
+    if example_inputs is None:
+        return None
+    with torch.no_grad():
+        results = _as_tuple(core(*tuple(x.detach().clone() for x in example_inputs)))
+    if len(results) < num_outputs:
+        raise ValueError(
+            f"FlexSN core returned {len(results)} values, expected at least "
+            f"{num_outputs} outputs."
+        )
+    specs = []
+    for result in results[:num_outputs]:
+        if not isinstance(result, torch.Tensor):
+            return None
+        specs.append((tuple(result.shape), result.dtype))
+    return tuple(specs)
 
 
 def _core_requires_grad(core: Callable) -> bool:
@@ -600,6 +626,11 @@ class FlexSN(base.MemoryModule):
                 num_inputs + num_states,
             )
         )
+        self._output_template_specs = _make_output_template_specs(
+            core,
+            num_outputs,
+            example_inputs,
+        )
 
         if backend in ("triton", "inductor"):
             _validate_scan_backend_contract(
@@ -876,7 +907,7 @@ class FlexSN(base.MemoryModule):
             if self.states is None:
                 self.states = self.init_states(self.num_states, self.step_mode, *args)
             output_seqs = _empty_multistep_outputs(
-                args, self.states, self.num_outputs
+                args, self.states, self.num_outputs, self._output_template_specs
             )
             if self.store_state_seqs:
                 self.state_seqs = [
@@ -885,6 +916,8 @@ class FlexSN(base.MemoryModule):
             return output_seqs
 
         if self.backend == "torch":
+            if self.states is None:
+                self.states = self.init_states(self.num_states, self.step_mode, *args)
             output_seqs = [[] for _ in range(self.num_outputs)]
             if self.store_state_seqs:
                 state_seqs = [[] for _ in range(self.num_states)]
@@ -915,6 +948,8 @@ class FlexSN(base.MemoryModule):
             return output_seqs
 
         elif self.backend == "hop":
+            if self.states is None:
+                self.states = self.init_states(self.num_states, self.step_mode, *args)
             state_args = [state.contiguous() for state in self.states]
             result_seqs = _run_hop_scan(
                 self.core,

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -314,6 +314,12 @@ def _core_requires_grad(core: Callable) -> bool:
     bound_self = getattr(core, "__self__", None)
     if bound_self is not None and _value_requires_grad(bound_self):
         return True
+    if bound_self is not None:
+        bound_self_dict = getattr(bound_self, "__dict__", None)
+        if bound_self_dict is not None and any(
+            _value_requires_grad(value) for value in bound_self_dict.values()
+        ):
+            return True
 
     if isinstance(core, torch.nn.Module):
         for tensor in [*core.parameters(), *core.buffers()]:
@@ -664,11 +670,12 @@ class FlexSN(base.MemoryModule):
                 num_inputs + num_states,
             )
         )
+        self._explicit_output_template_specs = _make_output_template_specs_from_outputs(
+            num_outputs,
+            example_outputs,
+        )
         self._output_template_specs = (
-            _make_output_template_specs_from_outputs(
-                num_outputs,
-                example_outputs,
-            )
+            self._explicit_output_template_specs
             or _make_output_template_specs_from_examples(
                 num_outputs,
                 example_inputs,
@@ -952,6 +959,12 @@ class FlexSN(base.MemoryModule):
         if T == 0 and self.backend != "hop":
             if self.states is None:
                 self.states = self.init_states(self.num_states, self.step_mode, *args)
+            if self.backend == "torch" and self._explicit_output_template_specs is None:
+                raise ValueError(
+                    "FlexSN backend='torch' requires example_outputs for empty "
+                    "multi-step inputs so output shapes and dtypes match core's "
+                    "per-step return contract without executing core."
+                )
             output_seqs = _empty_multistep_outputs(
                 args, self.states, self.num_outputs, self._output_template_specs
             )

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -813,15 +813,7 @@ class FlexSN(base.MemoryModule):
 
         elif self.backend == "inductor":
             result_has_state_seqs = self.store_state_seqs
-            _no_grad = (not torch.is_grad_enabled()) and not (
-                any(
-                    a.requires_grad for a in (
-                        *args,
-                        *([] if self.states is None else self.states),
-                    )
-                )
-                or _core_requires_grad(self.core)
-            )
+            _no_grad = not torch.is_grad_enabled()
             use_implicit_zero_states = (
                 self.states is None and _no_grad and _can_elide_zero_state_inputs(self)
             )

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -989,6 +989,8 @@ class FlexSN(base.MemoryModule):
                 and not _core_requires_grad(self.core)
             )
             use_implicit_zero_states = can_elide_zero_states and _no_grad
+            if self.states is None and not use_implicit_zero_states:
+                self.states = self.init_states(self.num_states, self.step_mode, *args)
             state_args = [] if use_implicit_zero_states else list(self.states)
             flat_args = [*args, *state_args]
             all_cuda = len(flat_args) > 0 and all(t.is_cuda for t in flat_args)
@@ -1001,7 +1003,7 @@ class FlexSN(base.MemoryModule):
                     flexsn_inductor_training_final_state,
                 )
 
-                if _no_grad and self._inductor_inference_available:
+                if _no_grad:
                     if (
                         not self.store_state_seqs
                         and self._inductor_inference_final_state_available
@@ -1012,11 +1014,13 @@ class FlexSN(base.MemoryModule):
                         output_seqs = list(result_seqs[: self.num_outputs])
                         self.states = list(result_seqs[self.num_outputs :])
                         return output_seqs
-                    else:
+                    elif self._inductor_inference_available:
                         result_seqs = flexsn_inductor_inference(
                             self._inductor_handle, flat_args
                         )
                         result_has_state_seqs = True
+                    else:
+                        result_seqs = None
                 elif (not _no_grad) and self._inductor_training_available:
                     if not self.store_state_seqs:
                         result_seqs = flexsn_inductor_training_final_state(

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -269,6 +269,26 @@ def _empty_multistep_outputs(
     return [_empty_output(i) for i in range(num_outputs)]
 
 
+def _make_output_template_specs_from_core(
+    core: Callable,
+    args: Tuple[torch.Tensor, ...],
+    states: List[torch.Tensor],
+    num_outputs: int,
+    num_states: int,
+) -> Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]:
+    step_inputs = tuple(arg.new_empty(arg.shape[1:]) for arg in args)
+    state_inputs = [state.clone() for state in states]
+    with torch.no_grad():
+        returns = _as_tuple(core(*step_inputs, *state_inputs))
+    expected = num_outputs + num_states
+    if len(returns) != expected:
+        raise ValueError(
+            f"FlexSN core returned {len(returns)} values, but expected "
+            f"{expected} (= num_outputs + num_states)."
+        )
+    return tuple((tuple(t.shape), t.dtype) for t in returns[:num_outputs])
+
+
 def _make_output_template_specs_from_examples(
     num_outputs: int,
     example_inputs: Optional[Tuple[torch.Tensor, ...]],
@@ -907,8 +927,18 @@ class FlexSN(base.MemoryModule):
         if T == 0 and self.backend != "hop":
             if self.states is None:
                 self.states = self.init_states(self.num_states, self.step_mode, *args)
+            output_template_specs = self._output_template_specs
+            if self.backend == "torch":
+                output_template_specs = _make_output_template_specs_from_core(
+                    self.core,
+                    args,
+                    self.states,
+                    self.num_outputs,
+                    self.num_states,
+                )
+                self._output_template_specs = output_template_specs
             output_seqs = _empty_multistep_outputs(
-                args, self.states, self.num_outputs, self._output_template_specs
+                args, self.states, self.num_outputs, output_template_specs
             )
             if self.store_state_seqs:
                 self.state_seqs = [

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -158,6 +158,7 @@ def _run_hop_scan(
     num_outputs: int,
     store_state_seqs: bool,
     *flat_args: torch.Tensor,
+    output_template_specs=None,
 ):
     enable_lowerable_while_loop = (
         os.environ.get("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP", "0") == "1"
@@ -226,12 +227,18 @@ def _run_hop_scan(
     if scan_impl is None:
         raise RuntimeError("FlexSN HOP backend has no available scan implementation.")
 
+    template_kwargs = (
+        {}
+        if output_template_specs is None or scan_impl is _flexsn_hop_scan
+        else {"output_template_specs": output_template_specs}
+    )
     return scan_impl(
         core,
         num_inputs,
         num_states,
         num_outputs,
         *flat_args,
+        **template_kwargs,
     )
 
 
@@ -255,12 +262,17 @@ def _empty_multistep_outputs(
     args: Tuple[torch.Tensor, ...],
     states: List[torch.Tensor],
     num_outputs: int,
-    output_template_specs: Optional[Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]] = None,
+    output_template_specs: Optional[Tuple[Tuple, ...]] = None,
 ) -> List[torch.Tensor]:
     def _empty_output(i: int) -> torch.Tensor:
         if output_template_specs is not None and i < len(output_template_specs):
-            shape, dtype = output_template_specs[i]
-            return torch.empty((0, *shape), dtype=dtype, device=args[0].device)
+            spec = output_template_specs[i]
+            if len(spec) == 2:
+                shape, dtype = spec
+                device = args[0].device
+            else:
+                shape, dtype, device = spec
+            return torch.empty((0, *shape), dtype=dtype, device=device)
         if i < len(args):
             ref = args[i].new_empty(args[i].shape[1:])
         elif states:
@@ -275,17 +287,17 @@ def _empty_multistep_outputs(
 def _make_output_template_specs_from_examples(
     num_outputs: int,
     example_inputs: Optional[Tuple[torch.Tensor, ...]],
-) -> Optional[Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]]:
+) -> Optional[Tuple[Tuple, ...]]:
     if example_inputs is None:
         return None
     ref = example_inputs[0]
-    return tuple((tuple(ref.shape), ref.dtype) for _ in range(num_outputs))
+    return tuple((tuple(ref.shape), ref.dtype, ref.device) for _ in range(num_outputs))
 
 
 def _make_output_template_specs_from_outputs(
     num_outputs: int,
     example_outputs: Optional[Tuple[torch.Tensor, ...]],
-) -> Optional[Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]]:
+) -> Optional[Tuple[Tuple, ...]]:
     if example_outputs is None:
         return None
     if len(example_outputs) != num_outputs:
@@ -299,7 +311,7 @@ def _make_output_template_specs_from_outputs(
             raise TypeError(
                 f"FlexSN example output #{i} is {type(tensor)!r}; expected a tensor."
             )
-        specs.append((tuple(tensor.shape), tensor.dtype))
+        specs.append((tuple(tensor.shape), tensor.dtype, tensor.device))
     return tuple(specs)
 
 
@@ -1025,6 +1037,7 @@ class FlexSN(base.MemoryModule):
                 self.store_state_seqs,
                 *args,
                 *state_args,
+                output_template_specs=self._output_template_specs,
             )
             output_seqs = list(result_seqs[: self.num_outputs])
             state_results = list(result_seqs[self.num_outputs :])
@@ -1117,6 +1130,7 @@ class FlexSN(base.MemoryModule):
                     self.store_state_seqs,
                     *args,
                     *state_args,
+                    output_template_specs=self._output_template_specs,
                 )
                 result_has_state_seqs = self.store_state_seqs
             output_seqs = list(result_seqs[: self.num_outputs])

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -282,6 +282,27 @@ def _make_output_template_specs_from_examples(
     return tuple(specs)
 
 
+def _make_output_template_specs_from_outputs(
+    num_outputs: int,
+    example_outputs: Optional[Tuple[torch.Tensor, ...]],
+) -> Optional[Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]]:
+    if example_outputs is None:
+        return None
+    if len(example_outputs) != num_outputs:
+        raise ValueError(
+            f"FlexSN expected {num_outputs} example output tensors, but got "
+            f"{len(example_outputs)}."
+        )
+    specs = []
+    for i, tensor in enumerate(example_outputs):
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(
+                f"FlexSN example output #{i} is {type(tensor)!r}; expected a tensor."
+            )
+        specs.append((tuple(tensor.shape), tensor.dtype))
+    return tuple(specs)
+
+
 def _core_requires_grad(core: Callable) -> bool:
     if isinstance(core, functools.partial):
         return (
@@ -508,6 +529,7 @@ class FlexSN(base.MemoryModule):
         step_mode: str = "m",
         backend: str = "triton",
         store_state_seqs: bool = False,
+        example_outputs: Optional[Tuple[torch.Tensor]] = None,
     ):
         """
         **API Language:**
@@ -557,6 +579,11 @@ class FlexSN(base.MemoryModule):
         :param store_state_seqs: 是否保存状态序列。如果为 ``True``，用户可以通过 ``state_seqs`` 属性访问。
             ``state_seqs`` 是个列表，每个元素是形状为 ``[T, ...]`` 的张量。默认 ``False``。
         :type store_state_seqs: bool
+
+        :param example_outputs: ``core`` 的单步输出模板，形式为 ``[*outputs]``。
+            在空序列输入时用于构造输出张量的形状和 dtype，避免为了推断输出而执行 ``core``。
+            默认为 ``None``。
+        :type example_outputs: Optional[Tuple[torch.Tensor]]
 
         ----
 
@@ -617,6 +644,11 @@ class FlexSN(base.MemoryModule):
             ``state_seqs`` is a list of tensors with shape ``[T, ...]``. Defaults
             to ``False``.
         :type store_state_seqs: bool
+
+        :param example_outputs: per-step output templates for ``core`` with the form of
+            ``[*outputs]``. They provide the empty-sequence output shapes and dtypes
+            without executing ``core`` for shape inference. Defaults to ``None``.
+        :type example_outputs: Optional[Tuple[torch.Tensor]]
         """
         super().__init__()
         self.core = core
@@ -632,9 +664,15 @@ class FlexSN(base.MemoryModule):
                 num_inputs + num_states,
             )
         )
-        self._output_template_specs = _make_output_template_specs_from_examples(
-            num_outputs,
-            example_inputs,
+        self._output_template_specs = (
+            _make_output_template_specs_from_outputs(
+                num_outputs,
+                example_outputs,
+            )
+            or _make_output_template_specs_from_examples(
+                num_outputs,
+                example_inputs,
+            )
         )
 
         if backend in ("triton", "inductor"):
@@ -700,6 +738,9 @@ class FlexSN(base.MemoryModule):
                         build_inference_final_state_kernel(core, num_inputs, num_states, num_outputs, example_inputs=example_inputs)
                     )
                 except Exception as e:
+                    # Triton/CUDA/driver compilation failures surface through
+                    # several exception types; any failure here can safely fall
+                    # back to the already-built regular inference path.
                     logging.warning(
                         "FlexSN: could not build inductor inference-final-state kernel (%s); "
                         "store_state_seqs=False inference falls back to the regular inference kernel." % e

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -291,7 +291,7 @@ def _make_output_template_specs_from_examples(
     if example_inputs is None:
         return None
     ref = example_inputs[0]
-    return tuple((tuple(ref.shape), ref.dtype, ref.device) for _ in range(num_outputs))
+    return tuple((tuple(ref.shape), ref.dtype) for _ in range(num_outputs))
 
 
 def _make_output_template_specs_from_outputs(
@@ -311,7 +311,7 @@ def _make_output_template_specs_from_outputs(
             raise TypeError(
                 f"FlexSN example output #{i} is {type(tensor)!r}; expected a tensor."
             )
-        specs.append((tuple(tensor.shape), tensor.dtype, tensor.device))
+        specs.append((tuple(tensor.shape), tensor.dtype))
     return tuple(specs)
 
 

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -22,6 +22,50 @@ def _as_tuple(outputs):
     return tuple(outputs)
 
 
+def _is_compiling() -> bool:
+    compiler = getattr(torch, "compiler", None)
+    is_compiling = getattr(compiler, "is_compiling", None)
+    if callable(is_compiling):
+        return is_compiling()
+
+    dynamo = getattr(torch, "_dynamo", None)
+    is_compiling = getattr(dynamo, "is_compiling", None)
+    if callable(is_compiling):
+        return is_compiling()
+
+    return False
+
+
+def _run_hop_scan(
+    core: Callable,
+    num_inputs: int,
+    num_states: int,
+    num_outputs: int,
+    *flat_args: torch.Tensor,
+):
+    from ..triton_kernel.flex_sn_inductor import eager_scan, flex_sn_scan
+
+    if eager_scan is None:
+        raise RuntimeError(
+            "FlexSN HOP backend is unavailable: eager_scan failed to import. "
+            "See logs from "
+            "spikingjelly.activation_based.triton_kernel.flex_sn_inductor."
+        )
+
+    if _is_compiling() or flex_sn_scan is None:
+        scan_impl = eager_scan
+    else:
+        scan_impl = flex_sn_scan
+
+    return scan_impl(
+        core,
+        num_inputs,
+        num_states,
+        num_outputs,
+        *flat_args,
+    )
+
+
 def _validate_scan_backend_contract(
     core: Callable,
     num_inputs: int,
@@ -230,8 +274,8 @@ class FlexSN(base.MemoryModule):
         :param step_mode: 步进模式。Triton 内核仅在 ``"m"`` 模式下可用。默认 ``"m"``。
         :type step_mode: str
 
-        :param backend: 使用的后端。``"triton"`` 仅在 ``step_mode="m"`` 时可用；``"torch"`` 始终可用。
-            默认 ``"triton"``。
+        :param backend: 使用的后端。``"triton"``、``"inductor"`` 和 ``"hop"`` 仅在
+            ``step_mode="m"`` 时可用；``"torch"`` 始终可用。默认 ``"triton"``。
         :type backend: str
 
         :param store_state_seqs: 是否保存状态序列。如果为 ``True``，用户可以通过 ``state_seqs`` 属性访问。
@@ -287,8 +331,9 @@ class FlexSN(base.MemoryModule):
             mode. Defaults to ``"m"``.
         :type step_mode: str
 
-        :param backend: backend to use. ``"triton"`` is available only when
-            ``step_mode="m"``. ``"torch"`` is always available. Defaults to ``"triton"``.
+        :param backend: backend to use. ``"triton"``, ``"inductor"``, and
+            ``"hop"`` are available only when ``step_mode="m"``. ``"torch"``
+            is always available. Defaults to ``"triton"``.
         :type backend: str
 
         :param store_state_seqs: whether to store the state sequences. If ``True``,
@@ -306,7 +351,7 @@ class FlexSN(base.MemoryModule):
         self.backend = backend
         self.store_state_seqs = store_state_seqs
 
-        if backend in ("triton", "inductor"):
+        if backend in ("triton", "inductor", "hop"):
             _validate_scan_backend_contract(
                 core, num_inputs, num_states, num_outputs, example_inputs
             )
@@ -435,7 +480,7 @@ class FlexSN(base.MemoryModule):
 
     @property
     def supported_backends(self):
-        return ("triton", "torch", "inductor")
+        return ("triton", "torch", "inductor", "hop")
 
     @property
     def store_state_seqs(self):
@@ -548,6 +593,22 @@ class FlexSN(base.MemoryModule):
                 self.state_seqs = state_seqs
             return output_seqs
 
+        elif self.backend == "hop":
+            result_seqs = _run_hop_scan(
+                self.core,
+                self.num_inputs,
+                self.num_states,
+                self.num_outputs,
+                *args,
+                *self.states,
+            )
+            output_seqs = list(result_seqs[: self.num_outputs])
+            state_seqs = list(result_seqs[self.num_outputs :])
+            self.states = [v[-1] for v in state_seqs]
+            if self.store_state_seqs:
+                self.state_seqs = state_seqs
+            return output_seqs
+
         elif self.backend == "inductor":
             _no_grad = not torch.is_grad_enabled() or not any(
                 a.requires_grad for a in (*args, *self.states)
@@ -576,19 +637,7 @@ class FlexSN(base.MemoryModule):
                 result_seqs = None
 
             if result_seqs is None:
-                from ..triton_kernel.flex_sn_inductor import eager_scan, flex_sn_scan
-
-                if eager_scan is None:
-                    raise RuntimeError(
-                        "FlexSN inductor backend is unavailable: "
-                        "eager_scan failed to import. "
-                        "See logs from spikingjelly.activation_based.triton_kernel.flex_sn_inductor."
-                    )
-                if torch.compiler.is_compiling() or flex_sn_scan is None:
-                    scan_impl = eager_scan
-                else:
-                    scan_impl = flex_sn_scan
-                result_seqs = scan_impl(
+                result_seqs = _run_hop_scan(
                     self.core,
                     self.num_inputs,
                     self.num_states,

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -15,10 +15,19 @@ except BaseException as e:
 
 try:
     from ..triton_kernel.flex_sn_inductor import eager_scan as _flexsn_eager_scan
+    from ..triton_kernel.flex_sn_inductor import (
+        eager_scan_final_state as _flexsn_eager_scan_final_state,
+    )
     from ..triton_kernel.flex_sn_inductor import flex_sn_scan as _flexsn_hop_scan
     from ..triton_kernel.flex_sn_inductor import lowerable_scan as _flexsn_lowerable_scan
     from ..triton_kernel.flex_sn_inductor import (
+        lowerable_scan_final_state as _flexsn_lowerable_scan_final_state,
+    )
+    from ..triton_kernel.flex_sn_inductor import (
         lowerable_while_loop_scan as _flexsn_lowerable_while_loop_scan,
+    )
+    from ..triton_kernel.flex_sn_inductor import (
+        lowerable_while_loop_scan_final_state as _flexsn_lowerable_while_loop_scan_final_state,
     )
     from ..triton_kernel.flex_sn_inductor import (
         lowerable_scan_available as _flexsn_lowerable_scan_available,
@@ -29,10 +38,13 @@ try:
 except BaseException as e:
     logging.info(f"spikingjelly.activation_based.neuron.flexsn: {e}")
     _flexsn_eager_scan = None
+    _flexsn_eager_scan_final_state = None
     _flexsn_hop_scan = None
     _flexsn_lowerable_scan = None
+    _flexsn_lowerable_scan_final_state = None
     _flexsn_lowerable_scan_available = None
     _flexsn_lowerable_while_loop_scan = None
+    _flexsn_lowerable_while_loop_scan_final_state = None
     _flexsn_lowerable_while_loop_available = None
 
 
@@ -87,6 +99,7 @@ def _run_hop_scan(
     num_inputs: int,
     num_states: int,
     num_outputs: int,
+    store_state_seqs: bool,
     *flat_args: torch.Tensor,
 ):
     if _flexsn_eager_scan is None:
@@ -114,11 +127,25 @@ def _run_hop_scan(
     )
 
     if use_lowerable_while_loop:
-        scan_impl = _flexsn_lowerable_while_loop_scan
+        scan_impl = (
+            _flexsn_lowerable_while_loop_scan
+            if store_state_seqs
+            else _flexsn_lowerable_while_loop_scan_final_state
+        )
     elif use_lowerable_scan:
-        scan_impl = _flexsn_lowerable_scan
+        scan_impl = (
+            _flexsn_lowerable_scan
+            if store_state_seqs
+            else _flexsn_lowerable_scan_final_state
+        )
     elif _is_compiling() or _flexsn_hop_scan is None:
-        scan_impl = _flexsn_eager_scan
+        scan_impl = (
+            _flexsn_eager_scan
+            if store_state_seqs
+            else _flexsn_eager_scan_final_state
+        )
+    elif not store_state_seqs:
+        scan_impl = _flexsn_eager_scan_final_state
     else:
         scan_impl = _flexsn_hop_scan
 
@@ -700,14 +727,18 @@ class FlexSN(base.MemoryModule):
                 self.num_inputs,
                 self.num_states,
                 self.num_outputs,
+                self.store_state_seqs,
                 *args,
                 *self.states,
             )
             output_seqs = list(result_seqs[: self.num_outputs])
-            state_seqs = list(result_seqs[self.num_outputs :])
-            self.states = [v[-1] for v in state_seqs]
+            state_results = list(result_seqs[self.num_outputs :])
             if self.store_state_seqs:
+                state_seqs = state_results
+                self.states = [v[-1] for v in state_seqs]
                 self.state_seqs = state_seqs
+            else:
+                self.states = state_results
             return output_seqs
 
         elif self.backend == "inductor":

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -144,16 +144,12 @@ def _run_hop_scan(
             if store_state_seqs
             else _flexsn_lowerable_scan_final_state
         )
-    elif _is_compiling() or _flexsn_hop_scan is None:
-        scan_impl = (
-            _flexsn_eager_scan
-            if store_state_seqs
-            else _flexsn_eager_scan_final_state
-        )
+    elif _flexsn_hop_scan is not None and store_state_seqs:
+        scan_impl = _flexsn_hop_scan
     elif not store_state_seqs:
         scan_impl = _flexsn_eager_scan_final_state
     else:
-        scan_impl = _flexsn_hop_scan
+        scan_impl = _flexsn_eager_scan
 
     return scan_impl(
         core,
@@ -509,9 +505,6 @@ class FlexSN(base.MemoryModule):
                     self._inductor_scan_kernel, self._inductor_scan_info = (
                         build_inference_kernel(core, num_inputs, num_states, num_outputs, example_inputs=example_inputs)
                     )
-                    self._inductor_scan_final_state_kernel, self._inductor_scan_final_state_info = (
-                        build_inference_final_state_kernel(core, num_inputs, num_states, num_outputs, example_inputs=example_inputs)
-                    )
                 except Exception as e:
                     logging.warning(
                         "FlexSN: could not build inductor inference kernel (%s); "
@@ -519,6 +512,15 @@ class FlexSN(base.MemoryModule):
                     )
                     self._inductor_scan_kernel = None
                     self._inductor_scan_info = None
+                try:
+                    self._inductor_scan_final_state_kernel, self._inductor_scan_final_state_info = (
+                        build_inference_final_state_kernel(core, num_inputs, num_states, num_outputs, example_inputs=example_inputs)
+                    )
+                except Exception as e:
+                    logging.warning(
+                        "FlexSN: could not build inductor inference-final-state kernel (%s); "
+                        "store_state_seqs=False inference falls back to the regular inference kernel." % e
+                    )
                     self._inductor_scan_final_state_kernel = None
                     self._inductor_scan_final_state_info = None
                 try:

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -269,10 +269,9 @@ def _empty_multistep_outputs(
             spec = output_template_specs[i]
             if len(spec) == 2:
                 shape, dtype = spec
-                device = args[0].device
             else:
-                shape, dtype, device = spec
-            return torch.empty((0, *shape), dtype=dtype, device=device)
+                shape, dtype, _ = spec
+            return torch.empty((0, *shape), dtype=dtype, device=args[0].device)
         if args:
             ref = args[0].new_empty(args[0].shape[1:])
         elif states:
@@ -311,7 +310,7 @@ def _make_output_template_specs_from_outputs(
             raise TypeError(
                 f"FlexSN example output #{i} is {type(tensor)!r}; expected a tensor."
             )
-        specs.append((tuple(tensor.shape), tensor.dtype))
+        specs.append((tuple(tensor.shape), tensor.dtype, tensor.device))
     return tuple(specs)
 
 
@@ -975,6 +974,7 @@ class FlexSN(base.MemoryModule):
                 self.states = self.init_states(self.num_states, self.step_mode, *args)
             if (
                 self.backend in ("torch", "hop")
+                and self.num_outputs > 0
                 and self._explicit_output_template_specs is None
             ):
                 raise ValueError(

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -316,6 +316,26 @@ def _make_output_template_specs_from_outputs(
     return tuple(specs)
 
 
+def _validate_scan_backend_output_template_specs(
+    output_template_specs: Optional[Tuple[Tuple, ...]],
+    example_inputs: Optional[Tuple[torch.Tensor, ...]],
+) -> None:
+    if output_template_specs is None or example_inputs is None:
+        return
+    seq_template = example_inputs[0]
+    expected_shape = tuple(seq_template.shape)
+    expected_dtype = seq_template.dtype
+    for i, spec in enumerate(output_template_specs):
+        shape, dtype = spec[:2]
+        if tuple(shape) != expected_shape or dtype != expected_dtype:
+            raise ValueError(
+                "FlexSN triton/inductor scan backends require example_outputs "
+                "to match the first example input's per-step shape and dtype "
+                f"({expected_shape}, {expected_dtype}), but example output "
+                f"#{i} is ({tuple(shape)}, {dtype})."
+            )
+
+
 def _core_requires_grad(core: Callable) -> bool:
     if isinstance(core, functools.partial):
         return (
@@ -696,6 +716,10 @@ class FlexSN(base.MemoryModule):
         self._output_template_specs = self._explicit_output_template_specs
 
         if backend in ("triton", "inductor"):
+            _validate_scan_backend_output_template_specs(
+                self._explicit_output_template_specs,
+                example_inputs,
+            )
             _validate_scan_backend_contract(
                 core, num_inputs, num_states, num_outputs, example_inputs
             )
@@ -975,8 +999,31 @@ class FlexSN(base.MemoryModule):
                 raise ValueError(f"Unsupported backend: {self.backend}")
             if self.states is None:
                 self.states = self.init_states(self.num_states, self.step_mode, *args)
+            if self.backend == "hop":
+                state_args = [state.contiguous() for state in self.states]
+                result_seqs = _run_hop_scan(
+                    self.core,
+                    self.num_inputs,
+                    self.num_states,
+                    self.num_outputs,
+                    self.store_state_seqs,
+                    *args,
+                    *state_args,
+                    output_template_specs=self._output_template_specs,
+                )
+                output_seqs = list(result_seqs[: self.num_outputs])
+                state_results = list(result_seqs[self.num_outputs :])
+                if self.store_state_seqs:
+                    self.state_seqs = state_results
+                    self.states = [
+                        _last_state_or_current(v, self.states[i])
+                        for i, v in enumerate(state_results)
+                    ]
+                else:
+                    self.states = state_results
+                return output_seqs
             if (
-                self.backend in ("torch", "hop")
+                self.backend == "torch"
                 and self.num_outputs > 0
                 and self._output_template_specs is None
             ):

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -295,16 +295,6 @@ def _empty_multistep_outputs(
     return [_empty_output(i) for i in range(num_outputs)]
 
 
-def _make_output_template_specs_from_examples(
-    num_outputs: int,
-    example_inputs: Optional[Tuple[torch.Tensor, ...]],
-) -> Optional[Tuple[Tuple, ...]]:
-    if example_inputs is None:
-        return None
-    ref = example_inputs[0]
-    return tuple((tuple(ref.shape), ref.dtype) for _ in range(num_outputs))
-
-
 def _make_output_template_specs_from_outputs(
     num_outputs: int,
     example_outputs: Optional[Tuple[torch.Tensor, ...]],
@@ -703,13 +693,7 @@ class FlexSN(base.MemoryModule):
             num_outputs,
             example_outputs,
         )
-        self._output_template_specs = (
-            self._explicit_output_template_specs
-            or _make_output_template_specs_from_examples(
-                num_outputs,
-                example_inputs,
-            )
-        )
+        self._output_template_specs = self._explicit_output_template_specs
 
         if backend in ("triton", "inductor"):
             _validate_scan_backend_contract(
@@ -778,8 +762,9 @@ class FlexSN(base.MemoryModule):
                     # several exception types; any failure here can safely fall
                     # back to the already-built regular inference path.
                     logging.warning(
-                        "FlexSN: could not build inductor inference-final-state kernel (%s); "
-                        "store_state_seqs=False inference falls back to the regular inference kernel." % e
+                        "FlexSN: could not build inductor inference-final-state kernel (%s: %s); "
+                        "store_state_seqs=False inference falls back to the regular inference kernel."
+                        % (type(e).__name__, e)
                     )
                     self._inductor_scan_final_state_kernel = None
                     self._inductor_scan_final_state_info = None
@@ -997,7 +982,6 @@ class FlexSN(base.MemoryModule):
             ):
                 raise ValueError(
                     f"FlexSN backend='{self.backend}' requires example_outputs "
-                    "or example_inputs "
                     "for empty multi-step inputs so output shapes and dtypes "
                     "match core's per-step return contract without executing core."
                 )

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -61,11 +61,12 @@ def _warmup_inductor_inference_final_state_kernel(module: "FlexSN") -> None:
     from ..triton_kernel.flexsn.wrapper import flexsn_inference_final_state
 
     info = module._inductor_scan_final_state_info
-    device = None
+    device = getattr(module, "_inductor_scan_final_state_device", None)
     if isinstance(module.core, torch.nn.Module):
-        for tensor in [*module.core.parameters(), *module.core.buffers()]:
-            device = tensor.device
-            break
+        if device is None:
+            for tensor in [*module.core.parameters(), *module.core.buffers()]:
+                device = tensor.device
+                break
     if device is None:
         device = torch.device("cuda", torch.cuda.current_device())
     seq_template = torch.zeros((1, 1), device=device)
@@ -198,6 +199,22 @@ def _empty_multistep_outputs(
         return ref.new_empty((0, *ref.shape))
 
     return [_empty_output(i) for i in range(num_outputs)]
+
+
+def _infer_empty_output_templates(
+    core: Callable,
+    args: Tuple[torch.Tensor, ...],
+    states: List[torch.Tensor],
+    num_outputs: int,
+) -> List[torch.Tensor]:
+    step_inputs = tuple(arg.new_empty(arg.shape[1:]) for arg in args)
+    with torch.no_grad():
+        results = _as_tuple(core(*step_inputs, *states))
+    if len(results) < num_outputs:
+        raise ValueError(
+            f"FlexSN core returned {len(results)} values, expected at least {num_outputs} outputs."
+        )
+    return [result.new_empty((0, *result.shape)) for result in results[:num_outputs]]
 
 
 def _core_requires_grad(core: Callable) -> bool:
@@ -525,6 +542,9 @@ class FlexSN(base.MemoryModule):
         register_flexsn_kernel_handle = None
 
         if backend == "inductor" and torch.cuda.is_available():
+            self._inductor_scan_final_state_device = (
+                example_inputs[0].device if example_inputs is not None else None
+            )
             try:
                 from ..triton_kernel.flex_sn_inductor.kernel import (
                     build_inference_kernel, build_inference_final_state_kernel, build_training_kernels,
@@ -591,6 +611,7 @@ class FlexSN(base.MemoryModule):
             self._inductor_scan_info = None
             self._inductor_scan_final_state_kernel = None
             self._inductor_scan_final_state_info = None
+            self._inductor_scan_final_state_device = None
             self._inductor_fwd_kernel = None
             self._inductor_bwd_kernel = None
             self._inductor_train_info = None
@@ -765,10 +786,17 @@ class FlexSN(base.MemoryModule):
 
     def multi_step_forward(self, *args):
         T = args[0].shape[0]
-        if T == 0:
+        if T == 0 and self.backend != "hop":
             if self.states is None:
                 self.states = self.init_states(self.num_states, self.step_mode, *args)
-            output_seqs = _empty_multistep_outputs(args, self.states, self.num_outputs)
+            if self.backend == "torch":
+                output_seqs = _infer_empty_output_templates(
+                    self.core, args, self.states, self.num_outputs
+                )
+            else:
+                output_seqs = _empty_multistep_outputs(
+                    args, self.states, self.num_outputs
+                )
             if self.store_state_seqs:
                 self.state_seqs = [
                     s.new_empty((0, *s.shape)) for s in self.states

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -173,9 +173,19 @@ def _run_hop_scan(
             "spikingjelly.activation_based.triton_kernel.flex_sn_inductor."
         )
 
+    lowerable_while_loop_impl = (
+        _flexsn_lowerable_while_loop_scan
+        if store_state_seqs
+        else _flexsn_lowerable_while_loop_scan_final_state
+    )
+    lowerable_scan_impl = (
+        _flexsn_lowerable_scan
+        if store_state_seqs
+        else _flexsn_lowerable_scan_final_state
+    )
     use_lowerable_while_loop = (
         is_compiling
-        and _flexsn_lowerable_while_loop_scan is not None
+        and lowerable_while_loop_impl is not None
         and callable(_flexsn_lowerable_while_loop_available)
         and _flexsn_lowerable_while_loop_available()
         and (not torch.is_grad_enabled())
@@ -183,7 +193,7 @@ def _run_hop_scan(
     )
     use_lowerable_scan = (
         is_compiling
-        and _flexsn_lowerable_scan is not None
+        and lowerable_scan_impl is not None
         and callable(_flexsn_lowerable_scan_available)
         and _flexsn_lowerable_scan_available()
         and (not torch.is_grad_enabled())
@@ -191,17 +201,9 @@ def _run_hop_scan(
     )
 
     if use_lowerable_while_loop:
-        scan_impl = (
-            _flexsn_lowerable_while_loop_scan
-            if store_state_seqs
-            else _flexsn_lowerable_while_loop_scan_final_state
-        )
+        scan_impl = lowerable_while_loop_impl
     elif use_lowerable_scan:
-        scan_impl = (
-            _flexsn_lowerable_scan
-            if store_state_seqs
-            else _flexsn_lowerable_scan_final_state
-        )
+        scan_impl = lowerable_scan_impl
     elif (
         _flexsn_hop_scan is not None
         and store_state_seqs
@@ -218,6 +220,8 @@ def _run_hop_scan(
         scan_impl = _flexsn_eager_scan_final_state
     else:
         scan_impl = _flexsn_eager_scan
+    if scan_impl is None:
+        raise RuntimeError("FlexSN HOP backend has no available scan implementation.")
 
     return scan_impl(
         core,
@@ -265,25 +269,16 @@ def _empty_multistep_outputs(
     return [_empty_output(i) for i in range(num_outputs)]
 
 
-def _make_output_template_specs(
-    core: Callable,
+def _make_output_template_specs_from_examples(
     num_outputs: int,
     example_inputs: Optional[Tuple[torch.Tensor, ...]],
 ) -> Optional[Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]]:
     if example_inputs is None:
         return None
-    with torch.no_grad():
-        results = _as_tuple(core(*tuple(x.detach().clone() for x in example_inputs)))
-    if len(results) < num_outputs:
-        raise ValueError(
-            f"FlexSN core returned {len(results)} values, expected at least "
-            f"{num_outputs} outputs."
-        )
     specs = []
-    for result in results[:num_outputs]:
-        if not isinstance(result, torch.Tensor):
-            return None
-        specs.append((tuple(result.shape), result.dtype))
+    for i in range(num_outputs):
+        ref = example_inputs[i] if i < len(example_inputs) else example_inputs[0]
+        specs.append((tuple(ref.shape), ref.dtype))
     return tuple(specs)
 
 
@@ -626,8 +621,7 @@ class FlexSN(base.MemoryModule):
                 num_inputs + num_states,
             )
         )
-        self._output_template_specs = _make_output_template_specs(
-            core,
+        self._output_template_specs = _make_output_template_specs_from_examples(
             num_outputs,
             example_inputs,
         )
@@ -975,16 +969,17 @@ class FlexSN(base.MemoryModule):
 
         elif self.backend == "inductor":
             result_has_state_seqs = self.store_state_seqs
+            can_elide_zero_states = (
+                self.states is None and _can_elide_zero_state_inputs(self)
+            )
+            if self.states is None and not can_elide_zero_states:
+                self.states = self.init_states(self.num_states, self.step_mode, *args)
             _no_grad = not torch.is_grad_enabled() or (
                 not _value_requires_grad(args)
                 and not _value_requires_grad(self.states)
                 and not _core_requires_grad(self.core)
             )
-            use_implicit_zero_states = (
-                self.states is None and _no_grad and _can_elide_zero_state_inputs(self)
-            )
-            if self.states is None and not use_implicit_zero_states:
-                self.states = self.init_states(self.num_states, self.step_mode, *args)
+            use_implicit_zero_states = can_elide_zero_states and _no_grad
             state_args = [] if use_implicit_zero_states else list(self.states)
             flat_args = [*args, *state_args]
             all_cuda = len(flat_args) > 0 and all(t.is_cuda for t in flat_args)

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -108,6 +108,15 @@ def _run_hop_scan(
     )
 
 
+def _can_elide_zero_state_inputs(module: "FlexSN") -> bool:
+    return (
+        module.backend == "inductor"
+        and module._inductor_handle is not None
+        and module._memories_rv.get("states") is None
+        and module.__class__.init_states is FlexSN.init_states
+    )
+
+
 def _validate_scan_backend_contract(
     core: Callable,
     num_inputs: int,
@@ -653,9 +662,16 @@ class FlexSN(base.MemoryModule):
 
         elif self.backend == "inductor":
             _no_grad = not torch.is_grad_enabled() or not any(
-                a.requires_grad for a in (*args, *self.states)
+                a.requires_grad for a in (
+                    *args,
+                    *([] if self.states is None else self.states),
+                )
             )
-            flat_args = [*args, *self.states]
+            use_implicit_zero_states = (
+                self.states is None and _no_grad and _can_elide_zero_state_inputs(self)
+            )
+            state_args = [] if use_implicit_zero_states else list(self.states)
+            flat_args = [*args, *state_args]
             all_cuda = len(flat_args) > 0 and all(t.is_cuda for t in flat_args)
             same_device = len({t.device for t in flat_args}) == 1
             if self._inductor_handle is not None and all_cuda and same_device:
@@ -679,6 +695,8 @@ class FlexSN(base.MemoryModule):
                 result_seqs = None
 
             if result_seqs is None:
+                if self.states is None:
+                    self.states = self.init_states(self.num_states, self.step_mode, *args)
                 result_seqs = _run_hop_scan(
                     self.core,
                     self.num_inputs,
@@ -698,7 +716,8 @@ class FlexSN(base.MemoryModule):
             raise ValueError(f"Unsupported backend: {self.backend}")
 
     def forward(self, *args):
-        if self.states is None:
+        can_elide = _can_elide_zero_state_inputs(self) and not torch.is_grad_enabled()
+        if self.states is None and not can_elide:
             self.states = self.init_states(self.num_states, self.step_mode, *args)
         output = super().forward(*args)
         return output[0] if len(output) == 1 else output

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -295,6 +295,13 @@ def _core_requires_grad(core: Callable) -> bool:
             if tensor.requires_grad:
                 return True
 
+    if callable(core) and not hasattr(core, "__code__"):
+        core_dict = getattr(core, "__dict__", None)
+        if core_dict is not None:
+            for value in core_dict.values():
+                if _value_requires_grad(value):
+                    return True
+
     closure = getattr(core, "__closure__", None)
     if closure is None:
         return False
@@ -930,6 +937,8 @@ class FlexSN(base.MemoryModule):
             return [torch.stack(y, dim=0) for y in output_seqs]
 
         elif self.backend == "triton":
+            if self.states is None:
+                self.states = self.init_states(self.num_states, self.step_mode, *args)
             result_seqs = self.kernel(*args, *self.states)
             output_seqs = result_seqs[: self.num_outputs]
             state_seqs = result_seqs[self.num_outputs :]

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -229,7 +229,7 @@ def _run_hop_scan(
 
     template_kwargs = (
         {}
-        if output_template_specs is None or scan_impl is _flexsn_hop_scan
+        if output_template_specs is None
         else {"output_template_specs": output_template_specs}
     )
     return scan_impl(

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -813,9 +813,11 @@ class FlexSN(base.MemoryModule):
                 )
             output_seqs = list(result_seqs[: self.num_outputs])
             state_seqs = list(result_seqs[self.num_outputs :])
-            self.states = [v[-1] for v in state_seqs]
             if self.store_state_seqs:
+                self.states = [v[-1] for v in state_seqs]
                 self.state_seqs = state_seqs
+            else:
+                self.states = state_seqs
             return output_seqs
 
         else:

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -795,6 +795,7 @@ class FlexSN(base.MemoryModule):
                     self.num_inputs,
                     self.num_states,
                     self.num_outputs,
+                    self.store_state_seqs,
                     *args,
                     *self.states,
                 )

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -61,7 +61,14 @@ def _warmup_inductor_inference_final_state_kernel(module: "FlexSN") -> None:
     from ..triton_kernel.flexsn.wrapper import flexsn_inference_final_state
 
     info = module._inductor_scan_final_state_info
-    seq_template = torch.zeros((1, 1), device="cuda")
+    device = None
+    if isinstance(module.core, torch.nn.Module):
+        for tensor in [*module.core.parameters(), *module.core.buffers()]:
+            device = tensor.device
+            break
+    if device is None:
+        device = torch.device("cuda", torch.cuda.current_device())
+    seq_template = torch.zeros((1, 1), device=device)
     state_template = seq_template[0].clone()
     warm_args = [seq_template.clone() for _ in range(info.num_inputs)]
     warm_args.extend(state_template.clone() for _ in range(info.num_states))
@@ -174,6 +181,23 @@ def _last_state_or_current(
     current_state: torch.Tensor,
 ) -> torch.Tensor:
     return current_state if state_seq.shape[0] == 0 else state_seq[-1]
+
+
+def _empty_multistep_outputs(
+    args: Tuple[torch.Tensor, ...],
+    states: List[torch.Tensor],
+    num_outputs: int,
+) -> List[torch.Tensor]:
+    def _empty_output(i: int) -> torch.Tensor:
+        if i < len(states):
+            ref = states[i]
+        elif states:
+            ref = states[-1]
+        else:
+            ref = args[0].new_empty(args[0].shape[1:])
+        return ref.new_empty((0, *ref.shape))
+
+    return [_empty_output(i) for i in range(num_outputs)]
 
 
 def _core_requires_grad(core: Callable) -> bool:
@@ -740,25 +764,18 @@ class FlexSN(base.MemoryModule):
         return results[: self.num_outputs]
 
     def multi_step_forward(self, *args):
+        T = args[0].shape[0]
+        if T == 0:
+            if self.states is None:
+                self.states = self.init_states(self.num_states, self.step_mode, *args)
+            output_seqs = _empty_multistep_outputs(args, self.states, self.num_outputs)
+            if self.store_state_seqs:
+                self.state_seqs = [
+                    s.new_empty((0, *s.shape)) for s in self.states
+                ]
+            return output_seqs
+
         if self.backend == "torch":
-            T = args[0].shape[0]
-            if T == 0:
-                def _empty_output(i: int) -> torch.Tensor:
-                    if i < len(self.states):
-                        ref = self.states[i]
-                    elif self.states:
-                        ref = self.states[-1]
-                    else:
-                        ref = args[0].new_empty(args[0].shape[1:])
-                    return ref.new_empty((0, *ref.shape))
-
-                output_seqs = [_empty_output(i) for i in range(self.num_outputs)]
-                if self.store_state_seqs:
-                    self.state_seqs = [
-                        s.new_empty((0, *s.shape)) for s in self.states
-                    ]
-                return output_seqs
-
             output_seqs = [[] for _ in range(self.num_outputs)]
             if self.store_state_seqs:
                 state_seqs = [[] for _ in range(self.num_states)]

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -1,4 +1,5 @@
 import copy
+import os
 from typing import Callable, Optional, Tuple, List
 import logging
 
@@ -17,7 +18,13 @@ try:
     from ..triton_kernel.flex_sn_inductor import flex_sn_scan as _flexsn_hop_scan
     from ..triton_kernel.flex_sn_inductor import lowerable_scan as _flexsn_lowerable_scan
     from ..triton_kernel.flex_sn_inductor import (
+        lowerable_while_loop_scan as _flexsn_lowerable_while_loop_scan,
+    )
+    from ..triton_kernel.flex_sn_inductor import (
         lowerable_scan_available as _flexsn_lowerable_scan_available,
+    )
+    from ..triton_kernel.flex_sn_inductor import (
+        lowerable_while_loop_available as _flexsn_lowerable_while_loop_available,
     )
 except BaseException as e:
     logging.info(f"spikingjelly.activation_based.neuron.flexsn: {e}")
@@ -25,6 +32,8 @@ except BaseException as e:
     _flexsn_hop_scan = None
     _flexsn_lowerable_scan = None
     _flexsn_lowerable_scan_available = None
+    _flexsn_lowerable_while_loop_scan = None
+    _flexsn_lowerable_while_loop_available = None
 
 
 __all__ = ["FlexSNKernel", "FlexSN"]
@@ -64,15 +73,26 @@ def _run_hop_scan(
             "spikingjelly.activation_based.triton_kernel.flex_sn_inductor."
         )
 
+    use_lowerable_while_loop = (
+        _is_compiling()
+        and _flexsn_lowerable_while_loop_scan is not None
+        and callable(_flexsn_lowerable_while_loop_available)
+        and _flexsn_lowerable_while_loop_available()
+        and (not torch.is_grad_enabled())
+        and os.getenv("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP", "0") == "1"
+    )
     use_lowerable_scan = (
         _is_compiling()
         and _flexsn_lowerable_scan is not None
         and callable(_flexsn_lowerable_scan_available)
         and _flexsn_lowerable_scan_available()
         and (not torch.is_grad_enabled())
+        and os.getenv("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_SCAN", "0") == "1"
     )
 
-    if use_lowerable_scan:
+    if use_lowerable_while_loop:
+        scan_impl = _flexsn_lowerable_while_loop_scan
+    elif use_lowerable_scan:
         scan_impl = _flexsn_lowerable_scan
     elif _is_compiling() or _flexsn_hop_scan is None:
         scan_impl = _flexsn_eager_scan

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -634,9 +634,9 @@ class FlexSN(base.MemoryModule):
         register_flexsn_kernel_handle = None
 
         if backend == "inductor" and torch.cuda.is_available():
-            self._inductor_scan_final_state_device = None
-            if example_inputs is not None and example_inputs[0].device.type == "cuda":
-                self._inductor_scan_final_state_device = example_inputs[0].device
+            self._inductor_scan_final_state_device = torch.device(
+                "cuda", torch.cuda.current_device()
+            )
             try:
                 from ..triton_kernel.flex_sn_inductor.kernel import (
                     build_inference_kernel, build_inference_final_state_kernel, build_training_kernels,

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -760,6 +760,7 @@ class FlexSN(base.MemoryModule):
                     flexsn_inductor_inference,
                     flexsn_inductor_inference_final_state,
                     flexsn_inductor_training,
+                    flexsn_inductor_training_final_state,
                 )
 
                 if _no_grad and self._inductor_inference_available:
@@ -778,6 +779,17 @@ class FlexSN(base.MemoryModule):
                             self._inductor_handle, flat_args
                         )
                 elif (not _no_grad) and self._inductor_training_available:
+                    if not self.store_state_seqs:
+                        result_seqs = flexsn_inductor_training_final_state(
+                            self._inductor_handle, flat_args
+                        )
+                        output_seqs = list(result_seqs[: self.num_outputs])
+                        self.states = list(
+                            result_seqs[
+                                self.num_outputs : self.num_outputs + self.num_states
+                            ]
+                        )
+                        return output_seqs
                     result_seqs = flexsn_inductor_training(
                         self._inductor_handle, flat_args
                     )

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -62,11 +62,14 @@ def _warmup_inductor_inference_final_state_kernel(module: "FlexSN") -> None:
 
     info = module._inductor_scan_final_state_info
     device = getattr(module, "_inductor_scan_final_state_device", None)
+    if device is not None and device.type != "cuda":
+        device = None
     if isinstance(module.core, torch.nn.Module):
         if device is None:
             for tensor in [*module.core.parameters(), *module.core.buffers()]:
-                device = tensor.device
-                break
+                if tensor.device.type == "cuda":
+                    device = tensor.device
+                    break
     if device is None:
         device = torch.device("cuda", torch.cuda.current_device())
     seq_template = torch.zeros((1, 1), device=device)
@@ -546,9 +549,9 @@ class FlexSN(base.MemoryModule):
         register_flexsn_kernel_handle = None
 
         if backend == "inductor" and torch.cuda.is_available():
-            self._inductor_scan_final_state_device = (
-                example_inputs[0].device if example_inputs is not None else None
-            )
+            self._inductor_scan_final_state_device = None
+            if example_inputs is not None and example_inputs[0].device.type == "cuda":
+                self._inductor_scan_final_state_device = example_inputs[0].device
             try:
                 from ..triton_kernel.flex_sn_inductor.kernel import (
                     build_inference_kernel, build_inference_final_state_kernel, build_training_kernels,

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -173,6 +173,13 @@ def _can_elide_zero_state_inputs(module: "FlexSN") -> bool:
     )
 
 
+def _last_state_or_current(
+    state_seq: torch.Tensor,
+    current_state: torch.Tensor,
+) -> torch.Tensor:
+    return current_state if state_seq.shape[0] == 0 else state_seq[-1]
+
+
 def _validate_scan_backend_contract(
     core: Callable,
     num_inputs: int,
@@ -458,7 +465,7 @@ class FlexSN(base.MemoryModule):
         self.backend = backend
         self.store_state_seqs = store_state_seqs
 
-        if backend in ("triton", "inductor", "hop"):
+        if backend in ("triton", "inductor"):
             _validate_scan_backend_contract(
                 core, num_inputs, num_states, num_outputs, example_inputs
             )
@@ -741,7 +748,10 @@ class FlexSN(base.MemoryModule):
             result_seqs = self.kernel(*args, *self.states)
             output_seqs = result_seqs[: self.num_outputs]
             state_seqs = result_seqs[self.num_outputs :]
-            self.states = [v[-1] for v in state_seqs]
+            self.states = [
+                _last_state_or_current(v, self.states[i])
+                for i, v in enumerate(state_seqs)
+            ]
             if self.store_state_seqs:
                 self.state_seqs = state_seqs
             return output_seqs
@@ -760,7 +770,10 @@ class FlexSN(base.MemoryModule):
             state_results = list(result_seqs[self.num_outputs :])
             if self.store_state_seqs:
                 state_seqs = state_results
-                self.states = [v[-1] for v in state_seqs]
+                self.states = [
+                    _last_state_or_current(v, self.states[i])
+                    for i, v in enumerate(state_seqs)
+                ]
                 self.state_seqs = state_seqs
             else:
                 self.states = state_results
@@ -842,7 +855,12 @@ class FlexSN(base.MemoryModule):
             output_seqs = list(result_seqs[: self.num_outputs])
             state_seqs = list(result_seqs[self.num_outputs :])
             if result_has_state_seqs:
-                self.states = [v[-1] for v in state_seqs]
+                if self.states is None:
+                    self.states = self.init_states(self.num_states, self.step_mode, *args)
+                self.states = [
+                    _last_state_or_current(v, self.states[i])
+                    for i, v in enumerate(state_seqs)
+                ]
                 if self.store_state_seqs:
                     self.state_seqs = state_seqs
             else:

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -39,6 +39,29 @@ except BaseException as e:
 __all__ = ["FlexSNKernel", "FlexSN"]
 
 
+def _warmup_inductor_inference_final_state_kernel(module: "FlexSN") -> None:
+    if (
+        module._inductor_scan_final_state_kernel is None
+        or module._inductor_scan_final_state_info is None
+    ):
+        return
+
+    from ..triton_kernel.flexsn.wrapper import flexsn_inference_final_state
+
+    info = module._inductor_scan_final_state_info
+    seq_template = torch.zeros((1, 1), device="cuda")
+    state_template = seq_template[0].clone()
+    warm_args = [seq_template.clone() for _ in range(info.num_inputs)]
+    warm_args.extend(state_template.clone() for _ in range(info.num_states))
+
+    with torch.no_grad():
+        flexsn_inference_final_state(
+            module._inductor_scan_final_state_kernel,
+            info,
+            *warm_args,
+        )
+
+
 def _as_tuple(outputs):
     if isinstance(outputs, torch.Tensor):
         return (outputs,)
@@ -418,7 +441,7 @@ class FlexSN(base.MemoryModule):
         if backend == "inductor" and torch.cuda.is_available():
             try:
                 from ..triton_kernel.flex_sn_inductor.kernel import (
-                    build_inference_kernel, build_training_kernels,
+                    build_inference_kernel, build_inference_final_state_kernel, build_training_kernels,
                 )
                 from ..triton_kernel.flex_sn_inductor.custom_ops import (
                     attach_flexsn_handle_finalizer,
@@ -430,6 +453,7 @@ class FlexSN(base.MemoryModule):
                     "falling back to eager_scan/flex_sn_scan for all paths." % e
                 )
                 build_inference_kernel = None
+                build_inference_final_state_kernel = None
                 build_training_kernels = None
                 attach_flexsn_handle_finalizer = None
                 register_flexsn_kernel_handle = None
@@ -438,6 +462,9 @@ class FlexSN(base.MemoryModule):
                     self._inductor_scan_kernel, self._inductor_scan_info = (
                         build_inference_kernel(core, num_inputs, num_states, num_outputs, example_inputs=example_inputs)
                     )
+                    self._inductor_scan_final_state_kernel, self._inductor_scan_final_state_info = (
+                        build_inference_final_state_kernel(core, num_inputs, num_states, num_outputs, example_inputs=example_inputs)
+                    )
                 except Exception as e:
                     logging.warning(
                         "FlexSN: could not build inductor inference kernel (%s); "
@@ -445,6 +472,8 @@ class FlexSN(base.MemoryModule):
                     )
                     self._inductor_scan_kernel = None
                     self._inductor_scan_info = None
+                    self._inductor_scan_final_state_kernel = None
+                    self._inductor_scan_final_state_info = None
                 try:
                     self._inductor_fwd_kernel, self._inductor_bwd_kernel, self._inductor_train_info = (
                         build_training_kernels(core, num_inputs, num_states, num_outputs, example_inputs=example_inputs)
@@ -460,12 +489,16 @@ class FlexSN(base.MemoryModule):
             else:
                 self._inductor_scan_kernel = None
                 self._inductor_scan_info = None
+                self._inductor_scan_final_state_kernel = None
+                self._inductor_scan_final_state_info = None
                 self._inductor_fwd_kernel = None
                 self._inductor_bwd_kernel = None
                 self._inductor_train_info = None
         else:
             self._inductor_scan_kernel = None
             self._inductor_scan_info = None
+            self._inductor_scan_final_state_kernel = None
+            self._inductor_scan_final_state_info = None
             self._inductor_fwd_kernel = None
             self._inductor_bwd_kernel = None
             self._inductor_train_info = None
@@ -473,6 +506,10 @@ class FlexSN(base.MemoryModule):
         self._inductor_inference_available = (
             self._inductor_scan_kernel is not None
             and self._inductor_scan_info is not None
+        )
+        self._inductor_inference_final_state_available = (
+            self._inductor_scan_final_state_kernel is not None
+            and self._inductor_scan_final_state_info is not None
         )
         self._inductor_training_available = (
             self._inductor_fwd_kernel is not None
@@ -487,6 +524,8 @@ class FlexSN(base.MemoryModule):
             self._inductor_handle = register_flexsn_kernel_handle(
                 inference_kernel=self._inductor_scan_kernel,
                 inference_info=self._inductor_scan_info,
+                inference_final_state_kernel=self._inductor_scan_final_state_kernel,
+                inference_final_state_info=self._inductor_scan_final_state_info,
                 forward_kernel=self._inductor_fwd_kernel,
                 backward_kernel=self._inductor_bwd_kernel,
                 training_info=self._inductor_train_info,
@@ -494,6 +533,17 @@ class FlexSN(base.MemoryModule):
             self._inductor_handle_finalizer = attach_flexsn_handle_finalizer(
                 self, self._inductor_handle
             )
+            if self._inductor_inference_final_state_available:
+                try:
+                    _warmup_inductor_inference_final_state_kernel(self)
+                except Exception as e:
+                    logging.warning(
+                        "FlexSN: could not warm up inductor inference-final-state kernel (%s); "
+                        "falling back to the regular inference kernel for store_state_seqs=False." % e
+                    )
+                    self._inductor_scan_final_state_kernel = None
+                    self._inductor_scan_final_state_info = None
+                    self._inductor_inference_final_state_available = False
         else:
             self._inductor_handle_finalizer = None
 
@@ -677,13 +727,25 @@ class FlexSN(base.MemoryModule):
             if self._inductor_handle is not None and all_cuda and same_device:
                 from ..triton_kernel.flex_sn_inductor.custom_ops import (
                     flexsn_inductor_inference,
+                    flexsn_inductor_inference_final_state,
                     flexsn_inductor_training,
                 )
 
                 if _no_grad and self._inductor_inference_available:
-                    result_seqs = flexsn_inductor_inference(
-                        self._inductor_handle, flat_args
-                    )
+                    if (
+                        not self.store_state_seqs
+                        and self._inductor_inference_final_state_available
+                    ):
+                        result_seqs = flexsn_inductor_inference_final_state(
+                            self._inductor_handle, flat_args
+                        )
+                        output_seqs = list(result_seqs[: self.num_outputs])
+                        self.states = list(result_seqs[self.num_outputs :])
+                        return output_seqs
+                    else:
+                        result_seqs = flexsn_inductor_inference(
+                            self._inductor_handle, flat_args
+                        )
                 elif (not _no_grad) and self._inductor_training_available:
                     result_seqs = flexsn_inductor_training(
                         self._inductor_handle, flat_args

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -469,6 +469,13 @@ class FlexSN(base.MemoryModule):
             _validate_scan_backend_contract(
                 core, num_inputs, num_states, num_outputs, example_inputs
             )
+        elif backend == "hop":
+            if num_inputs + num_states == 0:
+                raise ValueError("FlexSN requires at least one input or state tensor.")
+            if num_inputs == 0:
+                raise ValueError(
+                    "FlexSN HOP backend requires at least one input sequence to derive T."
+                )
 
         if backend == "triton":
             self.kernel = FlexSNKernel(

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -526,6 +526,10 @@ class FlexSN(base.MemoryModule):
                 core, num_inputs, num_states, num_outputs, example_inputs
             )
         elif backend == "hop":
+            if _flexsn_eager_scan is None:
+                raise ImportError(
+                    "FlexSN backend='hop' is unavailable: missing _flexsn_eager_scan."
+                )
             if num_inputs + num_states == 0:
                 raise ValueError("FlexSN requires at least one input or state tensor.")
             if num_inputs == 0:
@@ -834,6 +838,7 @@ class FlexSN(base.MemoryModule):
             return output_seqs
 
         elif self.backend == "hop":
+            state_args = [state.contiguous() for state in self.states]
             result_seqs = _run_hop_scan(
                 self.core,
                 self.num_inputs,
@@ -841,7 +846,7 @@ class FlexSN(base.MemoryModule):
                 self.num_outputs,
                 self.store_state_seqs,
                 *args,
-                *self.states,
+                *state_args,
             )
             output_seqs = list(result_seqs[: self.num_outputs])
             state_results = list(result_seqs[self.num_outputs :])
@@ -916,6 +921,7 @@ class FlexSN(base.MemoryModule):
             if result_seqs is None:
                 if self.states is None:
                     self.states = self.init_states(self.num_states, self.step_mode, *args)
+                state_args = [state.contiguous() for state in self.states]
                 result_seqs = _run_hop_scan(
                     self.core,
                     self.num_inputs,
@@ -923,7 +929,7 @@ class FlexSN(base.MemoryModule):
                     self.num_outputs,
                     self.store_state_seqs,
                     *args,
-                    *self.states,
+                    *state_args,
                 )
                 result_has_state_seqs = self.store_state_seqs
             output_seqs = list(result_seqs[: self.num_outputs])

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -34,6 +34,9 @@ try:
         lowerable_scan_available as _flexsn_lowerable_scan_available,
     )
     from ..triton_kernel.flex_sn_inductor import (
+        dynamo_hop_available as _flexsn_dynamo_hop_available,
+    )
+    from ..triton_kernel.flex_sn_inductor import (
         lowerable_while_loop_available as _flexsn_lowerable_while_loop_available,
     )
 except (ImportError, AttributeError) as e:
@@ -44,6 +47,7 @@ except (ImportError, AttributeError) as e:
     _flexsn_lowerable_scan = None
     _flexsn_lowerable_scan_final_state = None
     _flexsn_lowerable_scan_available = None
+    _flexsn_dynamo_hop_available = None
     _flexsn_lowerable_while_loop_scan = None
     _flexsn_lowerable_while_loop_scan_final_state = None
     _flexsn_lowerable_while_loop_available = None
@@ -153,6 +157,7 @@ def _run_hop_scan(
     enable_lowerable_scan = (
         os.environ.get("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_SCAN", "0") == "1"
     )
+    is_compiling = _is_compiling()
     if _flexsn_eager_scan is None:
         raise RuntimeError(
             "FlexSN HOP backend is unavailable: eager_scan failed to import. "
@@ -161,7 +166,7 @@ def _run_hop_scan(
         )
 
     use_lowerable_while_loop = (
-        _is_compiling()
+        is_compiling
         and _flexsn_lowerable_while_loop_scan is not None
         and callable(_flexsn_lowerable_while_loop_available)
         and _flexsn_lowerable_while_loop_available()
@@ -169,7 +174,7 @@ def _run_hop_scan(
         and enable_lowerable_while_loop
     )
     use_lowerable_scan = (
-        _is_compiling()
+        is_compiling
         and _flexsn_lowerable_scan is not None
         and callable(_flexsn_lowerable_scan_available)
         and _flexsn_lowerable_scan_available()
@@ -189,7 +194,17 @@ def _run_hop_scan(
             if store_state_seqs
             else _flexsn_lowerable_scan_final_state
         )
-    elif _flexsn_hop_scan is not None and store_state_seqs:
+    elif (
+        _flexsn_hop_scan is not None
+        and store_state_seqs
+        and (
+            not is_compiling
+            or (
+                callable(_flexsn_dynamo_hop_available)
+                and _flexsn_dynamo_hop_available()
+            )
+        )
+    ):
         scan_impl = _flexsn_hop_scan
     elif not store_state_seqs:
         scan_impl = _flexsn_eager_scan_final_state
@@ -732,8 +747,10 @@ class FlexSN(base.MemoryModule):
                     _warmup_inductor_inference_final_state_kernel(self)
                 except Exception as e:
                     logging.warning(
-                        "FlexSN: could not warm up inductor inference-final-state kernel (%s); "
-                        "falling back to the regular inference kernel for store_state_seqs=False." % e
+                        "FlexSN: could not warm up inductor inference-final-state "
+                        "kernel (%s: %s); falling back to the regular inference "
+                        "kernel for store_state_seqs=False."
+                        % (type(e).__name__, e)
                     )
                     self._inductor_scan_final_state_kernel = None
                     self._inductor_scan_final_state_info = None

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -166,6 +166,9 @@ def _run_hop_scan(
         os.environ.get("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_SCAN", "0") == "1"
     )
     is_compiling = _is_compiling()
+    # flex_sn_inductor imports HOP helpers as an all-or-none group and sets all
+    # of them to None on failure, so _flexsn_eager_scan is the availability
+    # sentinel for this backend family.
     if _flexsn_eager_scan is None:
         raise RuntimeError(
             "FlexSN HOP backend is unavailable: eager_scan failed to import. "
@@ -956,14 +959,19 @@ class FlexSN(base.MemoryModule):
 
     def multi_step_forward(self, *args):
         T = args[0].shape[0]
-        if T == 0 and self.backend != "hop":
+        if T == 0:
+            if self.backend not in self.supported_backends:
+                raise ValueError(f"Unsupported backend: {self.backend}")
             if self.states is None:
                 self.states = self.init_states(self.num_states, self.step_mode, *args)
-            if self.backend == "torch" and self._explicit_output_template_specs is None:
+            if (
+                self.backend in ("torch", "hop")
+                and self._explicit_output_template_specs is None
+            ):
                 raise ValueError(
-                    "FlexSN backend='torch' requires example_outputs for empty "
-                    "multi-step inputs so output shapes and dtypes match core's "
-                    "per-step return contract without executing core."
+                    f"FlexSN backend='{self.backend}' requires example_outputs "
+                    "for empty multi-step inputs so output shapes and dtypes "
+                    "match core's per-step return contract without executing core."
                 )
             output_seqs = _empty_multistep_outputs(
                 args, self.states, self.num_outputs, self._output_template_specs

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -15,10 +15,16 @@ except BaseException as e:
 try:
     from ..triton_kernel.flex_sn_inductor import eager_scan as _flexsn_eager_scan
     from ..triton_kernel.flex_sn_inductor import flex_sn_scan as _flexsn_hop_scan
+    from ..triton_kernel.flex_sn_inductor import lowerable_scan as _flexsn_lowerable_scan
+    from ..triton_kernel.flex_sn_inductor import (
+        lowerable_scan_available as _flexsn_lowerable_scan_available,
+    )
 except BaseException as e:
     logging.info(f"spikingjelly.activation_based.neuron.flexsn: {e}")
     _flexsn_eager_scan = None
     _flexsn_hop_scan = None
+    _flexsn_lowerable_scan = None
+    _flexsn_lowerable_scan_available = None
 
 
 __all__ = ["FlexSNKernel", "FlexSN"]
@@ -58,7 +64,17 @@ def _run_hop_scan(
             "spikingjelly.activation_based.triton_kernel.flex_sn_inductor."
         )
 
-    if _is_compiling() or _flexsn_hop_scan is None:
+    use_lowerable_scan = (
+        _is_compiling()
+        and _flexsn_lowerable_scan is not None
+        and callable(_flexsn_lowerable_scan_available)
+        and _flexsn_lowerable_scan_available()
+        and (not torch.is_grad_enabled())
+    )
+
+    if use_lowerable_scan:
+        scan_impl = _flexsn_lowerable_scan
+    elif _is_compiling() or _flexsn_hop_scan is None:
         scan_impl = _flexsn_eager_scan
     else:
         scan_impl = _flexsn_hop_scan

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -263,6 +263,8 @@ def _empty_multistep_outputs(
     states: List[torch.Tensor],
     num_outputs: int,
     output_template_specs: Optional[Tuple[Tuple, ...]] = None,
+    *,
+    use_template_device: bool = True,
 ) -> List[torch.Tensor]:
     def _empty_output(i: int) -> torch.Tensor:
         if output_template_specs is not None and i < len(output_template_specs):
@@ -271,7 +273,8 @@ def _empty_multistep_outputs(
                 shape, dtype = spec
                 device = args[0].device
             else:
-                shape, dtype, device = spec
+                shape, dtype, template_device = spec
+                device = template_device if use_template_device else args[0].device
             return torch.empty((0, *shape), dtype=dtype, device=device)
         if args:
             ref = args[0].new_empty(args[0].shape[1:])
@@ -978,15 +981,20 @@ class FlexSN(base.MemoryModule):
             if (
                 self.backend in ("torch", "hop")
                 and self.num_outputs > 0
-                and self._explicit_output_template_specs is None
+                and self._output_template_specs is None
             ):
                 raise ValueError(
                     f"FlexSN backend='{self.backend}' requires example_outputs "
+                    "or example_inputs "
                     "for empty multi-step inputs so output shapes and dtypes "
                     "match core's per-step return contract without executing core."
                 )
             output_seqs = _empty_multistep_outputs(
-                args, self.states, self.num_outputs, self._output_template_specs
+                args,
+                self.states,
+                self.num_outputs,
+                self._output_template_specs,
+                use_template_device=False,
             )
             if self.store_state_seqs:
                 self.state_seqs = [

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -1,4 +1,5 @@
 import copy
+import functools
 import os
 from typing import Callable, Optional, Tuple, List
 import logging
@@ -221,6 +222,13 @@ def _infer_empty_output_templates(
 
 
 def _core_requires_grad(core: Callable) -> bool:
+    if isinstance(core, functools.partial):
+        return (
+            _core_requires_grad(core.func)
+            or _value_requires_grad(core.args)
+            or _value_requires_grad(core.keywords)
+        )
+
     if isinstance(core, torch.nn.Module):
         for tensor in [*core.parameters(), *core.buffers()]:
             if tensor.requires_grad:
@@ -234,8 +242,31 @@ def _core_requires_grad(core: Callable) -> bool:
             cell_value = cell.cell_contents
         except ValueError:
             continue
-        if isinstance(cell_value, torch.Tensor) and cell_value.requires_grad:
+        if _value_requires_grad(cell_value):
             return True
+    return False
+
+
+def _value_requires_grad(value) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, torch.Tensor):
+        return value.requires_grad
+    if isinstance(value, torch.nn.Module):
+        return any(
+            tensor.requires_grad
+            for tensor in [*value.parameters(), *value.buffers()]
+        )
+    if isinstance(value, functools.partial):
+        return (
+            _core_requires_grad(value.func)
+            or _value_requires_grad(value.args)
+            or _value_requires_grad(value.keywords)
+        )
+    if isinstance(value, dict):
+        return any(_value_requires_grad(v) for v in value.values())
+    if isinstance(value, (tuple, list)):
+        return any(_value_requires_grad(v) for v in value)
     return False
 
 
@@ -866,7 +897,11 @@ class FlexSN(base.MemoryModule):
 
         elif self.backend == "inductor":
             result_has_state_seqs = self.store_state_seqs
-            _no_grad = not torch.is_grad_enabled()
+            _no_grad = not torch.is_grad_enabled() or (
+                not _value_requires_grad(args)
+                and not _value_requires_grad(self.states)
+                and not _core_requires_grad(self.core)
+            )
             use_implicit_zero_states = (
                 self.states is None and _no_grad and _can_elide_zero_state_inputs(self)
             )
@@ -957,7 +992,13 @@ class FlexSN(base.MemoryModule):
         can_elide = (
             self.step_mode == "m"
             and _can_elide_zero_state_inputs(self)
-            and not torch.is_grad_enabled()
+            and (
+                not torch.is_grad_enabled()
+                or (
+                    not _value_requires_grad(args)
+                    and not _core_requires_grad(self.core)
+                )
+            )
         )
         if self.states is None and not can_elide:
             self.states = self.init_states(self.num_states, self.step_mode, *args)

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -269,26 +269,6 @@ def _empty_multistep_outputs(
     return [_empty_output(i) for i in range(num_outputs)]
 
 
-def _make_output_template_specs_from_core(
-    core: Callable,
-    args: Tuple[torch.Tensor, ...],
-    states: List[torch.Tensor],
-    num_outputs: int,
-    num_states: int,
-) -> Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]:
-    step_inputs = tuple(arg.new_empty(arg.shape[1:]) for arg in args)
-    state_inputs = [state.clone() for state in states]
-    with torch.no_grad():
-        returns = _as_tuple(core(*step_inputs, *state_inputs))
-    expected = num_outputs + num_states
-    if len(returns) != expected:
-        raise ValueError(
-            f"FlexSN core returned {len(returns)} values, but expected "
-            f"{expected} (= num_outputs + num_states)."
-        )
-    return tuple((tuple(t.shape), t.dtype) for t in returns[:num_outputs])
-
-
 def _make_output_template_specs_from_examples(
     num_outputs: int,
     example_inputs: Optional[Tuple[torch.Tensor, ...]],
@@ -309,6 +289,10 @@ def _core_requires_grad(core: Callable) -> bool:
             or _value_requires_grad(core.args)
             or _value_requires_grad(core.keywords)
         )
+
+    bound_self = getattr(core, "__self__", None)
+    if bound_self is not None and _value_requires_grad(bound_self):
+        return True
 
     if isinstance(core, torch.nn.Module):
         for tensor in [*core.parameters(), *core.buffers()]:
@@ -927,18 +911,8 @@ class FlexSN(base.MemoryModule):
         if T == 0 and self.backend != "hop":
             if self.states is None:
                 self.states = self.init_states(self.num_states, self.step_mode, *args)
-            output_template_specs = self._output_template_specs
-            if self.backend == "torch":
-                output_template_specs = _make_output_template_specs_from_core(
-                    self.core,
-                    args,
-                    self.states,
-                    self.num_outputs,
-                    self.num_states,
-                )
-                self._output_template_specs = output_template_specs
             output_seqs = _empty_multistep_outputs(
-                args, self.states, self.num_outputs, output_template_specs
+                args, self.states, self.num_outputs, self._output_template_specs
             )
             if self.store_state_seqs:
                 self.state_seqs = [

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -176,6 +176,25 @@ def _last_state_or_current(
     return current_state if state_seq.shape[0] == 0 else state_seq[-1]
 
 
+def _core_requires_grad(core: Callable) -> bool:
+    if isinstance(core, torch.nn.Module):
+        for tensor in [*core.parameters(), *core.buffers()]:
+            if tensor.requires_grad:
+                return True
+
+    closure = getattr(core, "__closure__", None)
+    if closure is None:
+        return False
+    for cell in closure:
+        try:
+            cell_value = cell.cell_contents
+        except ValueError:
+            continue
+        if isinstance(cell_value, torch.Tensor) and cell_value.requires_grad:
+            return True
+    return False
+
+
 def _validate_scan_backend_contract(
     core: Callable,
     num_inputs: int,
@@ -790,11 +809,14 @@ class FlexSN(base.MemoryModule):
 
         elif self.backend == "inductor":
             result_has_state_seqs = self.store_state_seqs
-            _no_grad = not torch.is_grad_enabled() or not any(
-                a.requires_grad for a in (
-                    *args,
-                    *([] if self.states is None else self.states),
+            _no_grad = (not torch.is_grad_enabled()) and not (
+                any(
+                    a.requires_grad for a in (
+                        *args,
+                        *([] if self.states is None else self.states),
+                    )
                 )
+                or _core_requires_grad(self.core)
             )
             use_implicit_zero_states = (
                 self.states is None and _no_grad and _can_elide_zero_state_inputs(self)
@@ -880,7 +902,11 @@ class FlexSN(base.MemoryModule):
             raise ValueError(f"Unsupported backend: {self.backend}")
 
     def forward(self, *args):
-        can_elide = _can_elide_zero_state_inputs(self) and not torch.is_grad_enabled()
+        can_elide = (
+            self.step_mode == "m"
+            and _can_elide_zero_state_inputs(self)
+            and not torch.is_grad_enabled()
+        )
         if self.states is None and not can_elide:
             self.states = self.init_states(self.num_states, self.step_mode, *args)
         output = super().forward(*args)

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -587,7 +587,11 @@ class FlexSN(base.MemoryModule):
         if (
             backend == "inductor"
             and register_flexsn_kernel_handle is not None
-            and (self._inductor_inference_available or self._inductor_training_available)
+            and (
+                self._inductor_inference_available
+                or self._inductor_inference_final_state_available
+                or self._inductor_training_available
+            )
         ):
             self._inductor_handle = register_flexsn_kernel_handle(
                 inference_kernel=self._inductor_scan_kernel,
@@ -821,6 +825,8 @@ class FlexSN(base.MemoryModule):
             use_implicit_zero_states = (
                 self.states is None and _no_grad and _can_elide_zero_state_inputs(self)
             )
+            if self.states is None and not use_implicit_zero_states:
+                self.states = self.init_states(self.num_states, self.step_mode, *args)
             state_args = [] if use_implicit_zero_states else list(self.states)
             flat_args = [*args, *state_args]
             all_cuda = len(flat_args) > 0 and all(t.is_cuda for t in flat_args)

--- a/spikingjelly/activation_based/triton_kernel/compress.py
+++ b/spikingjelly/activation_based/triton_kernel/compress.py
@@ -108,7 +108,7 @@ def bit_spike_compress(s_seq):
 def bit_spike_decompress(s_seq_compressed, shape):
     # s_seq: uint8, ndim=1
     n_compressed_elements = s_seq_compressed.numel()
-    n_decompressed_elements = shape.numel()
+    n_decompressed_elements = torch.Size(shape).numel()
     s_seq_decompressed = torch.zeros(
         n_decompressed_elements, dtype=torch.uint8, device=s_seq_compressed.device
     )

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
@@ -5,6 +5,8 @@ try:
         eager_scan,
         lowerable_scan,
         lowerable_scan_available,
+        lowerable_while_loop_scan,
+        lowerable_while_loop_available,
     )
 except BaseException as e:
     import logging
@@ -15,3 +17,5 @@ except BaseException as e:
     eager_scan = None
     lowerable_scan = None
     lowerable_scan_available = None
+    lowerable_while_loop_scan = None
+    lowerable_while_loop_available = None

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
@@ -1,5 +1,11 @@
 try:
-    from .hop import flex_sn_scan, FlexSNScan, eager_scan
+    from .hop import (
+        flex_sn_scan,
+        FlexSNScan,
+        eager_scan,
+        lowerable_scan,
+        lowerable_scan_available,
+    )
 except BaseException as e:
     import logging
 
@@ -7,3 +13,5 @@ except BaseException as e:
     flex_sn_scan = None
     FlexSNScan = None
     eager_scan = None
+    lowerable_scan = None
+    lowerable_scan_available = None

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
@@ -12,7 +12,7 @@ try:
         lowerable_while_loop_scan_final_state,
         lowerable_while_loop_available,
     )
-except BaseException as e:
+except (ImportError, AttributeError) as e:
     import logging
 
     logging.info(f"spikingjelly.activation_based.triton_kernel.flex_sn_inductor: {e}")

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
@@ -12,7 +12,7 @@ try:
         lowerable_while_loop_scan_final_state,
         lowerable_while_loop_available,
     )
-except (ImportError, AttributeError) as e:
+except Exception as e:
     import logging
 
     logging.info(f"spikingjelly.activation_based.triton_kernel.flex_sn_inductor: {e}")

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
@@ -3,9 +3,12 @@ try:
         flex_sn_scan,
         FlexSNScan,
         eager_scan,
+        eager_scan_final_state,
         lowerable_scan,
+        lowerable_scan_final_state,
         lowerable_scan_available,
         lowerable_while_loop_scan,
+        lowerable_while_loop_scan_final_state,
         lowerable_while_loop_available,
     )
 except BaseException as e:
@@ -15,7 +18,10 @@ except BaseException as e:
     flex_sn_scan = None
     FlexSNScan = None
     eager_scan = None
+    eager_scan_final_state = None
     lowerable_scan = None
+    lowerable_scan_final_state = None
     lowerable_scan_available = None
     lowerable_while_loop_scan = None
+    lowerable_while_loop_scan_final_state = None
     lowerable_while_loop_available = None

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
@@ -12,7 +12,7 @@ try:
         lowerable_while_loop_scan_final_state,
         lowerable_while_loop_available,
     )
-except Exception as e:
+except (ImportError, ModuleNotFoundError, AttributeError) as e:
     import logging
 
     logging.info(f"spikingjelly.activation_based.triton_kernel.flex_sn_inductor: {e}")

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
@@ -7,6 +7,7 @@ try:
         lowerable_scan,
         lowerable_scan_final_state,
         lowerable_scan_available,
+        dynamo_hop_available,
         lowerable_while_loop_scan,
         lowerable_while_loop_scan_final_state,
         lowerable_while_loop_available,
@@ -22,6 +23,7 @@ except BaseException as e:
     lowerable_scan = None
     lowerable_scan_final_state = None
     lowerable_scan_available = None
+    dynamo_hop_available = None
     lowerable_while_loop_scan = None
     lowerable_while_loop_scan_final_state = None
     lowerable_while_loop_available = None

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -288,7 +288,7 @@ def _flexsn_inductor_training_final_state_impl(
     )
     init_states = list(args[info.num_inputs : info.num_inputs + info.num_states])
     final_states = [
-        init_states[i] if state_seq.shape[0] == 0 else state_seq[-1]
+        (init_states[i] if state_seq.shape[0] == 0 else state_seq[-1]).clone()
         for i, state_seq in enumerate(state_seqs)
     ]
     extra_saved_tensors = [full_returns[i] for i in _final_state_saved_return_indices(info)]

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -23,7 +23,12 @@ import weakref
 
 import torch
 
-from ..flexsn.wrapper import flexsn_backward, flexsn_forward, flexsn_inference
+from ..flexsn.wrapper import (
+    flexsn_backward,
+    flexsn_forward,
+    flexsn_inference,
+    flexsn_inference_final_state,
+)
 from ..flexsn.info import FlexSNInfo
 
 
@@ -31,6 +36,8 @@ from ..flexsn.info import FlexSNInfo
 class FlexSNKernelHandle:
     inference_kernel: object | None
     inference_info: FlexSNInfo | None
+    inference_final_state_kernel: object | None
+    inference_final_state_info: FlexSNInfo | None
     forward_kernel: object | None
     backward_kernel: object | None
     training_info: FlexSNInfo | None
@@ -47,6 +54,8 @@ def register_flexsn_kernel_handle(
     *,
     inference_kernel,
     inference_info,
+    inference_final_state_kernel,
+    inference_final_state_info,
     forward_kernel,
     backward_kernel,
     training_info,
@@ -56,6 +65,8 @@ def register_flexsn_kernel_handle(
         _KERNEL_REGISTRY[handle] = FlexSNKernelHandle(
             inference_kernel=inference_kernel,
             inference_info=inference_info,
+            inference_final_state_kernel=inference_final_state_kernel,
+            inference_final_state_info=inference_final_state_info,
             forward_kernel=forward_kernel,
             backward_kernel=backward_kernel,
             training_info=training_info,
@@ -74,6 +85,7 @@ def unregister_flexsn_kernel_handle(handle: int) -> None:
 def _cleanup_kernel_handle(bundle: FlexSNKernelHandle) -> None:
     for obj in (
         bundle.inference_kernel,
+        bundle.inference_final_state_kernel,
         bundle.forward_kernel,
         bundle.backward_kernel,
     ):
@@ -83,6 +95,13 @@ def _cleanup_kernel_handle(bundle: FlexSNKernelHandle) -> None:
 
 
 def _lookup_kernel_handle(handle: int) -> FlexSNKernelHandle:
+    if not isinstance(handle, int):
+        try:
+            handle = int(handle)
+        except Exception as exc:
+            raise TypeError(
+                f"Unsupported FlexSN kernel handle type: {type(handle)!r}"
+            ) from exc
     try:
         return _KERNEL_REGISTRY[handle]
     except KeyError as e:
@@ -187,6 +206,21 @@ def _flexsn_inductor_inference_impl(
         )
 
 
+def _flexsn_inductor_inference_final_state_impl(
+    bundle: FlexSNKernelHandle, flat_args: list[torch.Tensor]
+) -> list[torch.Tensor]:
+    args = _materialize_zero_state_args(bundle.inference_final_state_info, flat_args)
+    args = [arg.contiguous() for arg in args]
+    with _device_guard(args):
+        return list(
+            flexsn_inference_final_state(
+                bundle.inference_final_state_kernel,
+                bundle.inference_final_state_info,
+                *args,
+            )
+        )
+
+
 def _flexsn_inductor_training_impl(
     bundle: FlexSNKernelHandle, flat_args: list[torch.Tensor]
 ) -> list[torch.Tensor]:
@@ -228,6 +262,17 @@ def flexsn_inductor_inference(handle: int, flat_args: list[torch.Tensor]) -> lis
     return _flexsn_inductor_inference_impl(bundle, flat_args)
 
 
+@torch.library.custom_op("sj::flexsn_inductor_inference_final_state", mutates_args=())
+def flexsn_inductor_inference_final_state(handle: int, flat_args: list[torch.Tensor]) -> list[torch.Tensor]:
+    bundle = _lookup_kernel_handle(handle)
+    if (
+        bundle.inference_final_state_kernel is None
+        or bundle.inference_final_state_info is None
+    ):
+        raise RuntimeError("FlexSN inference-final-state kernel is unavailable for this handle.")
+    return _flexsn_inductor_inference_final_state_impl(bundle, flat_args)
+
+
 @torch.library.register_fake("sj::flexsn_inductor_inference")
 def _flexsn_inductor_inference_fake(
     handle: int, flat_args: list[torch.Tensor]
@@ -240,6 +285,31 @@ def _flexsn_inductor_inference_fake(
         flat_args,
         bundle.inference_info.num_outputs + bundle.inference_info.num_states,
     )
+
+
+@torch.library.register_fake("sj::flexsn_inductor_inference_final_state")
+def _flexsn_inductor_inference_final_state_fake(
+    handle: int, flat_args: list[torch.Tensor]
+) -> list[torch.Tensor]:
+    bundle = _lookup_kernel_handle(handle)
+    if bundle.inference_final_state_info is None:
+        raise RuntimeError(
+            "FlexSN inference-final-state metadata is unavailable for this handle."
+        )
+    seq_outputs = _make_seq_outputs_like(
+        bundle.inference_final_state_info,
+        flat_args,
+        bundle.inference_final_state_info.num_outputs,
+    )
+    if flat_args:
+        state_template = flat_args[0][0]
+    else:
+        raise ValueError("Expected at least one input tensor for FlexSN fake inference.")
+    final_states = [
+        state_template.new_empty(state_template.shape)
+        for _ in range(bundle.inference_final_state_info.num_states)
+    ]
+    return [*seq_outputs, *final_states]
 
 
 @torch.library.custom_op("sj::flexsn_inductor_training", mutates_args=())

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -183,6 +183,15 @@ def _device_guard(tensors: list[torch.Tensor]):
     return contextlib.nullcontext()
 
 
+def _visible_fwd_return_count(info: FlexSNInfo) -> int:
+    return info.num_outputs + info.num_states
+
+
+def _extra_saved_return_indices(info: FlexSNInfo) -> list[int]:
+    visible = _visible_fwd_return_count(info)
+    return [idx for idx in info.c2k_return_mapping if idx >= visible]
+
+
 def _materialize_zero_state_args(
     info: FlexSNInfo, flat_args: list[torch.Tensor]
 ) -> list[torch.Tensor]:
@@ -256,8 +265,10 @@ def _flexsn_inductor_training_final_state_impl(
         full_returns[info.num_outputs : info.num_outputs + info.num_states]
     )
     final_states = [state_seq[-1] for state_seq in state_seqs]
-    saved_tensors = [full_returns[i] for i in info.c2k_return_mapping]
-    return [*visible_outputs, *final_states, *saved_tensors]
+    extra_saved_tensors = [
+        full_returns[i] for i in _extra_saved_return_indices(info)
+    ]
+    return [*visible_outputs, *final_states, *extra_saved_tensors]
 
 
 def _flexsn_inductor_backward_impl(
@@ -396,12 +407,12 @@ def _flexsn_inductor_training_final_state_fake(
         state_template.new_empty(state_template.shape)
         for _ in range(bundle.training_info.num_states)
     ]
-    saved_tensors = _make_seq_outputs_like(
+    extra_saved_tensors = _make_seq_outputs_like(
         bundle.training_info,
         flat_args,
-        len(bundle.training_info.c2k_return_mapping),
+        len(_extra_saved_return_indices(bundle.training_info)),
     )
-    return [*seq_outputs, *final_states, *saved_tensors]
+    return [*seq_outputs, *final_states, *extra_saved_tensors]
 
 
 @torch.library.custom_op("sj::flexsn_inductor_backward", mutates_args=())
@@ -482,7 +493,15 @@ def _flexsn_training_final_state_setup_context(ctx, inputs, output):
     seq_shape, seq_dtype, seq_device = ctx.input_template_specs[0]
     ctx.state_seq_template_spec = (seq_shape, seq_dtype, seq_device)
     visible = bundle.training_info.num_outputs + bundle.training_info.num_states
-    ctx.save_for_backward(*list(output[visible:]))
+    extra_saved = list(output[visible:])
+    extra_saved_iter = iter(extra_saved)
+    saved = []
+    for idx in bundle.training_info.c2k_return_mapping:
+        if idx < visible:
+            saved.append(output[idx])
+        else:
+            saved.append(next(extra_saved_iter))
+    ctx.save_for_backward(*saved)
 
 
 def _flexsn_training_backward(ctx, grad_out: list[torch.Tensor | None]):

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -155,10 +155,28 @@ def _device_guard(tensors: list[torch.Tensor]):
     return contextlib.nullcontext()
 
 
+def _materialize_zero_state_args(
+    info: FlexSNInfo, flat_args: list[torch.Tensor]
+) -> list[torch.Tensor]:
+    if len(flat_args) == info.num_inputs:
+        # In the common reset-before-forward path, FlexSN initial states are
+        # zero tensors matching the per-step input shape. Materialize them
+        # inside the opaque custom op so compile graphs do not need explicit
+        # ``zeros_like`` nodes in front of every neuron layer.
+        if info.num_inputs == 0:
+            raise ValueError("FlexSN custom ops require at least one input sequence.")
+        seq0 = flat_args[0]
+        state_template = seq0[0]
+        zero_states = [torch.zeros_like(state_template) for _ in range(info.num_states)]
+        return [*flat_args, *zero_states]
+    return flat_args
+
+
 def _flexsn_inductor_inference_impl(
     bundle: FlexSNKernelHandle, flat_args: list[torch.Tensor]
 ) -> list[torch.Tensor]:
-    args = [arg.contiguous() for arg in flat_args]
+    args = _materialize_zero_state_args(bundle.inference_info, flat_args)
+    args = [arg.contiguous() for arg in args]
     with _device_guard(args):
         return list(
             flexsn_inference(
@@ -172,7 +190,8 @@ def _flexsn_inductor_inference_impl(
 def _flexsn_inductor_training_impl(
     bundle: FlexSNKernelHandle, flat_args: list[torch.Tensor]
 ) -> list[torch.Tensor]:
-    args = [arg.contiguous() for arg in flat_args]
+    args = _materialize_zero_state_args(bundle.training_info, flat_args)
+    args = [arg.contiguous() for arg in args]
     with _device_guard(args):
         return list(
             flexsn_forward(
@@ -272,6 +291,11 @@ def _flexsn_inductor_backward_fake(
     bundle = _lookup_kernel_handle(handle)
     if bundle.training_info is None:
         raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
+    if len(input_templates) == bundle.training_info.num_inputs:
+        return [
+            input_templates[i].new_empty(input_templates[i].shape)
+            for i in range(bundle.training_info.num_inputs)
+        ]
     seq_grads = [
         input_templates[i].new_empty(input_templates[i].shape)
         for i in range(bundle.training_info.num_inputs)
@@ -331,6 +355,8 @@ def _flexsn_training_backward(ctx, grad_out: list[torch.Tensor | None]):
                 input_templates,
             )
         )
+        if len(grads) != len(ctx.input_template_specs):
+            grads = grads[: len(ctx.input_template_specs)]
     finally:
         release_active_flexsn_kernel_handle(ctx.handle)
     return None, grads

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -203,8 +203,9 @@ def _materialize_zero_state_args(
         if info.num_inputs == 0:
             raise ValueError("FlexSN custom ops require at least one input sequence.")
         seq0 = flat_args[0]
-        state_template = seq0[0]
-        zero_states = [torch.zeros_like(state_template) for _ in range(info.num_states)]
+        zero_states = [
+            seq0.new_zeros(seq0.shape[1:]) for _ in range(info.num_states)
+        ]
         return [*flat_args, *zero_states]
     return flat_args
 

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import contextlib
 from dataclasses import dataclass
+from typing import Dict, List, Optional
 from itertools import count
 from threading import Lock
 import weakref
@@ -34,18 +35,18 @@ from ..flexsn.info import FlexSNInfo
 
 @dataclass
 class FlexSNKernelHandle:
-    inference_kernel: object | None
-    inference_info: FlexSNInfo | None
-    inference_final_state_kernel: object | None
-    inference_final_state_info: FlexSNInfo | None
-    forward_kernel: object | None
-    backward_kernel: object | None
-    training_info: FlexSNInfo | None
+    inference_kernel: Optional[object]
+    inference_info: Optional[FlexSNInfo]
+    inference_final_state_kernel: Optional[object]
+    inference_final_state_info: Optional[FlexSNInfo]
+    forward_kernel: Optional[object]
+    backward_kernel: Optional[object]
+    training_info: Optional[FlexSNInfo]
     owner_refs: int = 1
     active_refs: int = 0
 
 
-_KERNEL_REGISTRY: dict[int, FlexSNKernelHandle] = {}
+_KERNEL_REGISTRY: Dict[int, FlexSNKernelHandle] = {}
 _KERNEL_REGISTRY_LOCK = Lock()
 _KERNEL_ID_GEN = count(1)
 
@@ -156,8 +157,8 @@ def release_active_flexsn_kernel_handle(handle: int) -> None:
 
 
 def _make_seq_outputs_like(
-    info: FlexSNInfo, flat_args: list[torch.Tensor], n: int
-) -> list[torch.Tensor]:
+    info: FlexSNInfo, flat_args: List[torch.Tensor], n: int
+) -> List[torch.Tensor]:
     if not flat_args:
         raise ValueError("Expected at least one FlexSN argument tensor.")
     # The underlying FlexSN Triton wrappers allocate all sequence outputs with
@@ -185,8 +186,8 @@ def _grad_or_zeros(grad_out, index: int, spec):
 
 
 def _make_state_templates_like(
-    info: FlexSNInfo, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
+    info: FlexSNInfo, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
     if not flat_args:
         raise ValueError("Expected at least one input tensor for FlexSN fake op.")
     explicit_states = flat_args[info.num_inputs: info.num_inputs + info.num_states]
@@ -203,7 +204,7 @@ def _make_state_templates_like(
     ]
 
 
-def _device_guard(tensors: list[torch.Tensor]):
+def _device_guard(tensors: List[torch.Tensor]):
     for tensor in tensors:
         if isinstance(tensor, torch.Tensor) and tensor.is_cuda:
             return torch.cuda.device(tensor.device)
@@ -214,18 +215,18 @@ def _visible_fwd_return_count(info: FlexSNInfo) -> int:
     return info.num_outputs + info.num_states
 
 
-def _extra_saved_return_indices(info: FlexSNInfo) -> list[int]:
+def _extra_saved_return_indices(info: FlexSNInfo) -> List[int]:
     visible = _visible_fwd_return_count(info)
     return [idx for idx in info.c2k_return_mapping if idx >= visible]
 
 
-def _final_state_saved_return_indices(info: FlexSNInfo) -> list[int]:
+def _final_state_saved_return_indices(info: FlexSNInfo) -> List[int]:
     return [idx for idx in info.c2k_return_mapping if idx >= info.num_outputs]
 
 
 def _materialize_zero_state_args(
-    info: FlexSNInfo, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
+    info: FlexSNInfo, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
     if len(flat_args) == info.num_inputs:
         # In the common reset-before-forward path, FlexSN initial states are
         # zero tensors matching the per-step input shape. Materialize them
@@ -242,8 +243,8 @@ def _materialize_zero_state_args(
 
 
 def _flexsn_inductor_inference_impl(
-    bundle: FlexSNKernelHandle, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
+    bundle: FlexSNKernelHandle, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
     args = _materialize_zero_state_args(bundle.inference_info, flat_args)
     args = [arg.contiguous() for arg in args]
     with _device_guard(args):
@@ -257,8 +258,8 @@ def _flexsn_inductor_inference_impl(
 
 
 def _flexsn_inductor_inference_final_state_impl(
-    bundle: FlexSNKernelHandle, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
+    bundle: FlexSNKernelHandle, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
     args = _materialize_zero_state_args(bundle.inference_final_state_info, flat_args)
     args = [arg.contiguous() for arg in args]
     with _device_guard(args):
@@ -272,8 +273,8 @@ def _flexsn_inductor_inference_final_state_impl(
 
 
 def _flexsn_inductor_training_impl(
-    bundle: FlexSNKernelHandle, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
+    bundle: FlexSNKernelHandle, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
     args = _materialize_zero_state_args(bundle.training_info, flat_args)
     args = [arg.contiguous() for arg in args]
     with _device_guard(args):
@@ -287,8 +288,8 @@ def _flexsn_inductor_training_impl(
 
 
 def _flexsn_inductor_training_final_state_impl(
-    bundle: FlexSNKernelHandle, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
+    bundle: FlexSNKernelHandle, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
     full_returns = _flexsn_inductor_training_impl(bundle, flat_args)
     info = bundle.training_info
     assert info is not None
@@ -308,9 +309,9 @@ def _flexsn_inductor_training_final_state_impl(
 
 def _flexsn_inductor_backward_impl(
     bundle: FlexSNKernelHandle,
-    grad_outputs: list[torch.Tensor],
-    saved_tensors: list[torch.Tensor],
-) -> list[torch.Tensor]:
+    grad_outputs: List[torch.Tensor],
+    saved_tensors: List[torch.Tensor],
+) -> List[torch.Tensor]:
     grads = [grad.contiguous() for grad in grad_outputs]
     saved = [tensor.contiguous() for tensor in saved_tensors]
     with _device_guard([*grads, *saved]):
@@ -325,7 +326,7 @@ def _flexsn_inductor_backward_impl(
 
 
 @torch.library.custom_op("sj::flexsn_inductor_inference", mutates_args=())
-def flexsn_inductor_inference(handle: int, flat_args: list[torch.Tensor]) -> list[torch.Tensor]:
+def flexsn_inductor_inference(handle: int, flat_args: List[torch.Tensor]) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if bundle.inference_kernel is None or bundle.inference_info is None:
         raise RuntimeError("FlexSN inference kernel is unavailable for this handle.")
@@ -333,7 +334,7 @@ def flexsn_inductor_inference(handle: int, flat_args: list[torch.Tensor]) -> lis
 
 
 @torch.library.custom_op("sj::flexsn_inductor_inference_final_state", mutates_args=())
-def flexsn_inductor_inference_final_state(handle: int, flat_args: list[torch.Tensor]) -> list[torch.Tensor]:
+def flexsn_inductor_inference_final_state(handle: int, flat_args: List[torch.Tensor]) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if (
         bundle.inference_final_state_kernel is None
@@ -345,8 +346,8 @@ def flexsn_inductor_inference_final_state(handle: int, flat_args: list[torch.Ten
 
 @torch.library.register_fake("sj::flexsn_inductor_inference")
 def _flexsn_inductor_inference_fake(
-    handle: int, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
+    handle: int, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if bundle.inference_info is None:
         raise RuntimeError("FlexSN inference metadata is unavailable for this handle.")
@@ -359,8 +360,8 @@ def _flexsn_inductor_inference_fake(
 
 @torch.library.register_fake("sj::flexsn_inductor_inference_final_state")
 def _flexsn_inductor_inference_final_state_fake(
-    handle: int, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
+    handle: int, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if bundle.inference_final_state_info is None:
         raise RuntimeError(
@@ -378,7 +379,7 @@ def _flexsn_inductor_inference_final_state_fake(
 
 
 @torch.library.custom_op("sj::flexsn_inductor_training", mutates_args=())
-def flexsn_inductor_training(handle: int, flat_args: list[torch.Tensor]) -> list[torch.Tensor]:
+def flexsn_inductor_training(handle: int, flat_args: List[torch.Tensor]) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if (
         bundle.forward_kernel is None
@@ -391,8 +392,8 @@ def flexsn_inductor_training(handle: int, flat_args: list[torch.Tensor]) -> list
 
 @torch.library.custom_op("sj::flexsn_inductor_training_final_state", mutates_args=())
 def flexsn_inductor_training_final_state(
-    handle: int, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
+    handle: int, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if (
         bundle.forward_kernel is None
@@ -405,8 +406,8 @@ def flexsn_inductor_training_final_state(
 
 @torch.library.register_fake("sj::flexsn_inductor_training")
 def _flexsn_inductor_training_fake(
-    handle: int, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
+    handle: int, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if bundle.training_info is None:
         raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
@@ -419,8 +420,8 @@ def _flexsn_inductor_training_fake(
 
 @torch.library.register_fake("sj::flexsn_inductor_training_final_state")
 def _flexsn_inductor_training_final_state_fake(
-    handle: int, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
+    handle: int, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if bundle.training_info is None:
         raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
@@ -441,10 +442,10 @@ def _flexsn_inductor_training_final_state_fake(
 @torch.library.custom_op("sj::flexsn_inductor_backward", mutates_args=())
 def flexsn_inductor_backward(
     handle: int,
-    grad_outputs: list[torch.Tensor],
-    saved_tensors: list[torch.Tensor],
-    input_templates: list[torch.Tensor],
-) -> list[torch.Tensor]:
+    grad_outputs: List[torch.Tensor],
+    saved_tensors: List[torch.Tensor],
+    input_templates: List[torch.Tensor],
+) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if bundle.backward_kernel is None or bundle.training_info is None:
         raise RuntimeError("FlexSN backward kernel is unavailable for this handle.")
@@ -454,10 +455,10 @@ def flexsn_inductor_backward(
 @torch.library.register_fake("sj::flexsn_inductor_backward")
 def _flexsn_inductor_backward_fake(
     handle: int,
-    grad_outputs: list[torch.Tensor],
-    saved_tensors: list[torch.Tensor],
-    input_templates: list[torch.Tensor],
-) -> list[torch.Tensor]:
+    grad_outputs: List[torch.Tensor],
+    saved_tensors: List[torch.Tensor],
+    input_templates: List[torch.Tensor],
+) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if bundle.training_info is None:
         raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
@@ -530,7 +531,7 @@ def _flexsn_training_final_state_setup_context(ctx, inputs, output):
     ctx.save_for_backward(*saved)
 
 
-def _flexsn_training_backward(ctx, grad_out: list[torch.Tensor | None]):
+def _flexsn_training_backward(ctx, grad_out: List[Optional[torch.Tensor]]):
     bundle = _lookup_kernel_handle(ctx.handle)
     if bundle.backward_kernel is None or bundle.training_info is None:
         raise RuntimeError("FlexSN backward kernel is unavailable for this handle.")
@@ -559,7 +560,7 @@ def _flexsn_training_backward(ctx, grad_out: list[torch.Tensor | None]):
     return None, grads
 
 
-def _flexsn_training_final_state_backward(ctx, grad_out: list[torch.Tensor | None]):
+def _flexsn_training_final_state_backward(ctx, grad_out: List[Optional[torch.Tensor]]):
     bundle = _lookup_kernel_handle(ctx.handle)
     if bundle.backward_kernel is None or bundle.training_info is None:
         raise RuntimeError("FlexSN backward kernel is unavailable for this handle.")

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -176,6 +176,22 @@ def _materialize_template(spec):
     return torch.empty((), dtype=dtype, device=device).expand(shape)
 
 
+def _make_state_templates_like(
+    flat_args: list[torch.Tensor], num_states: int
+) -> list[torch.Tensor]:
+    if not flat_args:
+        raise ValueError("Expected at least one input tensor for FlexSN fake op.")
+    seq_template = flat_args[0]
+    if seq_template.dim() == 0:
+        state_shape = ()
+    else:
+        state_shape = tuple(seq_template.shape[1:])
+    return [
+        seq_template.new_empty(state_shape)
+        for _ in range(num_states)
+    ]
+
+
 def _device_guard(tensors: list[torch.Tensor]):
     for tensor in tensors:
         if isinstance(tensor, torch.Tensor) and tensor.is_cuda:
@@ -265,11 +281,16 @@ def _flexsn_inductor_training_final_state_impl(
     full_returns = _flexsn_inductor_training_impl(bundle, flat_args)
     info = bundle.training_info
     assert info is not None
+    args = _materialize_zero_state_args(info, flat_args)
     visible_outputs = list(full_returns[: info.num_outputs])
     state_seqs = list(
         full_returns[info.num_outputs : info.num_outputs + info.num_states]
     )
-    final_states = [state_seq[-1] for state_seq in state_seqs]
+    init_states = list(args[info.num_inputs : info.num_inputs + info.num_states])
+    final_states = [
+        init_states[i] if state_seq.shape[0] == 0 else state_seq[-1]
+        for i, state_seq in enumerate(state_seqs)
+    ]
     extra_saved_tensors = [full_returns[i] for i in _final_state_saved_return_indices(info)]
     return [*visible_outputs, *final_states, *extra_saved_tensors]
 
@@ -339,14 +360,9 @@ def _flexsn_inductor_inference_final_state_fake(
         flat_args,
         bundle.inference_final_state_info.num_outputs,
     )
-    if flat_args:
-        state_template = flat_args[0][0]
-    else:
-        raise ValueError("Expected at least one input tensor for FlexSN fake inference.")
-    final_states = [
-        state_template.new_empty(state_template.shape)
-        for _ in range(bundle.inference_final_state_info.num_states)
-    ]
+    final_states = _make_state_templates_like(
+        flat_args, bundle.inference_final_state_info.num_states
+    )
     return [*seq_outputs, *final_states]
 
 
@@ -402,14 +418,9 @@ def _flexsn_inductor_training_final_state_fake(
         flat_args,
         bundle.training_info.num_outputs,
     )
-    if flat_args:
-        state_template = flat_args[0][0]
-    else:
-        raise ValueError("Expected at least one input tensor for FlexSN fake training.")
-    final_states = [
-        state_template.new_empty(state_template.shape)
-        for _ in range(bundle.training_info.num_states)
-    ]
+    final_states = _make_state_templates_like(
+        flat_args, bundle.training_info.num_states
+    )
     extra_saved_tensors = _make_seq_outputs_like(
         bundle.training_info,
         flat_args,
@@ -574,7 +585,7 @@ def _flexsn_training_final_state_backward(ctx, grad_out: list[torch.Tensor | Non
             dtype=state_seq_dtype,
             device=state_seq_device,
         )
-        if final_grad is not None:
+        if final_grad is not None and state_seq_shape[0] > 0:
             seq_grad[-1].copy_(final_grad)
         state_grads.append(seq_grad)
 

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -441,11 +441,6 @@ def _flexsn_inductor_backward_fake(
     bundle = _lookup_kernel_handle(handle)
     if bundle.training_info is None:
         raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
-    if len(input_templates) == bundle.training_info.num_inputs:
-        return [
-            input_templates[i].new_empty(input_templates[i].shape)
-            for i in range(bundle.training_info.num_inputs)
-        ]
     seq_grads = [
         input_templates[i].new_empty(input_templates[i].shape)
         for i in range(bundle.training_info.num_inputs)

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -290,10 +290,10 @@ def _flexsn_inductor_training_impl(
 def _flexsn_inductor_training_final_state_impl(
     bundle: FlexSNKernelHandle, flat_args: List[torch.Tensor]
 ) -> List[torch.Tensor]:
-    full_returns = _flexsn_inductor_training_impl(bundle, flat_args)
     info = bundle.training_info
     assert info is not None
     args = _materialize_zero_state_args(info, flat_args)
+    full_returns = _flexsn_inductor_training_impl(bundle, args)
     visible_outputs = list(full_returns[: info.num_outputs])
     state_seqs = list(
         full_returns[info.num_outputs : info.num_outputs + info.num_states]

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -185,10 +185,13 @@ def _grad_or_zeros(grad_out, index: int, spec):
 
 
 def _make_state_templates_like(
-    flat_args: list[torch.Tensor], num_states: int
+    info: FlexSNInfo, flat_args: list[torch.Tensor]
 ) -> list[torch.Tensor]:
     if not flat_args:
         raise ValueError("Expected at least one input tensor for FlexSN fake op.")
+    explicit_states = flat_args[info.num_inputs: info.num_inputs + info.num_states]
+    if len(explicit_states) == info.num_states:
+        return [state.new_empty(state.shape) for state in explicit_states]
     seq_template = flat_args[0]
     if seq_template.dim() == 0:
         state_shape = ()
@@ -196,7 +199,7 @@ def _make_state_templates_like(
         state_shape = tuple(seq_template.shape[1:])
     return [
         seq_template.new_empty(state_shape)
-        for _ in range(num_states)
+        for _ in range(info.num_states)
     ]
 
 
@@ -369,7 +372,7 @@ def _flexsn_inductor_inference_final_state_fake(
         bundle.inference_final_state_info.num_outputs,
     )
     final_states = _make_state_templates_like(
-        flat_args, bundle.inference_final_state_info.num_states
+        bundle.inference_final_state_info, flat_args
     )
     return [*seq_outputs, *final_states]
 
@@ -426,9 +429,7 @@ def _flexsn_inductor_training_final_state_fake(
         flat_args,
         bundle.training_info.num_outputs,
     )
-    final_states = _make_state_templates_like(
-        flat_args, bundle.training_info.num_states
-    )
+    final_states = _make_state_templates_like(bundle.training_info, flat_args)
     extra_saved_tensors = _make_seq_outputs_like(
         bundle.training_info,
         flat_args,

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -490,8 +490,15 @@ def _flexsn_training_final_state_setup_context(ctx, inputs, output):
     ]
     if bundle.training_info.num_inputs == 0:
         raise RuntimeError("FlexSN training requires at least one input sequence.")
-    seq_shape, seq_dtype, seq_device = ctx.input_template_specs[0]
-    ctx.state_seq_template_spec = (seq_shape, seq_dtype, seq_device)
+    seq_len = ctx.input_template_specs[0][0][0]
+    state_start = bundle.training_info.num_outputs
+    state_end = state_start + bundle.training_info.num_states
+    ctx.state_seq_template_specs = [
+        ((seq_len, *state_shape), state_dtype, state_device)
+        for state_shape, state_dtype, state_device in (
+            _template_spec(t) for t in output[state_start:state_end]
+        )
+    ]
     visible = bundle.training_info.num_outputs + bundle.training_info.num_states
     extra_saved = list(output[visible:])
     extra_saved_iter = iter(extra_saved)
@@ -557,9 +564,11 @@ def _flexsn_training_final_state_backward(ctx, grad_out: list[torch.Tensor | Non
                 )
             )
 
-    state_seq_shape, state_seq_dtype, state_seq_device = ctx.state_seq_template_spec
     state_grads = []
     for i in range(bundle.training_info.num_states):
+        state_seq_shape, state_seq_dtype, state_seq_device = (
+            ctx.state_seq_template_specs[i]
+        )
         final_grad = grad_out[bundle.training_info.num_outputs + i]
         seq_grad = torch.zeros(
             state_seq_shape,

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -50,6 +50,17 @@ _KERNEL_REGISTRY_LOCK = Lock()
 _KERNEL_ID_GEN = count(1)
 
 
+def _normalize_kernel_handle(handle: int) -> int:
+    if isinstance(handle, int):
+        return handle
+    try:
+        return int(handle)
+    except Exception as exc:
+        raise TypeError(
+            f"Unsupported FlexSN kernel handle type: {type(handle)!r}"
+        ) from exc
+
+
 def register_flexsn_kernel_handle(
     *,
     inference_kernel,
@@ -95,13 +106,7 @@ def _cleanup_kernel_handle(bundle: FlexSNKernelHandle) -> None:
 
 
 def _lookup_kernel_handle(handle: int) -> FlexSNKernelHandle:
-    if not isinstance(handle, int):
-        try:
-            handle = int(handle)
-        except Exception as exc:
-            raise TypeError(
-                f"Unsupported FlexSN kernel handle type: {type(handle)!r}"
-            ) from exc
+    handle = _normalize_kernel_handle(handle)
     try:
         return _KERNEL_REGISTRY[handle]
     except KeyError as e:
@@ -109,18 +114,21 @@ def _lookup_kernel_handle(handle: int) -> FlexSNKernelHandle:
 
 
 def retain_flexsn_kernel_handle(handle: int) -> None:
+    handle = _normalize_kernel_handle(handle)
     with _KERNEL_REGISTRY_LOCK:
         bundle = _lookup_kernel_handle(handle)
         bundle.active_refs += 1
 
 
 def retain_owner_flexsn_kernel_handle(handle: int) -> None:
+    handle = _normalize_kernel_handle(handle)
     with _KERNEL_REGISTRY_LOCK:
         bundle = _lookup_kernel_handle(handle)
         bundle.owner_refs += 1
 
 
 def release_flexsn_kernel_handle(handle: int) -> None:
+    handle = _normalize_kernel_handle(handle)
     with _KERNEL_REGISTRY_LOCK:
         bundle = _KERNEL_REGISTRY.get(handle)
         if bundle is None:
@@ -134,6 +142,7 @@ def release_flexsn_kernel_handle(handle: int) -> None:
 
 
 def release_active_flexsn_kernel_handle(handle: int) -> None:
+    handle = _normalize_kernel_handle(handle)
     with _KERNEL_REGISTRY_LOCK:
         bundle = _KERNEL_REGISTRY.get(handle)
         if bundle is None:
@@ -236,6 +245,21 @@ def _flexsn_inductor_training_impl(
         )
 
 
+def _flexsn_inductor_training_final_state_impl(
+    bundle: FlexSNKernelHandle, flat_args: list[torch.Tensor]
+) -> list[torch.Tensor]:
+    full_returns = _flexsn_inductor_training_impl(bundle, flat_args)
+    info = bundle.training_info
+    assert info is not None
+    visible_outputs = list(full_returns[: info.num_outputs])
+    state_seqs = list(
+        full_returns[info.num_outputs : info.num_outputs + info.num_states]
+    )
+    final_states = [state_seq[-1] for state_seq in state_seqs]
+    saved_tensors = [full_returns[i] for i in info.c2k_return_mapping]
+    return [*visible_outputs, *final_states, *saved_tensors]
+
+
 def _flexsn_inductor_backward_impl(
     bundle: FlexSNKernelHandle,
     grad_outputs: list[torch.Tensor],
@@ -324,6 +348,20 @@ def flexsn_inductor_training(handle: int, flat_args: list[torch.Tensor]) -> list
     return _flexsn_inductor_training_impl(bundle, flat_args)
 
 
+@torch.library.custom_op("sj::flexsn_inductor_training_final_state", mutates_args=())
+def flexsn_inductor_training_final_state(
+    handle: int, flat_args: list[torch.Tensor]
+) -> list[torch.Tensor]:
+    bundle = _lookup_kernel_handle(handle)
+    if (
+        bundle.forward_kernel is None
+        or bundle.backward_kernel is None
+        or bundle.training_info is None
+    ):
+        raise RuntimeError("FlexSN training kernels are unavailable for this handle.")
+    return _flexsn_inductor_training_final_state_impl(bundle, flat_args)
+
+
 @torch.library.register_fake("sj::flexsn_inductor_training")
 def _flexsn_inductor_training_fake(
     handle: int, flat_args: list[torch.Tensor]
@@ -336,6 +374,34 @@ def _flexsn_inductor_training_fake(
         flat_args,
         bundle.training_info.num_fwd_kernel_returns,
     )
+
+
+@torch.library.register_fake("sj::flexsn_inductor_training_final_state")
+def _flexsn_inductor_training_final_state_fake(
+    handle: int, flat_args: list[torch.Tensor]
+) -> list[torch.Tensor]:
+    bundle = _lookup_kernel_handle(handle)
+    if bundle.training_info is None:
+        raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
+    seq_outputs = _make_seq_outputs_like(
+        bundle.training_info,
+        flat_args,
+        bundle.training_info.num_outputs,
+    )
+    if flat_args:
+        state_template = flat_args[0][0]
+    else:
+        raise ValueError("Expected at least one input tensor for FlexSN fake training.")
+    final_states = [
+        state_template.new_empty(state_template.shape)
+        for _ in range(bundle.training_info.num_states)
+    ]
+    saved_tensors = _make_seq_outputs_like(
+        bundle.training_info,
+        flat_args,
+        len(bundle.training_info.c2k_return_mapping),
+    )
+    return [*seq_outputs, *final_states, *saved_tensors]
 
 
 @torch.library.custom_op("sj::flexsn_inductor_backward", mutates_args=())
@@ -379,7 +445,7 @@ def _flexsn_inductor_backward_fake(
 
 
 def _flexsn_training_setup_context(ctx, inputs, output):
-    handle = inputs[0]
+    handle = _normalize_kernel_handle(inputs[0])
     bundle = _lookup_kernel_handle(handle)
     if bundle.training_info is None:
         raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
@@ -395,6 +461,28 @@ def _flexsn_training_setup_context(ctx, inputs, output):
     ]
     saved = [output[i] for i in bundle.training_info.c2k_return_mapping]
     ctx.save_for_backward(*saved)
+
+
+def _flexsn_training_final_state_setup_context(ctx, inputs, output):
+    handle = _normalize_kernel_handle(inputs[0])
+    bundle = _lookup_kernel_handle(handle)
+    if bundle.training_info is None:
+        raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
+    retain_flexsn_kernel_handle(handle)
+    ctx._active_ref_finalizer = weakref.finalize(
+        ctx, release_active_flexsn_kernel_handle, handle
+    )
+    ctx.handle = handle
+    ctx.input_template_specs = [_template_spec(t) for t in inputs[1]]
+    ctx.output_template_specs = [
+        _template_spec(t) for t in output[: bundle.training_info.num_outputs]
+    ]
+    if bundle.training_info.num_inputs == 0:
+        raise RuntimeError("FlexSN training requires at least one input sequence.")
+    seq_shape, seq_dtype, seq_device = ctx.input_template_specs[0]
+    ctx.state_seq_template_spec = (seq_shape, seq_dtype, seq_device)
+    visible = bundle.training_info.num_outputs + bundle.training_info.num_states
+    ctx.save_for_backward(*list(output[visible:]))
 
 
 def _flexsn_training_backward(ctx, grad_out: list[torch.Tensor | None]):
@@ -432,10 +520,66 @@ def _flexsn_training_backward(ctx, grad_out: list[torch.Tensor | None]):
     return None, grads
 
 
+def _flexsn_training_final_state_backward(ctx, grad_out: list[torch.Tensor | None]):
+    bundle = _lookup_kernel_handle(ctx.handle)
+    if bundle.backward_kernel is None or bundle.training_info is None:
+        raise RuntimeError("FlexSN backward kernel is unavailable for this handle.")
+
+    output_grads = []
+    for i in range(bundle.training_info.num_outputs):
+        if grad_out[i] is not None:
+            output_grads.append(grad_out[i])
+        else:
+            output_grads.append(
+                torch.zeros(
+                    ctx.output_template_specs[i][0],
+                    dtype=ctx.output_template_specs[i][1],
+                    device=ctx.output_template_specs[i][2],
+                )
+            )
+
+    state_seq_shape, state_seq_dtype, state_seq_device = ctx.state_seq_template_spec
+    state_grads = []
+    for i in range(bundle.training_info.num_states):
+        final_grad = grad_out[bundle.training_info.num_outputs + i]
+        seq_grad = torch.zeros(
+            state_seq_shape,
+            dtype=state_seq_dtype,
+            device=state_seq_device,
+        )
+        if final_grad is not None:
+            seq_grad[-1].copy_(final_grad)
+        state_grads.append(seq_grad)
+
+    input_templates = [_materialize_template(spec) for spec in ctx.input_template_specs]
+    try:
+        if ctx._active_ref_finalizer.alive:
+            ctx._active_ref_finalizer.detach()
+        grads = list(
+            flexsn_inductor_backward(
+                ctx.handle,
+                [*output_grads, *state_grads],
+                list(ctx.saved_tensors),
+                input_templates,
+            )
+        )
+        if len(grads) != len(ctx.input_template_specs):
+            grads = grads[: len(ctx.input_template_specs)]
+    finally:
+        release_active_flexsn_kernel_handle(ctx.handle)
+    return None, grads
+
+
 torch.library.register_autograd(
     "sj::flexsn_inductor_training",
     _flexsn_training_backward,
     setup_context=_flexsn_training_setup_context,
+)
+
+torch.library.register_autograd(
+    "sj::flexsn_inductor_training_final_state",
+    _flexsn_training_final_state_backward,
+    setup_context=_flexsn_training_final_state_setup_context,
 )
 
 

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -192,6 +192,10 @@ def _extra_saved_return_indices(info: FlexSNInfo) -> list[int]:
     return [idx for idx in info.c2k_return_mapping if idx >= visible]
 
 
+def _final_state_saved_return_indices(info: FlexSNInfo) -> list[int]:
+    return [idx for idx in info.c2k_return_mapping if idx >= info.num_outputs]
+
+
 def _materialize_zero_state_args(
     info: FlexSNInfo, flat_args: list[torch.Tensor]
 ) -> list[torch.Tensor]:
@@ -266,9 +270,7 @@ def _flexsn_inductor_training_final_state_impl(
         full_returns[info.num_outputs : info.num_outputs + info.num_states]
     )
     final_states = [state_seq[-1] for state_seq in state_seqs]
-    extra_saved_tensors = [
-        full_returns[i] for i in _extra_saved_return_indices(info)
-    ]
+    extra_saved_tensors = [full_returns[i] for i in _final_state_saved_return_indices(info)]
     return [*visible_outputs, *final_states, *extra_saved_tensors]
 
 
@@ -411,7 +413,7 @@ def _flexsn_inductor_training_final_state_fake(
     extra_saved_tensors = _make_seq_outputs_like(
         bundle.training_info,
         flat_args,
-        len(_extra_saved_return_indices(bundle.training_info)),
+        len(_final_state_saved_return_indices(bundle.training_info)),
     )
     return [*seq_outputs, *final_states, *extra_saved_tensors]
 
@@ -500,12 +502,13 @@ def _flexsn_training_final_state_setup_context(ctx, inputs, output):
             _template_spec(t) for t in output[state_start:state_end]
         )
     ]
+    visible_outputs = bundle.training_info.num_outputs
     visible = bundle.training_info.num_outputs + bundle.training_info.num_states
     extra_saved = list(output[visible:])
     extra_saved_iter = iter(extra_saved)
     saved = []
     for idx in bundle.training_info.c2k_return_mapping:
-        if idx < visible:
+        if idx < visible_outputs:
             saved.append(output[idx])
         else:
             saved.append(next(extra_saved_iter))

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -176,6 +176,14 @@ def _materialize_template(spec):
     return torch.empty((), dtype=dtype, device=device).expand(shape)
 
 
+def _grad_or_zeros(grad_out, index: int, spec):
+    grad = grad_out[index] if index < len(grad_out) else None
+    if grad is not None:
+        return grad
+    shape, dtype, device = spec
+    return torch.zeros(shape, dtype=dtype, device=device)
+
+
 def _make_state_templates_like(
     flat_args: list[torch.Tensor], num_states: int
 ) -> list[torch.Tensor]:
@@ -528,13 +536,7 @@ def _flexsn_training_backward(ctx, grad_out: list[torch.Tensor | None]):
 
     required_grads = bundle.training_info.num_outputs + bundle.training_info.num_states
     grad_inputs = [
-        grad_out[i]
-        if grad_out[i] is not None
-        else torch.zeros(
-            ctx.output_template_specs[i][0],
-            dtype=ctx.output_template_specs[i][1],
-            device=ctx.output_template_specs[i][2],
-        )
+        _grad_or_zeros(grad_out, i, ctx.output_template_specs[i])
         for i in range(required_grads)
     ]
     input_templates = [_materialize_template(spec) for spec in ctx.input_template_specs]
@@ -563,23 +565,19 @@ def _flexsn_training_final_state_backward(ctx, grad_out: list[torch.Tensor | Non
 
     output_grads = []
     for i in range(bundle.training_info.num_outputs):
-        if grad_out[i] is not None:
-            output_grads.append(grad_out[i])
-        else:
-            output_grads.append(
-                torch.zeros(
-                    ctx.output_template_specs[i][0],
-                    dtype=ctx.output_template_specs[i][1],
-                    device=ctx.output_template_specs[i][2],
-                )
-            )
+        output_grads.append(_grad_or_zeros(grad_out, i, ctx.output_template_specs[i]))
 
     state_grads = []
     for i in range(bundle.training_info.num_states):
         state_seq_shape, state_seq_dtype, state_seq_device = (
             ctx.state_seq_template_specs[i]
         )
-        final_grad = grad_out[bundle.training_info.num_outputs + i]
+        final_grad_index = bundle.training_info.num_outputs + i
+        final_grad = (
+            grad_out[final_grad_index]
+            if final_grad_index < len(grad_out)
+            else None
+        )
         seq_grad = torch.zeros(
             state_seq_shape,
             dtype=state_seq_dtype,
@@ -605,7 +603,12 @@ def _flexsn_training_final_state_backward(ctx, grad_out: list[torch.Tensor | Non
             grads = grads[: len(ctx.input_template_specs)]
         explicit_state_start = bundle.training_info.num_inputs
         for i in range(bundle.training_info.num_states):
-            final_grad = grad_out[bundle.training_info.num_outputs + i]
+            final_grad_index = bundle.training_info.num_outputs + i
+            final_grad = (
+                grad_out[final_grad_index]
+                if final_grad_index < len(grad_out)
+                else None
+            )
             state_seq_shape = ctx.state_seq_template_specs[i][0]
             grad_index = explicit_state_start + i
             if (

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -55,7 +55,7 @@ def _normalize_kernel_handle(handle: int) -> int:
         return handle
     try:
         return int(handle)
-    except Exception as exc:
+    except (TypeError, ValueError) as exc:
         raise TypeError(
             f"Unsupported FlexSN kernel handle type: {type(handle)!r}"
         ) from exc

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -603,6 +603,17 @@ def _flexsn_training_final_state_backward(ctx, grad_out: list[torch.Tensor | Non
         )
         if len(grads) != len(ctx.input_template_specs):
             grads = grads[: len(ctx.input_template_specs)]
+        explicit_state_start = bundle.training_info.num_inputs
+        for i in range(bundle.training_info.num_states):
+            final_grad = grad_out[bundle.training_info.num_outputs + i]
+            state_seq_shape = ctx.state_seq_template_specs[i][0]
+            grad_index = explicit_state_start + i
+            if (
+                final_grad is not None
+                and state_seq_shape[0] == 0
+                and grad_index < len(grads)
+            ):
+                grads[grad_index] = grads[grad_index] + final_grad
     finally:
         release_active_flexsn_kernel_handle(ctx.handle)
     return None, grads

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -54,6 +54,12 @@ _KERNEL_ID_GEN = count(1)
 def _normalize_kernel_handle(handle: int) -> int:
     if isinstance(handle, int):
         return handle
+    if isinstance(handle, torch.Tensor):
+        if handle.numel() != 1:
+            raise TypeError(
+                f"Unsupported FlexSN kernel handle tensor shape: {tuple(handle.shape)}"
+            )
+        return int(handle.item())
     try:
         return int(handle)
     except (TypeError, ValueError) as exc:

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -169,6 +169,22 @@ def eager_scan(
                 f"input {i} has leading dim {x.shape[0]}, expected {T}"
             )
 
+    if T == 0:
+        def _empty_output(i: int) -> torch.Tensor:
+            if i < len(states):
+                ref = states[i]
+            elif states:
+                ref = states[-1]
+            elif lifted_args:
+                ref = lifted_args[min(i, len(lifted_args) - 1)]
+            else:
+                ref = inputs_seq[0].new_empty(inputs_seq[0].shape[1:])
+            return ref.new_empty((0, *ref.shape))
+
+        empty_outputs = tuple(_empty_output(i) for i in range(num_outputs))
+        empty_states = tuple(state.new_empty((0, *state.shape)) for state in states)
+        return (*empty_outputs, *empty_states)
+
     output_buffers = [[] for _ in range(num_outputs)]
     state_buffers = [[] for _ in range(num_states)]
 

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -894,11 +894,19 @@ def _register_dynamo_hop() -> None:
         )
         return
 
-    if getattr(TorchHigherOrderOperatorVariable.make, "_spikingjelly_flexsn_hop", False):
+    make_descriptor = TorchHigherOrderOperatorVariable.__dict__.get(
+        "make", TorchHigherOrderOperatorVariable.make
+    )
+    make_func = (
+        make_descriptor.__func__
+        if isinstance(make_descriptor, (classmethod, staticmethod))
+        else make_descriptor
+    )
+    if getattr(make_func, "_spikingjelly_flexsn_hop", False):
         _DYNAMO_HOP_REGISTERED = True
         return
 
-    original_make = TorchHigherOrderOperatorVariable.make
+    original_make = make_descriptor
 
     install_subgraph = getattr(hop_vars, "add_subgraph", None)
     if install_subgraph is None:
@@ -1064,13 +1072,17 @@ def _register_dynamo_hop() -> None:
             )
             return wrap_fx_proxy(tx=tx, proxy=proxy, example_value=example_value)
 
-    def patched_make(value, source=None, **kwargs):
+    def patched_make(cls, value, source=None, **kwargs):
         if value is flex_sn_scan:
             return FlexSNScanHigherOrderVariable(value, source, **kwargs)
-        return original_make(value, source=source, **kwargs)
+        if isinstance(original_make, classmethod):
+            return original_make.__func__(cls, value, source=source, **kwargs)
+        if isinstance(original_make, staticmethod):
+            return original_make.__func__(value, source=source, **kwargs)
+        return original_make(cls, value, source=source, **kwargs)
 
     patched_make._spikingjelly_flexsn_hop = True
-    TorchHigherOrderOperatorVariable.make = staticmethod(patched_make)
+    TorchHigherOrderOperatorVariable.make = classmethod(patched_make)
     _DYNAMO_HOP_REGISTERED = True
 
 

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -76,13 +76,13 @@ from torch._ops import HigherOrderOperator
 try:
     from torch._higher_order_ops.scan import scan_op as _torch_scan_op
     from torch._higher_order_ops.scan import wrap_combine_fn_flat as _wrap_scan_combine_fn_flat
-except Exception:
+except (ImportError, AttributeError):
     _torch_scan_op = None
     _wrap_scan_combine_fn_flat = None
 
 try:
     from torch._higher_order_ops.while_loop import while_loop as _torch_while_loop
-except Exception:
+except (ImportError, AttributeError):
     _torch_while_loop = None
 
 
@@ -469,8 +469,10 @@ def lowerable_while_loop_scan(
 
     if T == 0:
         def _empty_output(i: int) -> torch.Tensor:
-            if init_states:
-                ref = init_states[i % len(init_states)]
+            if i < len(init_states):
+                ref = init_states[i]
+            elif init_states:
+                ref = init_states[-1]
             elif lifted_args:
                 ref = lifted_args[min(i, len(lifted_args) - 1)]
             else:

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -1,22 +1,56 @@
 """FlexSN time-step scan as a HigherOrderOperator.
 
-Current scope (M1 + M2):
+Current progress:
 
+M1:
 * HOP definition with an eager Python time-step loop impl.
 * Eager autograd works via the natural computation graph (``x[t]`` indexing
   and ``torch.stack`` are differentiable, so the per-step ``core_fn`` graph
   is correctly chained through time). Verified with ``gradcheck``.
+
+M2:
 * AOTAutograd tracing (``torch.fx.experimental.proxy_tensor.make_fx`` /
-  ``torch._functorch.aot_autograd.aot_function``) works out of the box by
-  unrolling the scan into T copies of ``core_fn``'s aten ops. This is the
-  input format Inductor expects.
+  ``torch._functorch.aot_autograd.aot_function``) works by unrolling the scan
+  into T copies of ``core_fn``'s aten ops.
 
-Deferred to M3:
+M3:
+* ``FlexSN(backend="hop")`` is available as an explicit backend.
+* Dynamo recognizes ``flex_sn_scan`` via a compatibility registration and can
+  rewrite the call into a HOP node with a traced ``GraphModule`` body.
+* ``torch.compile(fullgraph=True)`` for the HOP backend is verified on the
+  Linux CI/server environment, including tensor lifted freevars/closures.
 
-* A true Inductor lowering that keeps FlexSN as its own first-class HOP and
-  emits a time loop without relying on PyTorch's built-in scan decomposition.
-* Training/autograd support for the lowerable scan path. The built-in scan HOP
-  used here to avoid full unrolling is currently inference-oriented.
+M4:
+* ``lowerable_scan`` re-expresses the FlexSN step function through PyTorch's
+  built-in ``torch.ops.higher_order.scan`` when that API is available.
+* It is kept as an explicit experimental helper for investigating a
+  single-scan-node forward path instead of fully unrolling the body.
+* ``lowerable_while_loop_scan`` provides an alternative experimental forward
+  path based on ``torch.ops.higher_order.while_loop``. On the Linux validation
+  environment, its ``torch.compile(fullgraph=True) + no_grad`` path is working
+  after switching to fixed-shape queue carries instead of ``x[t]`` indexing.
+* The experimental while-loop path is wired into ``FlexSN(backend="hop")`` via
+  ``SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP=1`` for compile-time forward
+  evaluation, and has been validated on:
+  - a single FlexSN layer,
+  - ``Linear -> FlexSN -> Linear``,
+  - ``SpikingVGG`` forward inference.
+
+Current limitations:
+
+* The custom Dynamo registration in this file is still a compatibility shim,
+  not a true in-tree ``BaseHOP`` integration.
+* ``lowerable_scan`` is currently an experimental helper, not the default
+  compiled path. In the PyTorch versions we validate against, fake/proxy/export
+  handling for this out-of-tree scan shape is not yet stable enough to enable
+  it by default.
+* Training and autograd still use the existing eager/unrolled path.
+* The current while-loop lowering is functionally correct for the validated
+  forward ``no_grad`` cases, but it is not yet faster than the current
+  ``backend="inductor"`` custom-op compile path on the server benchmark.
+* A true first-class Inductor lowering for ``flex_sn_scan`` itself does not
+  exist yet; the current "less unrolled" path relies on PyTorch's built-in
+  scan / while_loop decomposition.
 
 Usage::
 
@@ -32,16 +66,24 @@ Captured tensor freevars from ``core_fn`` are appended after the
 ``[*inputs_seq, *init_states]`` segment when Dynamo rewrites the HOP call.
 """
 from __future__ import annotations
-
+import functools
 from typing import Callable, Tuple
 
 import torch
+import torch.utils._pytree as pytree
 from torch._ops import HigherOrderOperator
 
 try:
     from torch._higher_order_ops.scan import scan_op as _torch_scan_op
+    from torch._higher_order_ops.scan import wrap_combine_fn_flat as _wrap_scan_combine_fn_flat
 except Exception:
     _torch_scan_op = None
+    _wrap_scan_combine_fn_flat = None
+
+try:
+    from torch._higher_order_ops.while_loop import while_loop as _torch_while_loop
+except Exception:
+    _torch_while_loop = None
 
 
 class FlexSNScan(HigherOrderOperator):
@@ -84,7 +126,11 @@ flex_sn_scan = FlexSNScan()
 
 
 def lowerable_scan_available() -> bool:
-    return _torch_scan_op is not None
+    return _torch_scan_op is not None and _wrap_scan_combine_fn_flat is not None
+
+
+def lowerable_while_loop_available() -> bool:
+    return _torch_while_loop is not None
 
 
 def eager_scan(
@@ -158,10 +204,18 @@ def lowerable_scan(
 
     This path keeps the scan as a single higher-order op under tracing so
     downstream compilers can decompose it to a loop instead of unrolling the
-    body T times in the traced graph. It is currently intended for inference /
-    no-grad usage.
+    body T times in the traced graph. It is currently intended as an
+    experimental helper for investigation rather than a production default.
+
+    Notes:
+    * On the PyTorch versions we validate against, fake/proxy/export handling
+      for this out-of-tree scan pattern is still not stable enough to make this
+      the default compiled path.
+    * We mirror the internal ``scan`` frontend contract by routing through
+      ``wrap_combine_fn_flat`` with explicit tree specs for the flattened
+      inputs/states.
     """
-    if _torch_scan_op is None:
+    if _torch_scan_op is None or _wrap_scan_combine_fn_flat is None:
         raise RuntimeError("PyTorch scan HOP is unavailable in this environment")
 
     expected = num_inputs + num_states
@@ -177,30 +231,182 @@ def lowerable_scan(
     input_seqs = flat_args[:num_inputs]
     init_states = flat_args[num_inputs:expected]
     lifted_args = tuple(flat_args[expected:])
-
-    def combine_fn(*args):
-        carry = args[:num_states]
-        step_inputs = args[num_states : num_states + num_inputs]
-        extra_inputs = args[num_states + num_inputs :]
-        results = core_fn(*step_inputs, *carry, *extra_inputs)
+    def combine_fn(carry, step_inputs):
+        carry = tuple(carry)
+        step_inputs = tuple(step_inputs)
+        results = core_fn(*step_inputs, *carry, *lifted_args)
         results = tuple(results) if not isinstance(results, torch.Tensor) else (results,)
         if len(results) != num_outputs + num_states:
             raise ValueError(
                 f"core returned {len(results)} values, "
                 f"expected num_outputs + num_states = {num_outputs + num_states}"
             )
-        outputs = results[:num_outputs]
-        next_states = results[num_outputs:]
-        return [*next_states, *outputs, *next_states]
+
+        outputs = list(results[:num_outputs])
+        next_states = list(results[num_outputs:])
+        return next_states, [*outputs, *next_states]
+
+    leaves_init = list(init_states)
+    leaves_xs = list(input_seqs)
+    _, spec_init = pytree.tree_flatten(leaves_init)
+    _, spec_xs = pytree.tree_flatten(leaves_xs)
+
+    wrapped_combine_fn = functools.partial(
+        _wrap_scan_combine_fn_flat,
+        combine_fn=combine_fn,
+        spec_init=spec_init,
+        spec_xs=spec_xs,
+        num_init_leaves=len(leaves_init),
+        num_inp_leaves=len(leaves_xs),
+    )
 
     result = _torch_scan_op(
-        combine_fn,
-        list(init_states),
-        list(input_seqs),
-        additional_inputs=lifted_args,
+        wrapped_combine_fn,
+        leaves_init,
+        leaves_xs,
+        additional_inputs=(),
     )
     result = tuple(result)
     return result[num_states:]
+
+
+def lowerable_while_loop_scan(
+    core_fn: Callable,
+    num_inputs: int,
+    num_states: int,
+    num_outputs: int,
+    *flat_args: torch.Tensor,
+) -> Tuple[torch.Tensor, ...]:
+    """Run FlexSN scan through PyTorch's built-in ``while_loop`` HOP.
+
+    This is an explicit research helper for probing whether a first-class loop
+    representation is a better fit than the current unrolled scan path.
+    """
+    if _torch_while_loop is None:
+        raise RuntimeError("PyTorch while_loop HOP is unavailable in this environment")
+
+    expected = num_inputs + num_states
+    if len(flat_args) < expected:
+        raise ValueError(
+            f"flex_sn_scan expected at least {expected} tensor args "
+            f"(num_inputs={num_inputs} + num_states={num_states}), "
+            f"got {len(flat_args)}"
+        )
+    if num_inputs == 0:
+        raise ValueError("flex_sn_scan requires at least one input sequence")
+
+    input_seqs = tuple(flat_args[:num_inputs])
+    init_states = tuple(flat_args[num_inputs:expected])
+    lifted_args = tuple(flat_args[expected:])
+
+    def _ensure_contiguous(tensor: torch.Tensor) -> torch.Tensor:
+        return tensor.contiguous()
+
+    T = input_seqs[0].shape[0]
+    for i, x in enumerate(input_seqs):
+        if x.shape[0] != T:
+            raise ValueError(f"input {i} has leading dim {x.shape[0]}, expected {T}")
+
+    if T == 0:
+        empty_outputs = tuple(
+            state.new_empty((0, *state.shape)) for state in init_states[:num_outputs]
+        )
+        empty_states = tuple(
+            state.new_empty((0, *state.shape)) for state in init_states
+        )
+        return (*empty_outputs, *empty_states)
+
+    input_seqs = tuple(_ensure_contiguous(seq) for seq in input_seqs)
+    init_states = tuple(_ensure_contiguous(state) for state in init_states)
+
+    first_step_inputs = tuple(_ensure_contiguous(x[0]) for x in input_seqs)
+    first_results = core_fn(*first_step_inputs, *init_states, *lifted_args)
+    first_results = (
+        tuple(first_results)
+        if not isinstance(first_results, torch.Tensor)
+        else (first_results,)
+    )
+    if len(first_results) != num_outputs + num_states:
+        raise ValueError(
+            f"core returned {len(first_results)} values, "
+            f"expected num_outputs + num_states = {num_outputs + num_states}"
+        )
+
+    first_outputs = tuple(_ensure_contiguous(x) for x in first_results[:num_outputs])
+    first_states = tuple(_ensure_contiguous(x) for x in first_results[num_outputs:])
+    def _append_to_tail(buffer: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
+        return torch.cat((buffer[1:], _ensure_contiguous(value).unsqueeze(0)), dim=0).contiguous()
+
+    def _shift_input_queue(queue: torch.Tensor) -> torch.Tensor:
+        return torch.cat((queue[1:], queue[-1:].clone()), dim=0).contiguous()
+
+    output_buffers = tuple(
+        _append_to_tail(out.new_zeros((T, *out.shape)), out) for out in first_outputs
+    )
+    state_buffers = tuple(
+        _append_to_tail(state.new_zeros((T, *state.shape)), state)
+        for state in first_states
+    )
+    pending_inputs = tuple(
+        _shift_input_queue(seq) for seq in input_seqs
+    )
+
+    t0 = torch.tensor(1, dtype=torch.int64, device=first_outputs[0].device)
+
+    def cond_fn(t, *carry):
+        return t < T
+
+    def body_fn(t, *carry):
+        pending_seq_end = num_inputs
+        states_end = pending_seq_end + num_states
+        outputs_end = states_end + num_outputs
+
+        step_input_queues = carry[:pending_seq_end]
+        states = carry[pending_seq_end:states_end]
+        outputs_acc = carry[states_end:outputs_end]
+        states_acc = carry[outputs_end:]
+
+        step_inputs = tuple(_ensure_contiguous(queue[0]) for queue in step_input_queues)
+        results = core_fn(*step_inputs, *states, *lifted_args)
+        results = tuple(results) if not isinstance(results, torch.Tensor) else (results,)
+        outputs = tuple(_ensure_contiguous(x) for x in results[:num_outputs])
+        next_states = tuple(_ensure_contiguous(x) for x in results[num_outputs:])
+        next_pending_inputs = tuple(
+            _shift_input_queue(queue) for queue in step_input_queues
+        )
+        next_output_acc = tuple(
+            _append_to_tail(buf, out) for buf, out in zip(outputs_acc, outputs)
+        )
+        next_state_acc = tuple(
+            _append_to_tail(buf, state)
+            for buf, state in zip(states_acc, next_states)
+        )
+        return (
+            t + 1,
+            *next_pending_inputs,
+            *next_states,
+            *next_output_acc,
+            *next_state_acc,
+        )
+
+    final = _torch_while_loop(
+        cond_fn,
+        body_fn,
+        (
+            t0,
+            *pending_inputs,
+            *first_states,
+            *output_buffers,
+            *state_buffers,
+        ),
+    )
+    final = tuple(final)
+    pending_seq_end = 1 + num_inputs
+    states_end = pending_seq_end + num_states
+    outputs_end = states_end + num_outputs
+    final_output_buffers = final[states_end:outputs_end]
+    final_state_buffers = final[outputs_end:]
+    return (*final_output_buffers, *final_state_buffers)
 
 
 flex_sn_scan.py_impl(torch._C.DispatchKey.CompositeExplicitAutograd)(eager_scan)

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -450,6 +450,12 @@ def lowerable_while_loop_scan(
     def _ensure_contiguous(tensor: torch.Tensor) -> torch.Tensor:
         return tensor.contiguous()
 
+    def _carry_device(*tensor_groups) -> torch.device:
+        for group in tensor_groups:
+            for tensor in group:
+                return tensor.device
+        return torch.device("cpu")
+
     T = input_seqs[0].shape[0]
     for i, x in enumerate(input_seqs):
         if x.shape[0] != T:
@@ -459,8 +465,11 @@ def lowerable_while_loop_scan(
         def _empty_output(i: int) -> torch.Tensor:
             if init_states:
                 ref = init_states[i % len(init_states)]
-                return ref.new_empty((0, *ref.shape))
-            return input_seqs[0].new_empty((0, *input_seqs[0].shape[1:]))
+            elif lifted_args:
+                ref = lifted_args[min(i, len(lifted_args) - 1)]
+            else:
+                return input_seqs[0].new_empty((0, *input_seqs[0].shape[1:]))
+            return ref.new_empty((0, *ref.shape))
 
         empty_outputs = tuple(
             _empty_output(i) for i in range(num_outputs)
@@ -505,7 +514,11 @@ def lowerable_while_loop_scan(
         _shift_input_queue(seq) for seq in input_seqs
     )
 
-    t0 = torch.tensor(1, dtype=torch.int64, device=first_outputs[0].device)
+    t0 = torch.tensor(
+        1,
+        dtype=torch.int64,
+        device=_carry_device(first_states, input_seqs, first_outputs),
+    )
 
     def cond_fn(t, *carry):
         return t < T
@@ -591,6 +604,12 @@ def lowerable_while_loop_scan_final_state(
     def _ensure_contiguous(tensor: torch.Tensor) -> torch.Tensor:
         return tensor.contiguous()
 
+    def _carry_device(*tensor_groups) -> torch.device:
+        for group in tensor_groups:
+            for tensor in group:
+                return tensor.device
+        return torch.device("cpu")
+
     T = input_seqs[0].shape[0]
     for i, x in enumerate(input_seqs):
         if x.shape[0] != T:
@@ -602,6 +621,8 @@ def lowerable_while_loop_scan_final_state(
                 ref = init_states[i]
             elif init_states:
                 ref = init_states[-1]
+            elif lifted_args:
+                ref = lifted_args[min(i, len(lifted_args) - 1)]
             else:
                 ref = input_seqs[0].new_empty(input_seqs[0].shape[1:])
             return ref.new_empty((0, *ref.shape))
@@ -641,7 +662,11 @@ def lowerable_while_loop_scan_final_state(
     )
     pending_inputs = tuple(_shift_input_queue(seq) for seq in input_seqs)
 
-    t0 = torch.tensor(1, dtype=torch.int64, device=first_outputs[0].device)
+    t0 = torch.tensor(
+        1,
+        dtype=torch.int64,
+        device=_carry_device(first_states, input_seqs, first_outputs),
+    )
 
     def cond_fn(t, *carry):
         return t < T

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -228,6 +228,19 @@ def eager_scan_final_state(
                 f"input {i} has leading dim {x.shape[0]}, expected {T}"
             )
 
+    if T == 0:
+        def _empty_output(i: int) -> torch.Tensor:
+            if i < len(states):
+                ref = states[i]
+            elif states:
+                ref = states[-1]
+            else:
+                ref = inputs_seq[0].new_empty(inputs_seq[0].shape[1:])
+            return ref.new_empty((0, *ref.shape))
+
+        empty_outputs = tuple(_empty_output(i) for i in range(num_outputs))
+        return (*empty_outputs, *tuple(states))
+
     output_buffers = [[] for _ in range(num_outputs)]
 
     for t in range(T):
@@ -500,11 +513,12 @@ def lowerable_while_loop_scan(
             _shift_input_queue(queue) for queue in step_input_queues
         )
         next_output_acc = tuple(
-            _append_to_tail(buf, out) for buf, out in zip(outputs_acc, outputs)
+            _append_to_tail(buf, out)
+            for buf, out in zip(outputs_acc, outputs, strict=True)
         )
         next_state_acc = tuple(
             _append_to_tail(buf, state)
-            for buf, state in zip(states_acc, next_states)
+            for buf, state in zip(states_acc, next_states, strict=True)
         )
         return (
             t + 1,
@@ -633,7 +647,8 @@ def lowerable_while_loop_scan_final_state(
             _shift_input_queue(queue) for queue in step_input_queues
         )
         next_output_acc = tuple(
-            _append_to_tail(buf, out) for buf, out in zip(outputs_acc, outputs)
+            _append_to_tail(buf, out)
+            for buf, out in zip(outputs_acc, outputs, strict=True)
         )
         return (
             t + 1,
@@ -762,26 +777,14 @@ def _register_dynamo_hop() -> None:
             step_inputs = [_make_step_template(arg) for arg in flat_args[:num_inputs]]
             body_args = [*step_inputs, *flat_args[num_inputs:]]
 
-            if "source_target" in getattr(speculate_subgraph, "__code__").co_varnames:
-                _body_r, body_graph, body_lifted_freevars = speculate_subgraph(
-                    tx,
-                    body_fn,
-                    body_args,
-                    {},
-                    "flex_sn_scan",
-                    source_target=self.value,
-                )
-            else:
-                graph_checkpoint, checkpoint = tx.output.graph, tx.copy_graphstate()
-                _body_r, body_graph, body_lifted_freevars = speculate_subgraph(
-                    tx,
-                    body_fn,
-                    body_args,
-                    {},
-                    graph_checkpoint,
-                    checkpoint,
-                    "flex_sn_scan",
-                )
+            _body_r, body_graph, body_lifted_freevars = speculate_subgraph(
+                tx,
+                body_fn,
+                body_args,
+                {},
+                "flex_sn_scan",
+                source_target=self.value,
+            )
 
             if hasattr(body_lifted_freevars, "keys"):
                 lifted_freevars = tuple(body_lifted_freevars.keys())

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -896,7 +896,7 @@ def _register_dynamo_hop() -> None:
             step_inputs = [_make_step_template(arg) for arg in flat_args[:num_inputs]]
             body_args = [*step_inputs, *flat_args[num_inputs:]]
 
-            _body_r, body_graph, body_lifted_freevars = speculate_subgraph(
+            _body_r, body_graph, body_lifted_freevars, _parent_proxy_map = speculate_subgraph(
                 tx,
                 body_fn,
                 body_args,

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -66,7 +66,6 @@ Captured tensor freevars from ``core_fn`` are appended after the
 ``[*inputs_seq, *init_states]`` segment when Dynamo rewrites the HOP call.
 """
 from __future__ import annotations
-import functools
 import warnings
 from typing import Callable, Tuple
 
@@ -322,10 +321,11 @@ def lowerable_scan(
     input_seqs = flat_args[:num_inputs]
     init_states = flat_args[num_inputs:expected]
     lifted_args = tuple(flat_args[expected:])
-    def combine_fn(carry, step_inputs):
+    def combine_fn(carry, step_inputs, additional_inputs):
         carry = tuple(carry)
         step_inputs = tuple(step_inputs)
-        results = core_fn(*step_inputs, *carry, *lifted_args)
+        additional_inputs = tuple(additional_inputs)
+        results = core_fn(*step_inputs, *carry, *additional_inputs)
         results = tuple(results) if not isinstance(results, torch.Tensor) else (results,)
         if len(results) != num_outputs + num_states:
             raise ValueError(
@@ -342,20 +342,25 @@ def lowerable_scan(
     _, spec_init = pytree.tree_flatten(leaves_init)
     _, spec_xs = pytree.tree_flatten(leaves_xs)
 
-    wrapped_combine_fn = functools.partial(
-        _wrap_scan_combine_fn_flat,
-        combine_fn=combine_fn,
-        spec_init=spec_init,
-        spec_xs=spec_xs,
-        num_init_leaves=len(leaves_init),
-        num_inp_leaves=len(leaves_xs),
-    )
+    def wrapped_combine_fn(*args):
+        expected_args = len(leaves_init) + len(leaves_xs) + len(lifted_args)
+        if len(args) != expected_args:
+            raise ValueError(
+                f"scan combine_fn expected {expected_args} flattened args, got {len(args)}"
+            )
+        carry = pytree.tree_unflatten(args[: len(leaves_init)], spec_init)
+        xs = pytree.tree_unflatten(
+            args[len(leaves_init) : len(leaves_init) + len(leaves_xs)],
+            spec_xs,
+        )
+        additional_inputs = tuple(args[len(leaves_init) + len(leaves_xs) :])
+        return combine_fn(carry, xs, additional_inputs)
 
     result = _torch_scan_op(
         wrapped_combine_fn,
         leaves_init,
         leaves_xs,
-        additional_inputs=(),
+        additional_inputs=lifted_args,
     )
     result = tuple(result)
     return result[num_states:]
@@ -385,10 +390,11 @@ def lowerable_scan_final_state(
     init_states = flat_args[num_inputs:expected]
     lifted_args = tuple(flat_args[expected:])
 
-    def combine_fn(carry, step_inputs):
+    def combine_fn(carry, step_inputs, additional_inputs):
         carry = tuple(carry)
         step_inputs = tuple(step_inputs)
-        results = core_fn(*step_inputs, *carry, *lifted_args)
+        additional_inputs = tuple(additional_inputs)
+        results = core_fn(*step_inputs, *carry, *additional_inputs)
         results = tuple(results) if not isinstance(results, torch.Tensor) else (results,)
         if len(results) != num_outputs + num_states:
             raise ValueError(
@@ -404,20 +410,25 @@ def lowerable_scan_final_state(
     _, spec_init = pytree.tree_flatten(leaves_init)
     _, spec_xs = pytree.tree_flatten(leaves_xs)
 
-    wrapped_combine_fn = functools.partial(
-        _wrap_scan_combine_fn_flat,
-        combine_fn=combine_fn,
-        spec_init=spec_init,
-        spec_xs=spec_xs,
-        num_init_leaves=len(leaves_init),
-        num_inp_leaves=len(leaves_xs),
-    )
+    def wrapped_combine_fn(*args):
+        expected_args = len(leaves_init) + len(leaves_xs) + len(lifted_args)
+        if len(args) != expected_args:
+            raise ValueError(
+                f"scan combine_fn expected {expected_args} flattened args, got {len(args)}"
+            )
+        carry = pytree.tree_unflatten(args[: len(leaves_init)], spec_init)
+        xs = pytree.tree_unflatten(
+            args[len(leaves_init) : len(leaves_init) + len(leaves_xs)],
+            spec_xs,
+        )
+        additional_inputs = tuple(args[len(leaves_init) + len(leaves_xs) :])
+        return combine_fn(carry, xs, additional_inputs)
 
     result = _torch_scan_op(
         wrapped_combine_fn,
         leaves_init,
         leaves_xs,
-        additional_inputs=(),
+        additional_inputs=lifted_args,
     )
     result = tuple(result)
     final_states = result[:num_states]
@@ -536,14 +547,16 @@ def lowerable_while_loop_scan(
         pending_seq_end = num_inputs
         states_end = pending_seq_end + num_states
         outputs_end = states_end + num_outputs
+        lifted_end = outputs_end + len(lifted_args)
 
         step_input_queues = carry[:pending_seq_end]
         states = carry[pending_seq_end:states_end]
         outputs_acc = carry[states_end:outputs_end]
-        states_acc = carry[outputs_end:]
+        lifted = carry[outputs_end:lifted_end]
+        states_acc = carry[lifted_end:]
 
         step_inputs = tuple(_ensure_contiguous(queue[0]) for queue in step_input_queues)
-        results = core_fn(*step_inputs, *states, *lifted_args)
+        results = core_fn(*step_inputs, *states, *lifted)
         results = tuple(results) if not isinstance(results, torch.Tensor) else (results,)
         if len(results) != len(first_results):
             raise ValueError(
@@ -568,6 +581,7 @@ def lowerable_while_loop_scan(
             *next_pending_inputs,
             *next_states,
             *next_output_acc,
+            *lifted,
             *next_state_acc,
         )
 
@@ -579,6 +593,7 @@ def lowerable_while_loop_scan(
             *pending_inputs,
             *first_states,
             *output_buffers,
+            *lifted_args,
             *state_buffers,
         ),
     )
@@ -586,8 +601,9 @@ def lowerable_while_loop_scan(
     pending_seq_end = 1 + num_inputs
     states_end = pending_seq_end + num_states
     outputs_end = states_end + num_outputs
+    lifted_end = outputs_end + len(lifted_args)
     final_output_buffers = final[states_end:outputs_end]
-    final_state_buffers = final[outputs_end:]
+    final_state_buffers = final[lifted_end:]
     return (*final_output_buffers, *final_state_buffers)
 
 
@@ -690,11 +706,14 @@ def lowerable_while_loop_scan_final_state(
         states_end = pending_seq_end + num_states
 
         step_input_queues = carry[:pending_seq_end]
+        outputs_end = states_end + num_outputs
+        lifted_end = outputs_end + len(lifted_args)
         states = carry[pending_seq_end:states_end]
-        outputs_acc = carry[states_end:]
+        outputs_acc = carry[states_end:outputs_end]
+        lifted = carry[outputs_end:lifted_end]
 
         step_inputs = tuple(_ensure_contiguous(queue[0]) for queue in step_input_queues)
-        results = core_fn(*step_inputs, *states, *lifted_args)
+        results = core_fn(*step_inputs, *states, *lifted)
         results = tuple(results) if not isinstance(results, torch.Tensor) else (results,)
         if len(results) != len(first_results):
             raise ValueError(
@@ -715,6 +734,7 @@ def lowerable_while_loop_scan_final_state(
             *next_pending_inputs,
             *next_states,
             *next_output_acc,
+            *lifted,
         )
 
     final = _torch_while_loop(
@@ -725,13 +745,15 @@ def lowerable_while_loop_scan_final_state(
             *pending_inputs,
             *first_states,
             *output_buffers,
+            *lifted_args,
         ),
     )
     final = tuple(final)
     pending_seq_end = 1 + num_inputs
     states_end = pending_seq_end + num_states
+    outputs_end = states_end + num_outputs
     final_states = final[pending_seq_end:states_end]
-    final_output_buffers = final[states_end:]
+    final_output_buffers = final[states_end:outputs_end]
     return (*final_output_buffers, *final_states)
 
 
@@ -862,6 +884,12 @@ def _register_dynamo_hop() -> None:
                 raise hop_vars.unimplemented(
                     "flex_sn_scan only supports tensor lifted freevars"
                 )
+            for freevar in lifted_freevars:
+                example_value = freevar.node.meta.get("example_value")
+                if not isinstance(example_value, torch.Tensor):
+                    raise hop_vars.unimplemented(
+                        "flex_sn_scan only supports tensor lifted freevars"
+                    )
 
             body_gm = torch.fx.GraphModule(tx.output.nn_modules, body_graph)
             body_name = install_subgraph(tx, self.source, "flex_sn_scan_body", body_gm)

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -545,11 +545,11 @@ def lowerable_while_loop_scan(
         )
         next_output_acc = tuple(
             _append_to_tail(buf, out)
-            for buf, out in zip(outputs_acc, outputs, strict=True)
+            for buf, out in zip(outputs_acc, outputs)
         )
         next_state_acc = tuple(
             _append_to_tail(buf, state)
-            for buf, state in zip(states_acc, next_states, strict=True)
+            for buf, state in zip(states_acc, next_states)
         )
         return (
             t + 1,
@@ -691,7 +691,7 @@ def lowerable_while_loop_scan_final_state(
         )
         next_output_acc = tuple(
             _append_to_tail(buf, out)
-            for buf, out in zip(outputs_acc, outputs, strict=True)
+            for buf, out in zip(outputs_acc, outputs)
         )
         return (
             t + 1,

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -116,7 +116,7 @@ class FlexSNScan(HigherOrderOperator):
         num_outputs: int,
         *flat_args: torch.Tensor,
         output_template_specs: Optional[
-            Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]
+            Tuple[Tuple, ...]
         ] = None,
     ) -> Tuple[torch.Tensor, ...]:
         return super().__call__(
@@ -142,7 +142,7 @@ def _as_tuple(outputs):
 def _empty_outputs_from_template(
     input_seqs: Tuple[torch.Tensor, ...],
     num_outputs: int,
-    output_template_specs: Optional[Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]],
+    output_template_specs: Optional[Tuple[Tuple, ...]],
 ) -> Tuple[torch.Tensor, ...]:
     if output_template_specs is None:
         raise ValueError(
@@ -154,10 +154,18 @@ def _empty_outputs_from_template(
             f"expected {num_outputs} output template specs, got "
             f"{len(output_template_specs)}"
         )
-    return tuple(
-        input_seqs[0].new_empty((0, *shape), dtype=dtype)
-        for shape, dtype in output_template_specs
-    )
+    outputs = []
+    for spec in output_template_specs:
+        if len(spec) == 2:
+            shape, dtype = spec
+            device = input_seqs[0].device
+        else:
+            shape, dtype, device = spec
+        if device == input_seqs[0].device:
+            outputs.append(input_seqs[0].new_empty((0, *shape), dtype=dtype))
+        else:
+            outputs.append(torch.empty((0, *shape), dtype=dtype, device=device))
+    return tuple(outputs)
 
 
 def _flatten_dynamo_body_result(value) -> Tuple[object, ...]:
@@ -196,7 +204,7 @@ def _dynamo_leaf_example_value(value):
 def _output_template_specs_from_dynamo_body_result(
     body_result,
     num_outputs: int,
-) -> Optional[Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]]:
+) -> Optional[Tuple[Tuple, ...]]:
     leaves = _flatten_dynamo_body_result(body_result)
     if len(leaves) < num_outputs:
         return None
@@ -205,7 +213,9 @@ def _output_template_specs_from_dynamo_body_result(
         example_value = _dynamo_leaf_example_value(leaf)
         if not isinstance(example_value, torch.Tensor):
             return None
-        specs.append((tuple(example_value.shape), example_value.dtype))
+        specs.append(
+            (tuple(example_value.shape), example_value.dtype, example_value.device)
+        )
     return tuple(specs)
 
 
@@ -504,7 +514,8 @@ def lowerable_scan(
 
         outputs = list(results[:num_outputs])
         next_states = list(results[num_outputs:])
-        return next_states, [*outputs, *next_states]
+        output_states = [state.clone() for state in next_states]
+        return next_states, [*outputs, *output_states]
 
     leaves_init = list(init_states)
     leaves_xs = list(input_seqs)
@@ -982,9 +993,10 @@ def _register_dynamo_hop() -> None:
         )
         return
 
-    make_descriptor = TorchHigherOrderOperatorVariable.__dict__.get(
-        "make", TorchHigherOrderOperatorVariable.make
-    )
+    make_descriptor = TorchHigherOrderOperatorVariable.__dict__.get("make")
+    original_make_is_bound = make_descriptor is None
+    if make_descriptor is None:
+        make_descriptor = TorchHigherOrderOperatorVariable.make
     make_func = (
         make_descriptor.__func__
         if isinstance(make_descriptor, (classmethod, staticmethod))
@@ -1172,6 +1184,8 @@ def _register_dynamo_hop() -> None:
             return original_make.__func__(cls, value, source=source, **kwargs)
         if isinstance(original_make, staticmethod):
             return original_make.__func__(value, source=source, **kwargs)
+        if original_make_is_bound:
+            return original_make(value, source=source, **kwargs)
         return original_make(cls, value, source=source, **kwargs)
 
     patched_make._spikingjelly_flexsn_hop = True

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -545,6 +545,7 @@ def lowerable_while_loop_scan(
     init_states = tuple(flat_args[num_inputs:expected])
     lifted_args = tuple(flat_args[expected:])
     _check_lifted_arg_arity(core_fn, num_inputs, num_states, lifted_args)
+    lifted_args = tuple(_ensure_contiguous(arg) for arg in lifted_args)
 
     T = input_seqs[0].shape[0]
     for i, x in enumerate(input_seqs):
@@ -703,6 +704,7 @@ def lowerable_while_loop_scan_final_state(
     init_states = tuple(flat_args[num_inputs:expected])
     lifted_args = tuple(flat_args[expected:])
     _check_lifted_arg_arity(core_fn, num_inputs, num_states, lifted_args)
+    lifted_args = tuple(_ensure_contiguous(arg) for arg in lifted_args)
 
     T = input_seqs[0].shape[0]
     for i, x in enumerate(input_seqs):
@@ -911,12 +913,10 @@ def _register_dynamo_hop() -> None:
                     "flex_sn_scan only supports tensor inputs and states"
                 )
 
-            from torch._dynamo.variables.constant import ConstantVariable as _ConstantVariable
-
             def _make_step_template(arg: TensorVariable):
                 example_value = arg.as_proxy().node.meta["example_value"]
                 if example_value.shape[0] > 0:
-                    return arg.call_method(tx, "__getitem__", [_ConstantVariable(0)], {})
+                    return arg.call_method(tx, "__getitem__", [ConstantVariable(0)], {})
 
                 shape_without_t = tuple(example_value.shape[1:])
                 proxy = tx.output.create_proxy(

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -248,8 +248,11 @@ def eager_scan(
 
     if T == 0:
         step_inputs = tuple(x.new_empty(x.shape[1:]) for x in inputs_seq)
+        temp_states = [s.clone() for s in states]
         with torch.no_grad():
-            template_results = _as_tuple(core_fn(*step_inputs, *states, *lifted_args))
+            template_results = _as_tuple(
+                core_fn(*step_inputs, *temp_states, *lifted_args)
+            )
         if len(template_results) != num_outputs + num_states:
             raise ValueError(
                 f"core returned {len(template_results)} values, "
@@ -332,8 +335,11 @@ def eager_scan_final_state(
 
     if T == 0:
         step_inputs = tuple(x.new_empty(x.shape[1:]) for x in inputs_seq)
+        temp_states = [s.clone() for s in states]
         with torch.no_grad():
-            template_results = _as_tuple(core_fn(*step_inputs, *states, *lifted_args))
+            template_results = _as_tuple(
+                core_fn(*step_inputs, *temp_states, *lifted_args)
+            )
         if len(template_results) != num_outputs + num_states:
             raise ValueError(
                 f"core returned {len(template_results)} values, "
@@ -346,7 +352,7 @@ def eager_scan_final_state(
             return ref.new_empty((0, *ref.shape))
 
         empty_outputs = tuple(_empty_output(i) for i in range(num_outputs))
-        final_states = tuple(states)
+        final_states = tuple(s.clone() for s in states)
         return (*empty_outputs, *final_states)
 
     output_buffers = [[] for _ in range(num_outputs)]
@@ -592,9 +598,10 @@ def lowerable_while_loop_scan(
 
     if T == 0:
         step_inputs = tuple(x.new_empty(x.shape[1:]) for x in input_seqs)
+        temp_states = [s.clone() for s in init_states]
         with torch.no_grad():
             template_results = _as_tuple(
-                core_fn(*step_inputs, *init_states, *lifted_args)
+                core_fn(*step_inputs, *temp_states, *lifted_args)
             )
         if len(template_results) != num_outputs + num_states:
             raise ValueError(
@@ -759,9 +766,10 @@ def lowerable_while_loop_scan_final_state(
 
     if T == 0:
         step_inputs = tuple(x.new_empty(x.shape[1:]) for x in input_seqs)
+        temp_states = [s.clone() for s in init_states]
         with torch.no_grad():
             template_results = _as_tuple(
-                core_fn(*step_inputs, *init_states, *lifted_args)
+                core_fn(*step_inputs, *temp_states, *lifted_args)
             )
         if len(template_results) != num_outputs + num_states:
             raise ValueError(
@@ -777,7 +785,7 @@ def lowerable_while_loop_scan_final_state(
         empty_outputs = tuple(
             _empty_output(i) for i in range(num_outputs)
         )
-        return (*empty_outputs, *init_states)
+        return (*empty_outputs, *(s.clone() for s in init_states))
 
     input_seqs = tuple(_ensure_contiguous(seq) for seq in input_seqs)
     init_states = tuple(_ensure_contiguous(state) for state in init_states)

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -68,7 +68,7 @@ Captured tensor freevars from ``core_fn`` are appended after the
 from __future__ import annotations
 import inspect
 import warnings
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional, Tuple, Union
 
 import torch
 import torch.utils._pytree as pytree
@@ -115,9 +115,7 @@ class FlexSNScan(HigherOrderOperator):
         num_states: int,
         num_outputs: int,
         *flat_args: torch.Tensor,
-        output_template_specs: Optional[
-            Tuple[Tuple, ...]
-        ] = None,
+        output_template_specs: Optional[OutputTemplateSpecs] = None,
     ) -> Tuple[torch.Tensor, ...]:
         return super().__call__(
             core_fn,
@@ -131,6 +129,11 @@ class FlexSNScan(HigherOrderOperator):
 
 flex_sn_scan = FlexSNScan()
 _DYNAMO_HOP_REGISTERED = False
+OutputTemplateSpec = Union[
+    Tuple[Tuple[int, ...], torch.dtype],
+    Tuple[Tuple[int, ...], torch.dtype, torch.device],
+]
+OutputTemplateSpecs = Tuple[OutputTemplateSpec, ...]
 
 
 def _as_tuple(outputs):
@@ -142,7 +145,7 @@ def _as_tuple(outputs):
 def _empty_outputs_from_template(
     input_seqs: Tuple[torch.Tensor, ...],
     num_outputs: int,
-    output_template_specs: Optional[Tuple[Tuple, ...]],
+    output_template_specs: Optional[OutputTemplateSpecs],
 ) -> Tuple[torch.Tensor, ...]:
     if output_template_specs is None:
         raise ValueError(
@@ -204,7 +207,7 @@ def _dynamo_leaf_example_value(value):
 def _output_template_specs_from_dynamo_body_result(
     body_result,
     num_outputs: int,
-) -> Optional[Tuple[Tuple, ...]]:
+) -> Optional[OutputTemplateSpecs]:
     leaves = _flatten_dynamo_body_result(body_result)
     if len(leaves) < num_outputs:
         return None
@@ -303,9 +306,7 @@ def eager_scan(
     num_states: int,
     num_outputs: int,
     *flat_args: torch.Tensor,
-    output_template_specs: Optional[
-        Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]
-    ] = None,
+    output_template_specs: Optional[OutputTemplateSpecs] = None,
 ) -> Tuple[torch.Tensor, ...]:
     """Plain-Python scan loop reused by both the HOP eager impl and the
     Dynamo-friendly path in :class:`FlexSN` (see ``backend="inductor"``).
@@ -379,9 +380,7 @@ def eager_scan_final_state(
     num_states: int,
     num_outputs: int,
     *flat_args: torch.Tensor,
-    output_template_specs: Optional[
-        Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]
-    ] = None,
+    output_template_specs: Optional[OutputTemplateSpecs] = None,
 ) -> Tuple[torch.Tensor, ...]:
     """Variant of :func:`eager_scan` that returns output sequences followed by
     final states only.
@@ -447,9 +446,7 @@ def lowerable_scan(
     num_states: int,
     num_outputs: int,
     *flat_args: torch.Tensor,
-    output_template_specs: Optional[
-        Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]
-    ] = None,
+    output_template_specs: Optional[OutputTemplateSpecs] = None,
 ) -> Tuple[torch.Tensor, ...]:
     """Run FlexSN scan through PyTorch's built-in ``scan`` HOP.
 
@@ -553,9 +550,7 @@ def lowerable_scan_final_state(
     num_states: int,
     num_outputs: int,
     *flat_args: torch.Tensor,
-    output_template_specs: Optional[
-        Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]
-    ] = None,
+    output_template_specs: Optional[OutputTemplateSpecs] = None,
 ) -> Tuple[torch.Tensor, ...]:
     if _torch_scan_op is None:
         raise RuntimeError("PyTorch scan HOP is unavailable in this environment")
@@ -666,9 +661,7 @@ def lowerable_while_loop_scan(
     num_states: int,
     num_outputs: int,
     *flat_args: torch.Tensor,
-    output_template_specs: Optional[
-        Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]
-    ] = None,
+    output_template_specs: Optional[OutputTemplateSpecs] = None,
 ) -> Tuple[torch.Tensor, ...]:
     """Run FlexSN scan through PyTorch's built-in ``while_loop`` HOP.
 
@@ -829,9 +822,7 @@ def lowerable_while_loop_scan_final_state(
     num_states: int,
     num_outputs: int,
     *flat_args: torch.Tensor,
-    output_template_specs: Optional[
-        Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]
-    ] = None,
+    output_template_specs: Optional[OutputTemplateSpecs] = None,
 ) -> Tuple[torch.Tensor, ...]:
     if _torch_while_loop is None:
         raise RuntimeError("PyTorch while_loop HOP is unavailable in this environment")
@@ -1020,8 +1011,21 @@ def _register_dynamo_hop() -> None:
         _ALLOW_FALLBACK_TO_EAGER = False
 
         def call_function(self, tx, args, kwargs):
+            output_template_specs_arg = kwargs.pop("output_template_specs", None)
             if kwargs:
-                raise hop_vars.unimplemented("flex_sn_scan does not support kwargs")
+                raise hop_vars.unimplemented(
+                    "flex_sn_scan only supports output_template_specs as a kwarg"
+                )
+            explicit_output_template_specs = None
+            if output_template_specs_arg is not None:
+                try:
+                    explicit_output_template_specs = (
+                        output_template_specs_arg.as_python_constant()
+                    )
+                except Exception:
+                    raise hop_vars.unimplemented(
+                        "flex_sn_scan output_template_specs must be a Python constant"
+                    )
 
             if len(args) < 4:
                 raise hop_vars.unimplemented(
@@ -1154,6 +1158,13 @@ def _register_dynamo_hop() -> None:
                 _body_r,
                 num_outputs,
             )
+            if explicit_output_template_specs is not None:
+                output_template_specs = explicit_output_template_specs
+            proxy_kwargs = (
+                {}
+                if output_template_specs is None
+                else {"output_template_specs": output_template_specs}
+            )
 
             proxy = tx.output.create_proxy(
                 "call_function",
@@ -1166,7 +1177,7 @@ def _register_dynamo_hop() -> None:
                     *(arg.as_proxy() for arg in flat_args),
                     *lifted_freevars,
                 ),
-                kwargs={"output_template_specs": output_template_specs},
+                kwargs=proxy_kwargs,
             )
             example_value = eager_scan(
                 body_gm,

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -452,6 +452,30 @@ def lowerable_scan_final_state(
     return (*output_seqs, *final_states)
 
 
+def _ensure_contiguous(tensor: torch.Tensor) -> torch.Tensor:
+    if tensor.dim() >= 4:
+        return tensor.clone(memory_format=torch.contiguous_format)
+    return tensor.contiguous()
+
+
+def _carry_device(*tensor_groups) -> torch.device:
+    for group in tensor_groups:
+        for tensor in group:
+            return tensor.device
+    return torch.device("cpu")
+
+
+def _append_to_tail(buffer: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
+    return torch.cat(
+        (buffer[1:], _ensure_contiguous(value).unsqueeze(0)),
+        dim=0,
+    ).contiguous()
+
+
+def _shift_input_queue(queue: torch.Tensor) -> torch.Tensor:
+    return torch.cat((queue[1:], queue[-1:].clone()), dim=0).contiguous()
+
+
 def lowerable_while_loop_scan(
     core_fn: Callable,
     num_inputs: int,
@@ -480,17 +504,6 @@ def lowerable_while_loop_scan(
     input_seqs = tuple(flat_args[:num_inputs])
     init_states = tuple(flat_args[num_inputs:expected])
     lifted_args = tuple(flat_args[expected:])
-
-    def _ensure_contiguous(tensor: torch.Tensor) -> torch.Tensor:
-        if tensor.dim() >= 4:
-            return tensor.clone(memory_format=torch.contiguous_format)
-        return tensor.contiguous()
-
-    def _carry_device(*tensor_groups) -> torch.device:
-        for group in tensor_groups:
-            for tensor in group:
-                return tensor.device
-        return torch.device("cpu")
 
     T = input_seqs[0].shape[0]
     for i, x in enumerate(input_seqs):
@@ -541,12 +554,6 @@ def lowerable_while_loop_scan(
 
     first_outputs = tuple(_ensure_contiguous(x) for x in first_results[:num_outputs])
     first_states = tuple(_ensure_contiguous(x) for x in first_results[num_outputs:])
-    def _append_to_tail(buffer: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
-        return torch.cat((buffer[1:], _ensure_contiguous(value).unsqueeze(0)), dim=0).contiguous()
-
-    def _shift_input_queue(queue: torch.Tensor) -> torch.Tensor:
-        return torch.cat((queue[1:], queue[-1:].clone()), dim=0).contiguous()
-
     output_buffers = tuple(
         _append_to_tail(out.new_zeros((T, *out.shape)), out) for out in first_outputs
     )
@@ -655,17 +662,6 @@ def lowerable_while_loop_scan_final_state(
     init_states = tuple(flat_args[num_inputs:expected])
     lifted_args = tuple(flat_args[expected:])
 
-    def _ensure_contiguous(tensor: torch.Tensor) -> torch.Tensor:
-        if tensor.dim() >= 4:
-            return tensor.clone(memory_format=torch.contiguous_format)
-        return tensor.contiguous()
-
-    def _carry_device(*tensor_groups) -> torch.device:
-        for group in tensor_groups:
-            for tensor in group:
-                return tensor.device
-        return torch.device("cpu")
-
     T = input_seqs[0].shape[0]
     for i, x in enumerate(input_seqs):
         if x.shape[0] != T:
@@ -711,12 +707,6 @@ def lowerable_while_loop_scan_final_state(
 
     first_outputs = tuple(_ensure_contiguous(x) for x in first_results[:num_outputs])
     first_states = tuple(_ensure_contiguous(x) for x in first_results[num_outputs:])
-
-    def _append_to_tail(buffer: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
-        return torch.cat((buffer[1:], _ensure_contiguous(value).unsqueeze(0)), dim=0).contiguous()
-
-    def _shift_input_queue(queue: torch.Tensor) -> torch.Tensor:
-        return torch.cat((queue[1:], queue[-1:].clone()), dim=0).contiguous()
 
     output_buffers = tuple(
         _append_to_tail(out.new_zeros((T, *out.shape)), out) for out in first_outputs
@@ -816,6 +806,9 @@ def _register_dynamo_hop() -> None:
     except (ImportError, ModuleNotFoundError, AttributeError):
         return
     except Exception as e:
+        # Import-time registration must never break package import on
+        # unsupported or drifting Torch internals; warn and leave the HOP
+        # available through its eager fallback instead.
         warnings.warn(
             f"FlexSN HOP Dynamo registration failed unexpectedly: {type(e).__name__}: {e}",
             stacklevel=2,

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -1181,15 +1181,36 @@ def _register_dynamo_hop() -> None:
                 ),
                 kwargs=proxy_kwargs,
             )
-            example_value = eager_scan(
-                body_gm,
-                num_inputs,
-                num_states,
-                num_outputs,
-                *(arg.as_proxy().node.meta["example_value"] for arg in flat_args),
-                *(freevar.node.meta["example_value"] for freevar in lifted_freevars),
-                output_template_specs=output_template_specs,
-            )
+            body_leaves = _flatten_dynamo_body_result(_body_r)
+            example_value = []
+            T = flat_args[0].as_proxy().node.meta["example_value"].shape[0]
+            for i in range(num_outputs + num_states):
+                if i >= len(body_leaves):
+                    example_value = None
+                    break
+                leaf_ev = _dynamo_leaf_example_value(body_leaves[i])
+                if not isinstance(leaf_ev, torch.Tensor):
+                    example_value = None
+                    break
+                example_value.append(leaf_ev.new_empty((T, *leaf_ev.shape)))
+            if example_value is None:
+                example_value = eager_scan(
+                    body_gm,
+                    num_inputs,
+                    num_states,
+                    num_outputs,
+                    *(
+                        arg.as_proxy().node.meta["example_value"]
+                        for arg in flat_args
+                    ),
+                    *(
+                        freevar.node.meta["example_value"]
+                        for freevar in lifted_freevars
+                    ),
+                    output_template_specs=output_template_specs,
+                )
+            else:
+                example_value = tuple(example_value)
             return wrap_fx_proxy(tx=tx, proxy=proxy, example_value=example_value)
 
     def patched_make(cls, value, source=None, **kwargs):

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -1107,6 +1107,9 @@ def _register_dynamo_hop() -> None:
         return original_make(cls, value, source=source, **kwargs)
 
     patched_make._spikingjelly_flexsn_hop = True
+    # Dynamo does not currently expose a public registry for this HOP hook.
+    # Patch only the flex_sn_scan dispatch and delegate every other operator
+    # back to PyTorch's original implementation.
     TorchHigherOrderOperatorVariable.make = classmethod(patched_make)
     _DYNAMO_HOP_REGISTERED = True
 

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -538,6 +538,11 @@ def lowerable_while_loop_scan(
         step_inputs = tuple(_ensure_contiguous(queue[0]) for queue in step_input_queues)
         results = core_fn(*step_inputs, *states, *lifted_args)
         results = tuple(results) if not isinstance(results, torch.Tensor) else (results,)
+        if len(results) != len(first_results):
+            raise ValueError(
+                f"core returned {len(results)} values at runtime, "
+                f"expected {len(first_results)}"
+            )
         outputs = tuple(_ensure_contiguous(x) for x in results[:num_outputs])
         next_states = tuple(_ensure_contiguous(x) for x in results[num_outputs:])
         next_pending_inputs = tuple(
@@ -545,11 +550,11 @@ def lowerable_while_loop_scan(
         )
         next_output_acc = tuple(
             _append_to_tail(buf, out)
-            for buf, out in zip(outputs_acc, outputs)
+            for buf, out in zip(outputs_acc, outputs, strict=True)
         )
         next_state_acc = tuple(
             _append_to_tail(buf, state)
-            for buf, state in zip(states_acc, next_states)
+            for buf, state in zip(states_acc, next_states, strict=True)
         )
         return (
             t + 1,
@@ -684,6 +689,11 @@ def lowerable_while_loop_scan_final_state(
         step_inputs = tuple(_ensure_contiguous(queue[0]) for queue in step_input_queues)
         results = core_fn(*step_inputs, *states, *lifted_args)
         results = tuple(results) if not isinstance(results, torch.Tensor) else (results,)
+        if len(results) != len(first_results):
+            raise ValueError(
+                f"core returned {len(results)} values at runtime, "
+                f"expected {len(first_results)}"
+            )
         outputs = tuple(_ensure_contiguous(x) for x in results[:num_outputs])
         next_states = tuple(_ensure_contiguous(x) for x in results[num_outputs:])
         next_pending_inputs = tuple(
@@ -691,7 +701,7 @@ def lowerable_while_loop_scan_final_state(
         )
         next_output_acc = tuple(
             _append_to_tail(buf, out)
-            for buf, out in zip(outputs_acc, outputs)
+            for buf, out in zip(outputs_acc, outputs, strict=True)
         )
         return (
             t + 1,

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -274,7 +274,7 @@ def eager_scan_final_state(
             return ref.new_empty((0, *ref.shape))
 
         empty_outputs = tuple(_empty_output(i) for i in range(num_outputs))
-        final_states = tuple(template_results[num_outputs:])
+        final_states = tuple(states)
         return (*empty_outputs, *final_states)
 
     output_buffers = [[] for _ in range(num_outputs)]
@@ -482,6 +482,8 @@ def lowerable_while_loop_scan(
     lifted_args = tuple(flat_args[expected:])
 
     def _ensure_contiguous(tensor: torch.Tensor) -> torch.Tensor:
+        if tensor.dim() >= 4:
+            return tensor.clone(memory_format=torch.contiguous_format)
         return tensor.contiguous()
 
     def _carry_device(*tensor_groups) -> torch.device:
@@ -648,6 +650,8 @@ def lowerable_while_loop_scan_final_state(
     lifted_args = tuple(flat_args[expected:])
 
     def _ensure_contiguous(tensor: torch.Tensor) -> torch.Tensor:
+        if tensor.dim() >= 4:
+            return tensor.clone(memory_format=torch.contiguous_format)
         return tensor.contiguous()
 
     def _carry_device(*tensor_groups) -> torch.device:
@@ -662,15 +666,20 @@ def lowerable_while_loop_scan_final_state(
             raise ValueError(f"input {i} has leading dim {x.shape[0]}, expected {T}")
 
     if T == 0:
+        step_inputs = tuple(x.new_empty(x.shape[1:]) for x in input_seqs)
+        with torch.no_grad():
+            template_results = _as_tuple(
+                core_fn(*step_inputs, *init_states, *lifted_args)
+            )
+        if len(template_results) != num_outputs + num_states:
+            raise ValueError(
+                f"core returned {len(template_results)} values, "
+                f"expected num_outputs + num_states "
+                f"= {num_outputs + num_states}"
+            )
+
         def _empty_output(i: int) -> torch.Tensor:
-            if i < len(init_states):
-                ref = init_states[i]
-            elif init_states:
-                ref = init_states[-1]
-            elif lifted_args:
-                ref = lifted_args[min(i, len(lifted_args) - 1)]
-            else:
-                ref = input_seqs[0].new_empty(input_seqs[0].shape[1:])
+            ref = template_results[i]
             return ref.new_empty((0, *ref.shape))
 
         empty_outputs = tuple(

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -817,7 +817,7 @@ def _register_dynamo_hop() -> None:
         return
     except Exception as e:
         warnings.warn(
-            f"FlexSN HOP Dynamo registration failed unexpectedly: {e}",
+            f"FlexSN HOP Dynamo registration failed unexpectedly: {type(e).__name__}: {e}",
             stacklevel=2,
         )
         return

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -250,6 +250,8 @@ def eager_scan_final_state(
                 ref = states[i]
             elif states:
                 ref = states[-1]
+            elif lifted_args:
+                ref = lifted_args[min(i, len(lifted_args) - 1)]
             else:
                 ref = inputs_seq[0].new_empty(inputs_seq[0].shape[1:])
             return ref.new_empty((0, *ref.shape))

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -122,6 +122,7 @@ class FlexSNScan(HigherOrderOperator):
 
 
 flex_sn_scan = FlexSNScan()
+_DYNAMO_HOP_REGISTERED = False
 
 
 def _as_tuple(outputs):
@@ -132,6 +133,10 @@ def _as_tuple(outputs):
 
 def lowerable_scan_available() -> bool:
     return _torch_scan_op is not None
+
+
+def dynamo_hop_available() -> bool:
+    return _DYNAMO_HOP_REGISTERED
 
 
 def lowerable_while_loop_available() -> bool:
@@ -862,6 +867,7 @@ flex_sn_scan.py_impl(torch._C.DispatchKey.Autograd)(eager_scan)
 
 
 def _register_dynamo_hop() -> None:
+    global _DYNAMO_HOP_REGISTERED
     try:
         from torch._dynamo.variables import higher_order_ops as hop_vars
         from torch._dynamo.variables.builder import wrap_fx_proxy
@@ -889,6 +895,7 @@ def _register_dynamo_hop() -> None:
         return
 
     if getattr(TorchHigherOrderOperatorVariable.make, "_spikingjelly_flexsn_hop", False):
+        _DYNAMO_HOP_REGISTERED = True
         return
 
     original_make = TorchHigherOrderOperatorVariable.make
@@ -1064,6 +1071,7 @@ def _register_dynamo_hop() -> None:
 
     patched_make._spikingjelly_flexsn_hop = True
     TorchHigherOrderOperatorVariable.make = staticmethod(patched_make)
+    _DYNAMO_HOP_REGISTERED = True
 
 
 _register_dynamo_hop()

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -161,7 +161,6 @@ def _register_dynamo_hop() -> None:
         )
         from torch._dynamo.variables.higher_order_ops import (
             TorchHigherOrderOperatorVariable,
-            add_subgraph,
             make_attr,
             speculate_subgraph,
         )
@@ -173,6 +172,11 @@ def _register_dynamo_hop() -> None:
         return
 
     original_make = TorchHigherOrderOperatorVariable.make
+
+    install_subgraph = getattr(hop_vars, "add_subgraph", None)
+    if install_subgraph is None:
+        def install_subgraph(tx, source, name, gm):
+            return tx.output.install_subgraph(name, gm)
 
     class FlexSNScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
         def call_function(self, tx, args, kwargs):
@@ -223,18 +227,31 @@ def _register_dynamo_hop() -> None:
             ]
             body_args = [*step_inputs, *flat_args[num_inputs:]]
 
-            graph_checkpoint, checkpoint = tx.output.graph, tx.copy_graphstate()
-            body_r, body_graph, body_lifted_freevars = speculate_subgraph(
-                tx,
-                body_fn,
-                body_args,
-                {},
-                graph_checkpoint,
-                checkpoint,
-                "flex_sn_scan",
-            )
+            if "source_target" in getattr(speculate_subgraph, "__code__").co_varnames:
+                body_r, body_graph, body_lifted_freevars = speculate_subgraph(
+                    tx,
+                    body_fn,
+                    body_args,
+                    {},
+                    "flex_sn_scan",
+                    source_target=self.value,
+                )
+            else:
+                graph_checkpoint, checkpoint = tx.output.graph, tx.copy_graphstate()
+                body_r, body_graph, body_lifted_freevars = speculate_subgraph(
+                    tx,
+                    body_fn,
+                    body_args,
+                    {},
+                    graph_checkpoint,
+                    checkpoint,
+                    "flex_sn_scan",
+                )
 
-            lifted_freevars = tuple(body_lifted_freevars.keys())
+            if hasattr(body_lifted_freevars, "keys"):
+                lifted_freevars = tuple(body_lifted_freevars.keys())
+            else:
+                lifted_freevars = tuple(body_lifted_freevars)
             if lifted_freevars and not all(
                 isinstance(freevar, torch.fx.Proxy) for freevar in lifted_freevars
             ):
@@ -243,7 +260,7 @@ def _register_dynamo_hop() -> None:
                 )
 
             body_gm = torch.fx.GraphModule(tx.output.nn_modules, body_graph)
-            body_name = add_subgraph(tx, self.source, "flex_sn_scan_body", body_gm)
+            body_name = install_subgraph(tx, self.source, "flex_sn_scan_body", body_gm)
             body_node = make_attr(tx, body_name)
 
             proxy = tx.output.create_proxy(

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -675,13 +675,23 @@ def lowerable_while_loop_scan(
         next_pending_inputs = tuple(
             _shift_input_queue(queue) for queue in step_input_queues
         )
+        if len(outputs_acc) != len(outputs):
+            raise ValueError(
+                f"core returned {len(outputs)} outputs at runtime, "
+                f"expected {len(outputs_acc)}"
+            )
         next_output_acc = tuple(
             _append_to_tail(buf, out)
-            for buf, out in zip(outputs_acc, outputs, strict=True)
+            for buf, out in zip(outputs_acc, outputs)
         )
+        if len(states_acc) != len(next_states):
+            raise ValueError(
+                f"core returned {len(next_states)} states at runtime, "
+                f"expected {len(states_acc)}"
+            )
         next_state_acc = tuple(
             _append_to_tail(buf, state)
-            for buf, state in zip(states_acc, next_states, strict=True)
+            for buf, state in zip(states_acc, next_states)
         )
         return (
             t + 1,
@@ -824,9 +834,14 @@ def lowerable_while_loop_scan_final_state(
         next_pending_inputs = tuple(
             _shift_input_queue(queue) for queue in step_input_queues
         )
+        if len(outputs_acc) != len(outputs):
+            raise ValueError(
+                f"core returned {len(outputs)} outputs at runtime, "
+                f"expected {len(outputs_acc)}"
+            )
         next_output_acc = tuple(
             _append_to_tail(buf, out)
-            for buf, out in zip(outputs_acc, outputs, strict=True)
+            for buf, out in zip(outputs_acc, outputs)
         )
         return (
             t + 1,

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -68,7 +68,7 @@ Captured tensor freevars from ``core_fn`` are appended after the
 from __future__ import annotations
 import inspect
 import warnings
-from typing import Callable, Tuple
+from typing import Callable, Optional, Tuple
 
 import torch
 import torch.utils._pytree as pytree
@@ -129,6 +129,28 @@ def _as_tuple(outputs):
     if isinstance(outputs, torch.Tensor):
         return (outputs,)
     return tuple(outputs)
+
+
+def _empty_outputs_from_template(
+    input_seqs: Tuple[torch.Tensor, ...],
+    num_outputs: int,
+    output_template_specs: Optional[Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]],
+) -> Tuple[torch.Tensor, ...]:
+    if output_template_specs is None:
+        raise ValueError(
+            "FlexSN HOP empty scans require output_template_specs so output "
+            "shapes and dtypes can be built without executing core_fn."
+        )
+    if len(output_template_specs) != num_outputs:
+        raise ValueError(
+            f"expected {num_outputs} output template specs, got "
+            f"{len(output_template_specs)}"
+        )
+    device = input_seqs[0].device
+    return tuple(
+        torch.empty((0, *shape), dtype=dtype, device=device)
+        for shape, dtype in output_template_specs
+    )
 
 
 def lowerable_scan_available() -> bool:
@@ -215,6 +237,9 @@ def eager_scan(
     num_states: int,
     num_outputs: int,
     *flat_args: torch.Tensor,
+    output_template_specs: Optional[
+        Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]
+    ] = None,
 ) -> Tuple[torch.Tensor, ...]:
     """Plain-Python scan loop reused by both the HOP eager impl and the
     Dynamo-friendly path in :class:`FlexSN` (see ``backend="inductor"``).
@@ -247,27 +272,12 @@ def eager_scan(
             )
 
     if T == 0:
-        step_inputs = tuple(x.new_empty(x.shape[1:]) for x in inputs_seq)
-        temp_states = [s.clone() for s in states]
-        with torch.no_grad():
-            template_results = _as_tuple(
-                core_fn(*step_inputs, *temp_states, *lifted_args)
-            )
-        if len(template_results) != num_outputs + num_states:
-            raise ValueError(
-                f"core returned {len(template_results)} values, "
-                f"expected num_outputs + num_states "
-                f"= {num_outputs + num_states}"
-            )
-
-        def _empty_output(i: int) -> torch.Tensor:
-            ref = template_results[i]
-            return ref.new_empty((0, *ref.shape))
-
-        empty_outputs = tuple(_empty_output(i) for i in range(num_outputs))
+        empty_outputs = _empty_outputs_from_template(
+            inputs_seq, num_outputs, output_template_specs
+        )
         empty_states = tuple(
             state.new_empty((0, *state.shape))
-            for state in template_results[num_outputs:]
+            for state in states
         )
         return (*empty_outputs, *empty_states)
 
@@ -303,6 +313,9 @@ def eager_scan_final_state(
     num_states: int,
     num_outputs: int,
     *flat_args: torch.Tensor,
+    output_template_specs: Optional[
+        Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]
+    ] = None,
 ) -> Tuple[torch.Tensor, ...]:
     """Variant of :func:`eager_scan` that returns output sequences followed by
     final states only.
@@ -334,24 +347,9 @@ def eager_scan_final_state(
             )
 
     if T == 0:
-        step_inputs = tuple(x.new_empty(x.shape[1:]) for x in inputs_seq)
-        temp_states = [s.clone() for s in states]
-        with torch.no_grad():
-            template_results = _as_tuple(
-                core_fn(*step_inputs, *temp_states, *lifted_args)
-            )
-        if len(template_results) != num_outputs + num_states:
-            raise ValueError(
-                f"core returned {len(template_results)} values, "
-                f"expected num_outputs + num_states "
-                f"= {num_outputs + num_states}"
-            )
-
-        def _empty_output(i: int) -> torch.Tensor:
-            ref = template_results[i]
-            return ref.new_empty((0, *ref.shape))
-
-        empty_outputs = tuple(_empty_output(i) for i in range(num_outputs))
+        empty_outputs = _empty_outputs_from_template(
+            inputs_seq, num_outputs, output_template_specs
+        )
         final_states = tuple(s.clone() for s in states)
         return (*empty_outputs, *final_states)
 
@@ -383,6 +381,9 @@ def lowerable_scan(
     num_states: int,
     num_outputs: int,
     *flat_args: torch.Tensor,
+    output_template_specs: Optional[
+        Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]
+    ] = None,
 ) -> Tuple[torch.Tensor, ...]:
     """Run FlexSN scan through PyTorch's built-in ``scan`` HOP.
 
@@ -424,25 +425,12 @@ def lowerable_scan(
             )
 
     if T == 0:
-        step_inputs = tuple(x.new_empty(x.shape[1:]) for x in input_seqs)
-        temp_states = [s.clone() for s in init_states]
-        with torch.no_grad():
-            template_results = _as_tuple(
-                core_fn(*step_inputs, *temp_states, *lifted_args)
-            )
-        if len(template_results) != num_outputs + num_states:
-            raise ValueError(
-                f"core returned {len(template_results)} values, "
-                f"expected num_outputs + num_states "
-                f"= {num_outputs + num_states}"
-            )
-        empty_outputs = tuple(
-            template_results[i].new_empty((0, *template_results[i].shape))
-            for i in range(num_outputs)
+        empty_outputs = _empty_outputs_from_template(
+            input_seqs, num_outputs, output_template_specs
         )
         empty_states = tuple(
             state.new_empty((0, *state.shape))
-            for state in template_results[num_outputs:]
+            for state in init_states
         )
         return (*empty_outputs, *empty_states)
 
@@ -497,6 +485,9 @@ def lowerable_scan_final_state(
     num_states: int,
     num_outputs: int,
     *flat_args: torch.Tensor,
+    output_template_specs: Optional[
+        Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]
+    ] = None,
 ) -> Tuple[torch.Tensor, ...]:
     if _torch_scan_op is None:
         raise RuntimeError("PyTorch scan HOP is unavailable in this environment")
@@ -524,21 +515,8 @@ def lowerable_scan_final_state(
             )
 
     if T == 0:
-        step_inputs = tuple(x.new_empty(x.shape[1:]) for x in input_seqs)
-        temp_states = [s.clone() for s in init_states]
-        with torch.no_grad():
-            template_results = _as_tuple(
-                core_fn(*step_inputs, *temp_states, *lifted_args)
-            )
-        if len(template_results) != num_outputs + num_states:
-            raise ValueError(
-                f"core returned {len(template_results)} values, "
-                f"expected num_outputs + num_states "
-                f"= {num_outputs + num_states}"
-            )
-        empty_outputs = tuple(
-            template_results[i].new_empty((0, *template_results[i].shape))
-            for i in range(num_outputs)
+        empty_outputs = _empty_outputs_from_template(
+            input_seqs, num_outputs, output_template_specs
         )
         final_states = tuple(s.clone() for s in init_states)
         return (*empty_outputs, *final_states)
@@ -619,6 +597,9 @@ def lowerable_while_loop_scan(
     num_states: int,
     num_outputs: int,
     *flat_args: torch.Tensor,
+    output_template_specs: Optional[
+        Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]
+    ] = None,
 ) -> Tuple[torch.Tensor, ...]:
     """Run FlexSN scan through PyTorch's built-in ``while_loop`` HOP.
 
@@ -654,29 +635,12 @@ def lowerable_while_loop_scan(
             raise ValueError(f"input {i} has leading dim {x.shape[0]}, expected {T}")
 
     if T == 0:
-        step_inputs = tuple(x.new_empty(x.shape[1:]) for x in input_seqs)
-        temp_states = [s.clone() for s in init_states]
-        with torch.no_grad():
-            template_results = _as_tuple(
-                core_fn(*step_inputs, *temp_states, *lifted_args)
-            )
-        if len(template_results) != num_outputs + num_states:
-            raise ValueError(
-                f"core returned {len(template_results)} values, "
-                f"expected num_outputs + num_states "
-                f"= {num_outputs + num_states}"
-            )
-
-        def _empty_output(i: int) -> torch.Tensor:
-            ref = template_results[i]
-            return ref.new_empty((0, *ref.shape))
-
-        empty_outputs = tuple(
-            _empty_output(i) for i in range(num_outputs)
+        empty_outputs = _empty_outputs_from_template(
+            input_seqs, num_outputs, output_template_specs
         )
         empty_states = tuple(
             state.new_empty((0, *state.shape))
-            for state in template_results[num_outputs:]
+            for state in init_states
         )
         return (*empty_outputs, *empty_states)
 
@@ -796,6 +760,9 @@ def lowerable_while_loop_scan_final_state(
     num_states: int,
     num_outputs: int,
     *flat_args: torch.Tensor,
+    output_template_specs: Optional[
+        Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]
+    ] = None,
 ) -> Tuple[torch.Tensor, ...]:
     if _torch_while_loop is None:
         raise RuntimeError("PyTorch while_loop HOP is unavailable in this environment")
@@ -822,25 +789,8 @@ def lowerable_while_loop_scan_final_state(
             raise ValueError(f"input {i} has leading dim {x.shape[0]}, expected {T}")
 
     if T == 0:
-        step_inputs = tuple(x.new_empty(x.shape[1:]) for x in input_seqs)
-        temp_states = [s.clone() for s in init_states]
-        with torch.no_grad():
-            template_results = _as_tuple(
-                core_fn(*step_inputs, *temp_states, *lifted_args)
-            )
-        if len(template_results) != num_outputs + num_states:
-            raise ValueError(
-                f"core returned {len(template_results)} values, "
-                f"expected num_outputs + num_states "
-                f"= {num_outputs + num_states}"
-            )
-
-        def _empty_output(i: int) -> torch.Tensor:
-            ref = template_results[i]
-            return ref.new_empty((0, *ref.shape))
-
-        empty_outputs = tuple(
-            _empty_output(i) for i in range(num_outputs)
+        empty_outputs = _empty_outputs_from_template(
+            input_seqs, num_outputs, output_template_specs
         )
         return (*empty_outputs, *(s.clone() for s in init_states))
 

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -416,6 +416,36 @@ def lowerable_scan(
     lifted_args = tuple(flat_args[expected:])
     _check_lifted_arg_arity(core_fn, num_inputs, num_states, lifted_args)
 
+    T = input_seqs[0].shape[0]
+    for i, x in enumerate(input_seqs):
+        if x.shape[0] != T:
+            raise ValueError(
+                f"input {i} has leading dim {x.shape[0]}, expected {T}"
+            )
+
+    if T == 0:
+        step_inputs = tuple(x.new_empty(x.shape[1:]) for x in input_seqs)
+        temp_states = [s.clone() for s in init_states]
+        with torch.no_grad():
+            template_results = _as_tuple(
+                core_fn(*step_inputs, *temp_states, *lifted_args)
+            )
+        if len(template_results) != num_outputs + num_states:
+            raise ValueError(
+                f"core returned {len(template_results)} values, "
+                f"expected num_outputs + num_states "
+                f"= {num_outputs + num_states}"
+            )
+        empty_outputs = tuple(
+            template_results[i].new_empty((0, *template_results[i].shape))
+            for i in range(num_outputs)
+        )
+        empty_states = tuple(
+            state.new_empty((0, *state.shape))
+            for state in template_results[num_outputs:]
+        )
+        return (*empty_outputs, *empty_states)
+
     def combine_fn(carry, step_inputs, additional_inputs):
         carry = tuple(carry)
         step_inputs = tuple(step_inputs)
@@ -485,6 +515,33 @@ def lowerable_scan_final_state(
     init_states = flat_args[num_inputs:expected]
     lifted_args = tuple(flat_args[expected:])
     _check_lifted_arg_arity(core_fn, num_inputs, num_states, lifted_args)
+
+    T = input_seqs[0].shape[0]
+    for i, x in enumerate(input_seqs):
+        if x.shape[0] != T:
+            raise ValueError(
+                f"input {i} has leading dim {x.shape[0]}, expected {T}"
+            )
+
+    if T == 0:
+        step_inputs = tuple(x.new_empty(x.shape[1:]) for x in input_seqs)
+        temp_states = [s.clone() for s in init_states]
+        with torch.no_grad():
+            template_results = _as_tuple(
+                core_fn(*step_inputs, *temp_states, *lifted_args)
+            )
+        if len(template_results) != num_outputs + num_states:
+            raise ValueError(
+                f"core returned {len(template_results)} values, "
+                f"expected num_outputs + num_states "
+                f"= {num_outputs + num_states}"
+            )
+        empty_outputs = tuple(
+            template_results[i].new_empty((0, *template_results[i].shape))
+            for i in range(num_outputs)
+        )
+        final_states = tuple(s.clone() for s in init_states)
+        return (*empty_outputs, *final_states)
 
     def combine_fn(carry, step_inputs, additional_inputs):
         carry = tuple(carry)

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -561,6 +561,10 @@ def lowerable_while_loop_scan(
 
     This is an explicit research helper for probing whether a first-class loop
     representation is a better fit than the current unrolled scan path.
+    Current PyTorch while-loop capture does not support indexing input
+    sequences by the symbolic loop counter in this path, so the implementation
+    keeps functional queue buffers. Prefer ``lowerable_scan`` for performance
+    experiments on long sequences.
     """
     if _torch_while_loop is None:
         raise RuntimeError("PyTorch while_loop HOP is unavailable in this environment")
@@ -637,9 +641,7 @@ def lowerable_while_loop_scan(
         _append_to_tail(state.new_zeros((T, *state.shape)), state)
         for state in first_states
     )
-    pending_inputs = tuple(
-        _shift_input_queue(seq) for seq in input_seqs
-    )
+    pending_inputs = tuple(_shift_input_queue(seq) for seq in input_seqs)
 
     t0 = torch.tensor(
         1,
@@ -681,8 +683,8 @@ def lowerable_while_loop_scan(
                 f"expected {len(outputs_acc)}"
             )
         next_output_acc = tuple(
-            _append_to_tail(buf, out)
-            for buf, out in zip(outputs_acc, outputs)
+            _append_to_tail(outputs_acc[i], outputs[i])
+            for i in range(len(outputs_acc))
         )
         if len(states_acc) != len(next_states):
             raise ValueError(
@@ -690,8 +692,8 @@ def lowerable_while_loop_scan(
                 f"expected {len(states_acc)}"
             )
         next_state_acc = tuple(
-            _append_to_tail(buf, state)
-            for buf, state in zip(states_acc, next_states)
+            _append_to_tail(states_acc[i], next_states[i])
+            for i in range(len(states_acc))
         )
         return (
             t + 1,
@@ -840,8 +842,8 @@ def lowerable_while_loop_scan_final_state(
                 f"expected {len(outputs_acc)}"
             )
         next_output_acc = tuple(
-            _append_to_tail(buf, out)
-            for buf, out in zip(outputs_acc, outputs)
+            _append_to_tail(outputs_acc[i], outputs[i])
+            for i in range(len(outputs_acc))
         )
         return (
             t + 1,

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -125,6 +125,12 @@ class FlexSNScan(HigherOrderOperator):
 flex_sn_scan = FlexSNScan()
 
 
+def _as_tuple(outputs):
+    if isinstance(outputs, torch.Tensor):
+        return (outputs,)
+    return tuple(outputs)
+
+
 def lowerable_scan_available() -> bool:
     return _torch_scan_op is not None and _wrap_scan_combine_fn_flat is not None
 
@@ -170,19 +176,25 @@ def eager_scan(
             )
 
     if T == 0:
+        step_inputs = tuple(x.new_empty(x.shape[1:]) for x in inputs_seq)
+        with torch.no_grad():
+            template_results = _as_tuple(core_fn(*step_inputs, *states, *lifted_args))
+        if len(template_results) != num_outputs + num_states:
+            raise ValueError(
+                f"core returned {len(template_results)} values, "
+                f"expected num_outputs + num_states "
+                f"= {num_outputs + num_states}"
+            )
+
         def _empty_output(i: int) -> torch.Tensor:
-            if i < len(states):
-                ref = states[i]
-            elif states:
-                ref = states[-1]
-            elif lifted_args:
-                ref = lifted_args[min(i, len(lifted_args) - 1)]
-            else:
-                ref = inputs_seq[0].new_empty(inputs_seq[0].shape[1:])
+            ref = template_results[i]
             return ref.new_empty((0, *ref.shape))
 
         empty_outputs = tuple(_empty_output(i) for i in range(num_outputs))
-        empty_states = tuple(state.new_empty((0, *state.shape)) for state in states)
+        empty_states = tuple(
+            state.new_empty((0, *state.shape))
+            for state in template_results[num_outputs:]
+        )
         return (*empty_outputs, *empty_states)
 
     output_buffers = [[] for _ in range(num_outputs)]
@@ -247,19 +259,23 @@ def eager_scan_final_state(
             )
 
     if T == 0:
+        step_inputs = tuple(x.new_empty(x.shape[1:]) for x in inputs_seq)
+        with torch.no_grad():
+            template_results = _as_tuple(core_fn(*step_inputs, *states, *lifted_args))
+        if len(template_results) != num_outputs + num_states:
+            raise ValueError(
+                f"core returned {len(template_results)} values, "
+                f"expected num_outputs + num_states "
+                f"= {num_outputs + num_states}"
+            )
+
         def _empty_output(i: int) -> torch.Tensor:
-            if i < len(states):
-                ref = states[i]
-            elif states:
-                ref = states[-1]
-            elif lifted_args:
-                ref = lifted_args[min(i, len(lifted_args) - 1)]
-            else:
-                ref = inputs_seq[0].new_empty(inputs_seq[0].shape[1:])
+            ref = template_results[i]
             return ref.new_empty((0, *ref.shape))
 
         empty_outputs = tuple(_empty_output(i) for i in range(num_outputs))
-        return (*empty_outputs, *tuple(states))
+        final_states = tuple(template_results[num_outputs:])
+        return (*empty_outputs, *final_states)
 
     output_buffers = [[] for _ in range(num_outputs)]
 

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -726,9 +726,9 @@ def _register_dynamo_hop() -> None:
             ]
             flat_args = args[4:]
             expected = num_inputs + num_states
-            if len(flat_args) != expected:
+            if len(flat_args) < expected:
                 raise hop_vars.unimplemented(
-                    f"flex_sn_scan expected {expected} tensor args, got {len(flat_args)}"
+                    f"flex_sn_scan expected at least {expected} tensor args, got {len(flat_args)}"
                 )
             if num_inputs == 0:
                 raise hop_vars.unimplemented(
@@ -741,10 +741,25 @@ def _register_dynamo_hop() -> None:
 
             from torch._dynamo.variables.constant import ConstantVariable as _ConstantVariable
 
-            step_inputs = [
-                arg.call_method(tx, "__getitem__", [_ConstantVariable(0)], {})
-                for arg in flat_args[:num_inputs]
-            ]
+            def _make_step_template(arg: TensorVariable):
+                example_value = arg.as_proxy().node.meta["example_value"]
+                if example_value.shape[0] > 0:
+                    return arg.call_method(tx, "__getitem__", [_ConstantVariable(0)], {})
+
+                shape_without_t = tuple(example_value.shape[1:])
+                proxy = tx.output.create_proxy(
+                    "call_function",
+                    torch.ops.aten.new_empty.default,
+                    args=(arg.as_proxy(), shape_without_t),
+                    kwargs={},
+                )
+                return wrap_fx_proxy(
+                    tx=tx,
+                    proxy=proxy,
+                    example_value=example_value.new_empty(shape_without_t),
+                )
+
+            step_inputs = [_make_step_template(arg) for arg in flat_args[:num_inputs]]
             body_args = [*step_inputs, *flat_args[num_inputs:]]
 
             if "source_target" in getattr(speculate_subgraph, "__code__").co_varnames:

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -543,6 +543,7 @@ def lowerable_scan(
         additional_inputs=lifted_args,
     )
     result = tuple(result)
+    # PyTorch scan returns final carry first, followed by the stacked outputs.
     return result[num_states:]
 
 
@@ -629,6 +630,7 @@ def lowerable_scan_final_state(
         additional_inputs=lifted_args,
     )
     result = tuple(result)
+    # PyTorch scan returns final carry first; keep that as the final states.
     final_states = result[:num_states]
     output_seqs = result[num_states:]
     return (*output_seqs, *final_states)

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -67,6 +67,7 @@ Captured tensor freevars from ``core_fn`` are appended after the
 """
 from __future__ import annotations
 import functools
+import warnings
 from typing import Callable, Tuple
 
 import torch
@@ -759,7 +760,13 @@ def _register_dynamo_hop() -> None:
             speculate_subgraph,
         )
         from torch._dynamo.variables.tensor import TensorVariable
-    except Exception:
+    except (ImportError, ModuleNotFoundError, AttributeError):
+        return
+    except Exception as e:
+        warnings.warn(
+            f"FlexSN HOP Dynamo registration failed unexpectedly: {e}",
+            stacklevel=2,
+        )
         return
 
     if getattr(TorchHigherOrderOperatorVariable.make, "_spikingjelly_flexsn_hop", False):

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -29,6 +29,9 @@ Usage::
     # returns: (*output_seqs, *state_seqs) — each with shape [T, ...]
     result = flex_sn_scan(core_fn, num_inputs, num_states, num_outputs,
                          *inputs_seq, *init_states)
+
+Captured tensor freevars from ``core_fn`` are appended after the
+``[*inputs_seq, *init_states]`` segment when Dynamo rewrites the HOP call.
 """
 from __future__ import annotations
 
@@ -51,7 +54,8 @@ class FlexSNScan(HigherOrderOperator):
       partition the flat tensor args.
     * ``flat_args``: first ``num_inputs`` tensors are input sequences with
       leading time dim ``T``; the next ``num_states`` tensors are initial
-      states (no time dim).
+      states (no time dim); any remaining tensors are lifted freevars that are
+      passed through to ``core_fn`` unchanged at every time step.
 
     Return: ``num_outputs`` output sequences followed by ``num_states`` state
     sequences, all stacked along the leading time dim.
@@ -91,15 +95,16 @@ def eager_scan(
     loop into an FX graph that Inductor can lower normally.
     """
     expected = num_inputs + num_states
-    if len(flat_args) != expected:
+    if len(flat_args) < expected:
         raise ValueError(
-            f"flex_sn_scan expected {expected} tensor args "
+            f"flex_sn_scan expected at least {expected} tensor args "
             f"(num_inputs={num_inputs} + num_states={num_states}), "
             f"got {len(flat_args)}"
         )
 
     inputs_seq = flat_args[:num_inputs]
-    states = list(flat_args[num_inputs:])
+    states = list(flat_args[num_inputs:expected])
+    lifted_args = tuple(flat_args[expected:])
 
     if num_inputs == 0:
         raise ValueError("flex_sn_scan requires at least one input sequence")
@@ -116,7 +121,7 @@ def eager_scan(
 
     for t in range(T):
         step_inputs = tuple(x[t] for x in inputs_seq)
-        results = core_fn(*step_inputs, *states)
+        results = core_fn(*step_inputs, *states, *lifted_args)
         if len(results) != num_outputs + num_states:
             raise ValueError(
                 f"core returned {len(results)} values, "
@@ -229,9 +234,12 @@ def _register_dynamo_hop() -> None:
                 "flex_sn_scan",
             )
 
-            if body_lifted_freevars:
+            lifted_freevars = tuple(body_lifted_freevars.keys())
+            if lifted_freevars and not all(
+                isinstance(freevar, torch.fx.Proxy) for freevar in lifted_freevars
+            ):
                 raise hop_vars.unimplemented(
-                    "flex_sn_scan with lifted freevars is not supported yet"
+                    "flex_sn_scan only supports tensor lifted freevars"
                 )
 
             body_gm = torch.fx.GraphModule(tx.output.nn_modules, body_graph)
@@ -247,6 +255,7 @@ def _register_dynamo_hop() -> None:
                     num_states,
                     num_outputs,
                     *(arg.as_proxy() for arg in flat_args),
+                    *lifted_freevars,
                 ),
                 kwargs={},
             )
@@ -256,6 +265,7 @@ def _register_dynamo_hop() -> None:
                 num_states,
                 num_outputs,
                 *(arg.as_proxy().node.meta["example_value"] for arg in flat_args),
+                *(freevar.node.meta["example_value"] for freevar in lifted_freevars),
             )
             return wrap_fx_proxy(tx=tx, proxy=proxy, example_value=example_value)
 

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -191,6 +191,8 @@ def eager_scan(
     for t in range(T):
         step_inputs = tuple(x[t] for x in inputs_seq)
         results = core_fn(*step_inputs, *states, *lifted_args)
+        if not isinstance(results, (tuple, list)):
+            results = (results,)
         if len(results) != num_outputs + num_states:
             raise ValueError(
                 f"core returned {len(results)} values, "
@@ -264,6 +266,8 @@ def eager_scan_final_state(
     for t in range(T):
         step_inputs = tuple(x[t] for x in inputs_seq)
         results = core_fn(*step_inputs, *states, *lifted_args)
+        if not isinstance(results, (tuple, list)):
+            results = (results,)
         if len(results) != num_outputs + num_states:
             raise ValueError(
                 f"core returned {len(results)} values, "

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -147,6 +147,8 @@ def _empty_outputs_from_template(
     num_outputs: int,
     output_template_specs: Optional[OutputTemplateSpecs],
 ) -> Tuple[torch.Tensor, ...]:
+    if num_outputs == 0:
+        return ()
     if output_template_specs is None:
         raise ValueError(
             "FlexSN HOP empty scans require output_template_specs so output "

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -143,3 +143,129 @@ flex_sn_scan.py_impl(torch._C.DispatchKey.CompositeExplicitAutograd)(eager_scan)
 # full BPTT graph. AOTAutograd (``aot_function`` / ``make_fx``) traces this
 # graph natively by unrolling; see module docstring.
 flex_sn_scan.py_impl(torch._C.DispatchKey.Autograd)(eager_scan)
+
+
+def _register_dynamo_hop() -> None:
+    try:
+        from torch._dynamo.variables import higher_order_ops as hop_vars
+        from torch._dynamo.variables.builder import wrap_fx_proxy
+        from torch._dynamo.variables.constant import ConstantVariable
+        from torch._dynamo.variables.functions import (
+            NestedUserFunctionVariable,
+            UserFunctionVariable,
+        )
+        from torch._dynamo.variables.higher_order_ops import (
+            TorchHigherOrderOperatorVariable,
+            add_subgraph,
+            make_attr,
+            speculate_subgraph,
+        )
+        from torch._dynamo.variables.tensor import TensorVariable
+    except Exception:
+        return
+
+    if getattr(TorchHigherOrderOperatorVariable.make, "_spikingjelly_flexsn_hop", False):
+        return
+
+    original_make = TorchHigherOrderOperatorVariable.make
+
+    class FlexSNScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
+        def call_function(self, tx, args, kwargs):
+            if kwargs:
+                raise hop_vars.unimplemented("flex_sn_scan does not support kwargs")
+
+            if len(args) < 4:
+                raise hop_vars.unimplemented(
+                    "flex_sn_scan expects body_fn, num_inputs, num_states, "
+                    "num_outputs, and tensor arguments"
+                )
+
+            body_fn = args[0]
+            if not isinstance(body_fn, (UserFunctionVariable, NestedUserFunctionVariable)):
+                raise hop_vars.unimplemented(
+                    "flex_sn_scan expects a user-defined Python function body"
+                )
+
+            const_args = args[1:4]
+            if not all(isinstance(arg, ConstantVariable) for arg in const_args):
+                raise hop_vars.unimplemented(
+                    "flex_sn_scan expects num_inputs/num_states/num_outputs to be constants"
+                )
+
+            num_inputs, num_states, num_outputs = [
+                arg.as_python_constant() for arg in const_args
+            ]
+            flat_args = args[4:]
+            expected = num_inputs + num_states
+            if len(flat_args) != expected:
+                raise hop_vars.unimplemented(
+                    f"flex_sn_scan expected {expected} tensor args, got {len(flat_args)}"
+                )
+            if num_inputs == 0:
+                raise hop_vars.unimplemented(
+                    "flex_sn_scan requires at least one input sequence"
+                )
+            if not all(isinstance(arg, TensorVariable) for arg in flat_args):
+                raise hop_vars.unimplemented(
+                    "flex_sn_scan only supports tensor inputs and states"
+                )
+
+            from torch._dynamo.variables.constant import ConstantVariable as _ConstantVariable
+
+            step_inputs = [
+                arg.call_method(tx, "__getitem__", [_ConstantVariable(0)], {})
+                for arg in flat_args[:num_inputs]
+            ]
+            body_args = [*step_inputs, *flat_args[num_inputs:]]
+
+            graph_checkpoint, checkpoint = tx.output.graph, tx.copy_graphstate()
+            body_r, body_graph, body_lifted_freevars = speculate_subgraph(
+                tx,
+                body_fn,
+                body_args,
+                {},
+                graph_checkpoint,
+                checkpoint,
+                "flex_sn_scan",
+            )
+
+            if body_lifted_freevars:
+                raise hop_vars.unimplemented(
+                    "flex_sn_scan with lifted freevars is not supported yet"
+                )
+
+            body_gm = torch.fx.GraphModule(tx.output.nn_modules, body_graph)
+            body_name = add_subgraph(tx, self.source, "flex_sn_scan_body", body_gm)
+            body_node = make_attr(tx, body_name)
+
+            proxy = tx.output.create_proxy(
+                "call_function",
+                self.value,
+                args=(
+                    body_node,
+                    num_inputs,
+                    num_states,
+                    num_outputs,
+                    *(arg.as_proxy() for arg in flat_args),
+                ),
+                kwargs={},
+            )
+            example_value = eager_scan(
+                body_gm,
+                num_inputs,
+                num_states,
+                num_outputs,
+                *(arg.as_proxy().node.meta["example_value"] for arg in flat_args),
+            )
+            return wrap_fx_proxy(tx=tx, proxy=proxy, example_value=example_value)
+
+    def patched_make(value, source=None, **kwargs):
+        if value is flex_sn_scan:
+            return FlexSNScanHigherOrderVariable(value, source, **kwargs)
+        return original_make(value, source=source, **kwargs)
+
+    patched_make._spikingjelly_flexsn_hop = True
+    TorchHigherOrderOperatorVariable.make = staticmethod(patched_make)
+
+
+_register_dynamo_hop()

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -193,6 +193,61 @@ def eager_scan(
     return (*output_seqs, *state_seqs)
 
 
+def eager_scan_final_state(
+    core_fn: Callable,
+    num_inputs: int,
+    num_states: int,
+    num_outputs: int,
+    *flat_args: torch.Tensor,
+) -> Tuple[torch.Tensor, ...]:
+    """Variant of :func:`eager_scan` that returns output sequences followed by
+    final states only.
+
+    This is used by :class:`FlexSN` when ``store_state_seqs=False`` so the HOP
+    backend does not materialize full state sequences only to discard them.
+    """
+    expected = num_inputs + num_states
+    if len(flat_args) < expected:
+        raise ValueError(
+            f"flex_sn_scan expected at least {expected} tensor args "
+            f"(num_inputs={num_inputs} + num_states={num_states}), "
+            f"got {len(flat_args)}"
+        )
+
+    inputs_seq = flat_args[:num_inputs]
+    states = list(flat_args[num_inputs:expected])
+    lifted_args = tuple(flat_args[expected:])
+
+    if num_inputs == 0:
+        raise ValueError("flex_sn_scan requires at least one input sequence")
+
+    T = inputs_seq[0].shape[0]
+    for i, x in enumerate(inputs_seq):
+        if x.shape[0] != T:
+            raise ValueError(
+                f"input {i} has leading dim {x.shape[0]}, expected {T}"
+            )
+
+    output_buffers = [[] for _ in range(num_outputs)]
+
+    for t in range(T):
+        step_inputs = tuple(x[t] for x in inputs_seq)
+        results = core_fn(*step_inputs, *states, *lifted_args)
+        if len(results) != num_outputs + num_states:
+            raise ValueError(
+                f"core returned {len(results)} values, "
+                f"expected num_outputs + num_states "
+                f"= {num_outputs + num_states}"
+            )
+        outputs = results[:num_outputs]
+        states = list(results[num_outputs:])
+        for i, y in enumerate(outputs):
+            output_buffers[i].append(y)
+
+    output_seqs = tuple(torch.stack(buf, dim=0) for buf in output_buffers)
+    return (*output_seqs, *tuple(states))
+
+
 def lowerable_scan(
     core_fn: Callable,
     num_inputs: int,
@@ -268,6 +323,70 @@ def lowerable_scan(
     )
     result = tuple(result)
     return result[num_states:]
+
+
+def lowerable_scan_final_state(
+    core_fn: Callable,
+    num_inputs: int,
+    num_states: int,
+    num_outputs: int,
+    *flat_args: torch.Tensor,
+) -> Tuple[torch.Tensor, ...]:
+    if _torch_scan_op is None or _wrap_scan_combine_fn_flat is None:
+        raise RuntimeError("PyTorch scan HOP is unavailable in this environment")
+
+    expected = num_inputs + num_states
+    if len(flat_args) < expected:
+        raise ValueError(
+            f"flex_sn_scan expected at least {expected} tensor args "
+            f"(num_inputs={num_inputs} + num_states={num_states}), "
+            f"got {len(flat_args)}"
+        )
+    if num_inputs == 0:
+        raise ValueError("flex_sn_scan requires at least one input sequence")
+
+    input_seqs = flat_args[:num_inputs]
+    init_states = flat_args[num_inputs:expected]
+    lifted_args = tuple(flat_args[expected:])
+
+    def combine_fn(carry, step_inputs):
+        carry = tuple(carry)
+        step_inputs = tuple(step_inputs)
+        results = core_fn(*step_inputs, *carry, *lifted_args)
+        results = tuple(results) if not isinstance(results, torch.Tensor) else (results,)
+        if len(results) != num_outputs + num_states:
+            raise ValueError(
+                f"core returned {len(results)} values, "
+                f"expected num_outputs + num_states = {num_outputs + num_states}"
+            )
+        outputs = list(results[:num_outputs])
+        next_states = list(results[num_outputs:])
+        return next_states, outputs
+
+    leaves_init = list(init_states)
+    leaves_xs = list(input_seqs)
+    _, spec_init = pytree.tree_flatten(leaves_init)
+    _, spec_xs = pytree.tree_flatten(leaves_xs)
+
+    wrapped_combine_fn = functools.partial(
+        _wrap_scan_combine_fn_flat,
+        combine_fn=combine_fn,
+        spec_init=spec_init,
+        spec_xs=spec_xs,
+        num_init_leaves=len(leaves_init),
+        num_inp_leaves=len(leaves_xs),
+    )
+
+    result = _torch_scan_op(
+        wrapped_combine_fn,
+        leaves_init,
+        leaves_xs,
+        additional_inputs=(),
+    )
+    result = tuple(result)
+    final_states = result[:num_states]
+    output_seqs = result[num_states:]
+    return (*output_seqs, *final_states)
 
 
 def lowerable_while_loop_scan(
@@ -407,6 +526,123 @@ def lowerable_while_loop_scan(
     final_output_buffers = final[states_end:outputs_end]
     final_state_buffers = final[outputs_end:]
     return (*final_output_buffers, *final_state_buffers)
+
+
+def lowerable_while_loop_scan_final_state(
+    core_fn: Callable,
+    num_inputs: int,
+    num_states: int,
+    num_outputs: int,
+    *flat_args: torch.Tensor,
+) -> Tuple[torch.Tensor, ...]:
+    if _torch_while_loop is None:
+        raise RuntimeError("PyTorch while_loop HOP is unavailable in this environment")
+
+    expected = num_inputs + num_states
+    if len(flat_args) < expected:
+        raise ValueError(
+            f"flex_sn_scan expected at least {expected} tensor args "
+            f"(num_inputs={num_inputs} + num_states={num_states}), "
+            f"got {len(flat_args)}"
+        )
+    if num_inputs == 0:
+        raise ValueError("flex_sn_scan requires at least one input sequence")
+
+    input_seqs = tuple(flat_args[:num_inputs])
+    init_states = tuple(flat_args[num_inputs:expected])
+    lifted_args = tuple(flat_args[expected:])
+
+    def _ensure_contiguous(tensor: torch.Tensor) -> torch.Tensor:
+        return tensor.contiguous()
+
+    T = input_seqs[0].shape[0]
+    for i, x in enumerate(input_seqs):
+        if x.shape[0] != T:
+            raise ValueError(f"input {i} has leading dim {x.shape[0]}, expected {T}")
+
+    if T == 0:
+        empty_outputs = tuple(
+            state.new_empty((0, *state.shape)) for state in init_states[:num_outputs]
+        )
+        return (*empty_outputs, *init_states)
+
+    input_seqs = tuple(_ensure_contiguous(seq) for seq in input_seqs)
+    init_states = tuple(_ensure_contiguous(state) for state in init_states)
+
+    first_step_inputs = tuple(_ensure_contiguous(x[0]) for x in input_seqs)
+    first_results = core_fn(*first_step_inputs, *init_states, *lifted_args)
+    first_results = (
+        tuple(first_results)
+        if not isinstance(first_results, torch.Tensor)
+        else (first_results,)
+    )
+    if len(first_results) != num_outputs + num_states:
+        raise ValueError(
+            f"core returned {len(first_results)} values, "
+            f"expected num_outputs + num_states = {num_outputs + num_states}"
+        )
+
+    first_outputs = tuple(_ensure_contiguous(x) for x in first_results[:num_outputs])
+    first_states = tuple(_ensure_contiguous(x) for x in first_results[num_outputs:])
+
+    def _append_to_tail(buffer: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
+        return torch.cat((buffer[1:], _ensure_contiguous(value).unsqueeze(0)), dim=0).contiguous()
+
+    def _shift_input_queue(queue: torch.Tensor) -> torch.Tensor:
+        return torch.cat((queue[1:], queue[-1:].clone()), dim=0).contiguous()
+
+    output_buffers = tuple(
+        _append_to_tail(out.new_zeros((T, *out.shape)), out) for out in first_outputs
+    )
+    pending_inputs = tuple(_shift_input_queue(seq) for seq in input_seqs)
+
+    t0 = torch.tensor(1, dtype=torch.int64, device=first_outputs[0].device)
+
+    def cond_fn(t, *carry):
+        return t < T
+
+    def body_fn(t, *carry):
+        pending_seq_end = num_inputs
+        states_end = pending_seq_end + num_states
+
+        step_input_queues = carry[:pending_seq_end]
+        states = carry[pending_seq_end:states_end]
+        outputs_acc = carry[states_end:]
+
+        step_inputs = tuple(_ensure_contiguous(queue[0]) for queue in step_input_queues)
+        results = core_fn(*step_inputs, *states, *lifted_args)
+        results = tuple(results) if not isinstance(results, torch.Tensor) else (results,)
+        outputs = tuple(_ensure_contiguous(x) for x in results[:num_outputs])
+        next_states = tuple(_ensure_contiguous(x) for x in results[num_outputs:])
+        next_pending_inputs = tuple(
+            _shift_input_queue(queue) for queue in step_input_queues
+        )
+        next_output_acc = tuple(
+            _append_to_tail(buf, out) for buf, out in zip(outputs_acc, outputs)
+        )
+        return (
+            t + 1,
+            *next_pending_inputs,
+            *next_states,
+            *next_output_acc,
+        )
+
+    final = _torch_while_loop(
+        cond_fn,
+        body_fn,
+        (
+            t0,
+            *pending_inputs,
+            *first_states,
+            *output_buffers,
+        ),
+    )
+    final = tuple(final)
+    pending_seq_end = 1 + num_inputs
+    states_end = pending_seq_end + num_states
+    final_states = final[pending_seq_end:states_end]
+    final_output_buffers = final[states_end:]
+    return (*final_output_buffers, *final_states)
 
 
 flex_sn_scan.py_impl(torch._C.DispatchKey.CompositeExplicitAutograd)(eager_scan)

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -13,12 +13,10 @@ Current scope (M1 + M2):
 
 Deferred to M3:
 
-* A Dynamo ``VariableBuilder`` so ``torch.compile(model, fullgraph=True)``
-  can lift the HOP directly. Today the HOP is unsupported by Dynamo and
-  users must either wrap the scan in ``torch.compiler.disable`` or use
-  the lower-level ``aot_function`` API.
-* An Inductor lowering that preserves the scan as a single node and emits
-  a ``tl.static_range`` time loop (vs. the current unrolled-aten path).
+* A true Inductor lowering that keeps FlexSN as its own first-class HOP and
+  emits a time loop without relying on PyTorch's built-in scan decomposition.
+* Training/autograd support for the lowerable scan path. The built-in scan HOP
+  used here to avoid full unrolling is currently inference-oriented.
 
 Usage::
 
@@ -39,6 +37,11 @@ from typing import Callable, Tuple
 
 import torch
 from torch._ops import HigherOrderOperator
+
+try:
+    from torch._higher_order_ops.scan import scan_op as _torch_scan_op
+except Exception:
+    _torch_scan_op = None
 
 
 class FlexSNScan(HigherOrderOperator):
@@ -78,6 +81,10 @@ class FlexSNScan(HigherOrderOperator):
 
 
 flex_sn_scan = FlexSNScan()
+
+
+def lowerable_scan_available() -> bool:
+    return _torch_scan_op is not None
 
 
 def eager_scan(
@@ -138,6 +145,62 @@ def eager_scan(
     output_seqs = tuple(torch.stack(buf, dim=0) for buf in output_buffers)
     state_seqs = tuple(torch.stack(buf, dim=0) for buf in state_buffers)
     return (*output_seqs, *state_seqs)
+
+
+def lowerable_scan(
+    core_fn: Callable,
+    num_inputs: int,
+    num_states: int,
+    num_outputs: int,
+    *flat_args: torch.Tensor,
+) -> Tuple[torch.Tensor, ...]:
+    """Run FlexSN scan through PyTorch's built-in ``scan`` HOP.
+
+    This path keeps the scan as a single higher-order op under tracing so
+    downstream compilers can decompose it to a loop instead of unrolling the
+    body T times in the traced graph. It is currently intended for inference /
+    no-grad usage.
+    """
+    if _torch_scan_op is None:
+        raise RuntimeError("PyTorch scan HOP is unavailable in this environment")
+
+    expected = num_inputs + num_states
+    if len(flat_args) < expected:
+        raise ValueError(
+            f"flex_sn_scan expected at least {expected} tensor args "
+            f"(num_inputs={num_inputs} + num_states={num_states}), "
+            f"got {len(flat_args)}"
+        )
+    if num_inputs == 0:
+        raise ValueError("flex_sn_scan requires at least one input sequence")
+
+    input_seqs = flat_args[:num_inputs]
+    init_states = flat_args[num_inputs:expected]
+    lifted_args = tuple(flat_args[expected:])
+
+    def combine_fn(*args):
+        carry = args[:num_states]
+        step_inputs = args[num_states : num_states + num_inputs]
+        extra_inputs = args[num_states + num_inputs :]
+        results = core_fn(*step_inputs, *carry, *extra_inputs)
+        results = tuple(results) if not isinstance(results, torch.Tensor) else (results,)
+        if len(results) != num_outputs + num_states:
+            raise ValueError(
+                f"core returned {len(results)} values, "
+                f"expected num_outputs + num_states = {num_outputs + num_states}"
+            )
+        outputs = results[:num_outputs]
+        next_states = results[num_outputs:]
+        return [*next_states, *outputs, *next_states]
+
+    result = _torch_scan_op(
+        combine_fn,
+        list(init_states),
+        list(input_seqs),
+        additional_inputs=lifted_args,
+    )
+    result = tuple(result)
+    return result[num_states:]
 
 
 flex_sn_scan.py_impl(torch._C.DispatchKey.CompositeExplicitAutograd)(eager_scan)

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -498,22 +498,28 @@ def lowerable_while_loop_scan(
             raise ValueError(f"input {i} has leading dim {x.shape[0]}, expected {T}")
 
     if T == 0:
+        step_inputs = tuple(x.new_empty(x.shape[1:]) for x in input_seqs)
+        with torch.no_grad():
+            template_results = _as_tuple(
+                core_fn(*step_inputs, *init_states, *lifted_args)
+            )
+        if len(template_results) != num_outputs + num_states:
+            raise ValueError(
+                f"core returned {len(template_results)} values, "
+                f"expected num_outputs + num_states "
+                f"= {num_outputs + num_states}"
+            )
+
         def _empty_output(i: int) -> torch.Tensor:
-            if i < len(init_states):
-                ref = init_states[i]
-            elif init_states:
-                ref = init_states[-1]
-            elif lifted_args:
-                ref = lifted_args[min(i, len(lifted_args) - 1)]
-            else:
-                return input_seqs[0].new_empty((0, *input_seqs[0].shape[1:]))
+            ref = template_results[i]
             return ref.new_empty((0, *ref.shape))
 
         empty_outputs = tuple(
             _empty_output(i) for i in range(num_outputs)
         )
         empty_states = tuple(
-            state.new_empty((0, *state.shape)) for state in init_states
+            state.new_empty((0, *state.shape))
+            for state in template_results[num_outputs:]
         )
         return (*empty_outputs, *empty_states)
 

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -427,8 +427,14 @@ def lowerable_while_loop_scan(
             raise ValueError(f"input {i} has leading dim {x.shape[0]}, expected {T}")
 
     if T == 0:
+        def _empty_output(i: int) -> torch.Tensor:
+            if init_states:
+                ref = init_states[i % len(init_states)]
+                return ref.new_empty((0, *ref.shape))
+            return input_seqs[0].new_empty((0, *input_seqs[0].shape[1:]))
+
         empty_outputs = tuple(
-            state.new_empty((0, *state.shape)) for state in init_states[:num_outputs]
+            _empty_output(i) for i in range(num_outputs)
         )
         empty_states = tuple(
             state.new_empty((0, *state.shape)) for state in init_states
@@ -561,8 +567,17 @@ def lowerable_while_loop_scan_final_state(
             raise ValueError(f"input {i} has leading dim {x.shape[0]}, expected {T}")
 
     if T == 0:
+        def _empty_output(i: int) -> torch.Tensor:
+            if i < len(init_states):
+                ref = init_states[i]
+            elif init_states:
+                ref = init_states[-1]
+            else:
+                ref = input_seqs[0].new_empty(input_seqs[0].shape[1:])
+            return ref.new_empty((0, *ref.shape))
+
         empty_outputs = tuple(
-            state.new_empty((0, *state.shape)) for state in init_states[:num_outputs]
+            _empty_output(i) for i in range(num_outputs)
         )
         return (*empty_outputs, *init_states)
 
@@ -733,7 +748,7 @@ def _register_dynamo_hop() -> None:
             body_args = [*step_inputs, *flat_args[num_inputs:]]
 
             if "source_target" in getattr(speculate_subgraph, "__code__").co_varnames:
-                body_r, body_graph, body_lifted_freevars = speculate_subgraph(
+                _body_r, body_graph, body_lifted_freevars = speculate_subgraph(
                     tx,
                     body_fn,
                     body_args,
@@ -743,7 +758,7 @@ def _register_dynamo_hop() -> None:
                 )
             else:
                 graph_checkpoint, checkpoint = tx.output.graph, tx.copy_graphstate()
-                body_r, body_graph, body_lifted_freevars = speculate_subgraph(
+                _body_r, body_graph, body_lifted_freevars = speculate_subgraph(
                     tx,
                     body_fn,
                     body_args,

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -75,10 +75,8 @@ from torch._ops import HigherOrderOperator
 
 try:
     from torch._higher_order_ops.scan import scan_op as _torch_scan_op
-    from torch._higher_order_ops.scan import wrap_combine_fn_flat as _wrap_scan_combine_fn_flat
 except (ImportError, AttributeError):
     _torch_scan_op = None
-    _wrap_scan_combine_fn_flat = None
 
 try:
     from torch._higher_order_ops.while_loop import while_loop as _torch_while_loop
@@ -132,7 +130,7 @@ def _as_tuple(outputs):
 
 
 def lowerable_scan_available() -> bool:
-    return _torch_scan_op is not None and _wrap_scan_combine_fn_flat is not None
+    return _torch_scan_op is not None
 
 
 def lowerable_while_loop_available() -> bool:
@@ -317,9 +315,8 @@ def lowerable_scan(
     * On the PyTorch versions we validate against, fake/proxy/export handling
       for this out-of-tree scan pattern is still not stable enough to make this
       the default compiled path.
-    * We mirror the internal ``scan`` frontend contract by routing through
-      ``wrap_combine_fn_flat`` with explicit tree specs for the flattened
-      inputs/states.
+    * We pass flattened input/state leaves directly to ``torch.ops.higher_order.scan``
+      and rebuild the structured inputs inside ``wrapped_combine_fn``.
     """
     if _torch_scan_op is None or _wrap_scan_combine_fn_flat is None:
         raise RuntimeError("PyTorch scan HOP is unavailable in this environment")
@@ -454,7 +451,7 @@ def lowerable_scan_final_state(
 
 def _ensure_contiguous(tensor: torch.Tensor) -> torch.Tensor:
     if tensor.dim() >= 4:
-        return tensor.clone(memory_format=torch.contiguous_format)
+        return tensor.contiguous(memory_format=torch.contiguous_format)
     return tensor.contiguous()
 
 
@@ -469,11 +466,11 @@ def _append_to_tail(buffer: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
     return torch.cat(
         (buffer[1:], _ensure_contiguous(value).unsqueeze(0)),
         dim=0,
-    ).contiguous()
+    )
 
 
 def _shift_input_queue(queue: torch.Tensor) -> torch.Tensor:
-    return torch.cat((queue[1:], queue[-1:].clone()), dim=0).contiguous()
+    return torch.cat((queue[1:], queue[-1:]), dim=0)
 
 
 def lowerable_while_loop_scan(

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -115,9 +115,17 @@ class FlexSNScan(HigherOrderOperator):
         num_states: int,
         num_outputs: int,
         *flat_args: torch.Tensor,
+        output_template_specs: Optional[
+            Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]
+        ] = None,
     ) -> Tuple[torch.Tensor, ...]:
         return super().__call__(
-            core_fn, num_inputs, num_states, num_outputs, *flat_args
+            core_fn,
+            num_inputs,
+            num_states,
+            num_outputs,
+            *flat_args,
+            output_template_specs=output_template_specs,
         )
 
 
@@ -146,11 +154,59 @@ def _empty_outputs_from_template(
             f"expected {num_outputs} output template specs, got "
             f"{len(output_template_specs)}"
         )
-    device = input_seqs[0].device
     return tuple(
-        torch.empty((0, *shape), dtype=dtype, device=device)
+        input_seqs[0].new_empty((0, *shape), dtype=dtype)
         for shape, dtype in output_template_specs
     )
+
+
+def _flatten_dynamo_body_result(value) -> Tuple[object, ...]:
+    if isinstance(value, torch.Tensor):
+        return (value,)
+    if isinstance(value, (tuple, list)):
+        return tuple(
+            leaf for item in value for leaf in _flatten_dynamo_body_result(item)
+        )
+    variable_items = getattr(value, "items", None)
+    if isinstance(variable_items, (tuple, list)):
+        return tuple(
+            leaf
+            for item in variable_items
+            for leaf in _flatten_dynamo_body_result(item)
+        )
+    return (value,)
+
+
+def _dynamo_leaf_example_value(value):
+    if isinstance(value, torch.Tensor):
+        return value
+    as_proxy = getattr(value, "as_proxy", None)
+    if callable(as_proxy):
+        try:
+            proxy = as_proxy()
+        except Exception:
+            return None
+        node = getattr(proxy, "node", None)
+        meta = getattr(node, "meta", None)
+        if isinstance(meta, dict):
+            return meta.get("example_value")
+    return None
+
+
+def _output_template_specs_from_dynamo_body_result(
+    body_result,
+    num_outputs: int,
+) -> Optional[Tuple[Tuple[Tuple[int, ...], torch.dtype], ...]]:
+    leaves = _flatten_dynamo_body_result(body_result)
+    if len(leaves) < num_outputs:
+        return None
+    specs = []
+    for leaf in leaves[:num_outputs]:
+        example_value = _dynamo_leaf_example_value(leaf)
+        if not isinstance(example_value, torch.Tensor):
+            return None
+        specs.append((tuple(example_value.shape), example_value.dtype))
+    return tuple(specs)
 
 
 def lowerable_scan_available() -> bool:
@@ -1080,6 +1136,10 @@ def _register_dynamo_hop() -> None:
             body_gm = torch.fx.GraphModule(tx.output.nn_modules, body_graph)
             body_name = install_subgraph(tx, self.source, "flex_sn_scan_body", body_gm)
             body_node = make_attr(tx, body_name)
+            output_template_specs = _output_template_specs_from_dynamo_body_result(
+                _body_r,
+                num_outputs,
+            )
 
             proxy = tx.output.create_proxy(
                 "call_function",
@@ -1092,7 +1152,7 @@ def _register_dynamo_hop() -> None:
                     *(arg.as_proxy() for arg in flat_args),
                     *lifted_freevars,
                 ),
-                kwargs={},
+                kwargs={"output_template_specs": output_template_specs},
             )
             example_value = eager_scan(
                 body_gm,
@@ -1101,6 +1161,7 @@ def _register_dynamo_hop() -> None:
                 num_outputs,
                 *(arg.as_proxy().node.meta["example_value"] for arg in flat_args),
                 *(freevar.node.meta["example_value"] for freevar in lifted_freevars),
+                output_template_specs=output_template_specs,
             )
             return wrap_fx_proxy(tx=tx, proxy=proxy, example_value=example_value)
 

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -138,7 +138,7 @@ def lowerable_while_loop_available() -> bool:
     return _torch_while_loop is not None
 
 
-def _callable_accepts_positional_args(fn: Callable, n_args: int) -> bool | None:
+def _callable_positional_arg_capacity(fn: Callable) -> int | None:
     target = fn.forward if isinstance(fn, torch.nn.Module) else fn
     try:
         signature = inspect.signature(target)
@@ -147,13 +147,42 @@ def _callable_accepts_positional_args(fn: Callable, n_args: int) -> bool | None:
     positional = 0
     for parameter in signature.parameters.values():
         if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
-            return True
+            return None
         if parameter.kind in (
             inspect.Parameter.POSITIONAL_ONLY,
             inspect.Parameter.POSITIONAL_OR_KEYWORD,
         ):
             positional += 1
-    return n_args <= positional
+    return positional
+
+
+def _callable_accepts_positional_args(fn: Callable, n_args: int) -> bool | None:
+    capacity = _callable_positional_arg_capacity(fn)
+    if capacity is None:
+        return None
+    return n_args <= capacity
+
+
+def _reorder_placeholders_to_canonical_args(
+    graph: torch.fx.Graph, canonical_arg_names: Tuple[str, ...]
+) -> Tuple[torch.fx.Node, ...]:
+    placeholders = [node for node in graph.nodes if node.op == "placeholder"]
+    if not placeholders:
+        return ()
+
+    by_name = {node.name: node for node in placeholders}
+    ordered = [by_name[name] for name in canonical_arg_names if name in by_name]
+    ordered.extend(node for node in placeholders if node not in ordered)
+
+    if ordered != placeholders:
+        first_non_placeholder = next(
+            (node for node in graph.nodes if node.op != "placeholder"), None
+        )
+        if first_non_placeholder is not None:
+            for node in ordered:
+                first_non_placeholder.prepend(node)
+
+    return tuple(node for node in graph.nodes if node.op == "placeholder")
 
 
 def _check_lifted_arg_arity(
@@ -933,8 +962,11 @@ def _register_dynamo_hop() -> None:
 
             step_inputs = [_make_step_template(arg) for arg in flat_args[:num_inputs]]
             body_args = [*step_inputs, *flat_args[num_inputs:]]
+            canonical_body_arg_names = tuple(
+                arg.as_proxy().node.name for arg in body_args
+            )
 
-            _body_r, body_graph, body_lifted_freevars, _parent_proxy_map = speculate_subgraph(
+            speculated = speculate_subgraph(
                 tx,
                 body_fn,
                 body_args,
@@ -942,6 +974,19 @@ def _register_dynamo_hop() -> None:
                 "flex_sn_scan",
                 source_target=self.value,
             )
+            if len(speculated) == 4:
+                (
+                    _body_r,
+                    body_graph,
+                    body_lifted_freevars,
+                    _parent_proxy_map,
+                ) = speculated
+            elif len(speculated) == 3:
+                _body_r, body_graph, body_lifted_freevars = speculated
+            else:
+                raise hop_vars.unimplemented(
+                    "flex_sn_scan received an unsupported speculate_subgraph result"
+                )
 
             if hasattr(body_lifted_freevars, "keys"):
                 lifted_freevars = tuple(body_lifted_freevars.keys())
@@ -959,6 +1004,31 @@ def _register_dynamo_hop() -> None:
                     raise hop_vars.unimplemented(
                         "flex_sn_scan only supports tensor lifted freevars"
                     )
+
+            placeholders = _reorder_placeholders_to_canonical_args(
+                body_graph, canonical_body_arg_names
+            )
+            placeholder_freevar_names = tuple(
+                node.name for node in placeholders[len(body_args) :]
+            )
+            if placeholder_freevar_names:
+                freevars_by_name = {
+                    freevar.node.name: freevar for freevar in lifted_freevars
+                }
+                missing = [
+                    name
+                    for name in placeholder_freevar_names
+                    if name not in freevars_by_name
+                ]
+                if missing:
+                    raise hop_vars.unimplemented(
+                        "flex_sn_scan could not map lifted tensor freevars"
+                    )
+                lifted_freevars = tuple(
+                    freevars_by_name[name] for name in placeholder_freevar_names
+                )
+            else:
+                lifted_freevars = ()
 
             body_gm = torch.fx.GraphModule(tx.output.nn_modules, body_graph)
             body_name = install_subgraph(tx, self.source, "flex_sn_scan_body", body_gm)

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -66,6 +66,7 @@ Captured tensor freevars from ``core_fn`` are appended after the
 ``[*inputs_seq, *init_states]`` segment when Dynamo rewrites the HOP call.
 """
 from __future__ import annotations
+import inspect
 import warnings
 from typing import Callable, Tuple
 
@@ -137,6 +138,43 @@ def lowerable_while_loop_available() -> bool:
     return _torch_while_loop is not None
 
 
+def _callable_accepts_positional_args(fn: Callable, n_args: int) -> bool | None:
+    target = fn.forward if isinstance(fn, torch.nn.Module) else fn
+    try:
+        signature = inspect.signature(target)
+    except (TypeError, ValueError):
+        return None
+    positional = 0
+    for parameter in signature.parameters.values():
+        if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
+            return True
+        if parameter.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            positional += 1
+    return n_args <= positional
+
+
+def _check_lifted_arg_arity(
+    core_fn: Callable,
+    num_inputs: int,
+    num_states: int,
+    lifted_args: Tuple[torch.Tensor, ...],
+) -> None:
+    if not lifted_args:
+        return
+    expected = num_inputs + num_states
+    total = expected + len(lifted_args)
+    accepts = _callable_accepts_positional_args(core_fn, total)
+    if accepts is False:
+        raise ValueError(
+            f"flex_sn_scan expected {expected} tensor args "
+            f"(num_inputs={num_inputs} + num_states={num_states}), "
+            f"got {total}"
+        )
+
+
 def eager_scan(
     core_fn: Callable,
     num_inputs: int,
@@ -162,6 +200,7 @@ def eager_scan(
     inputs_seq = flat_args[:num_inputs]
     states = list(flat_args[num_inputs:expected])
     lifted_args = tuple(flat_args[expected:])
+    _check_lifted_arg_arity(core_fn, num_inputs, num_states, lifted_args)
 
     if num_inputs == 0:
         raise ValueError("flex_sn_scan requires at least one input sequence")
@@ -245,6 +284,7 @@ def eager_scan_final_state(
     inputs_seq = flat_args[:num_inputs]
     states = list(flat_args[num_inputs:expected])
     lifted_args = tuple(flat_args[expected:])
+    _check_lifted_arg_arity(core_fn, num_inputs, num_states, lifted_args)
 
     if num_inputs == 0:
         raise ValueError("flex_sn_scan requires at least one input sequence")
@@ -318,7 +358,7 @@ def lowerable_scan(
     * We pass flattened input/state leaves directly to ``torch.ops.higher_order.scan``
       and rebuild the structured inputs inside ``wrapped_combine_fn``.
     """
-    if _torch_scan_op is None or _wrap_scan_combine_fn_flat is None:
+    if _torch_scan_op is None:
         raise RuntimeError("PyTorch scan HOP is unavailable in this environment")
 
     expected = num_inputs + num_states
@@ -334,6 +374,8 @@ def lowerable_scan(
     input_seqs = flat_args[:num_inputs]
     init_states = flat_args[num_inputs:expected]
     lifted_args = tuple(flat_args[expected:])
+    _check_lifted_arg_arity(core_fn, num_inputs, num_states, lifted_args)
+
     def combine_fn(carry, step_inputs, additional_inputs):
         carry = tuple(carry)
         step_inputs = tuple(step_inputs)
@@ -386,7 +428,7 @@ def lowerable_scan_final_state(
     num_outputs: int,
     *flat_args: torch.Tensor,
 ) -> Tuple[torch.Tensor, ...]:
-    if _torch_scan_op is None or _wrap_scan_combine_fn_flat is None:
+    if _torch_scan_op is None:
         raise RuntimeError("PyTorch scan HOP is unavailable in this environment")
 
     expected = num_inputs + num_states
@@ -402,6 +444,7 @@ def lowerable_scan_final_state(
     input_seqs = flat_args[:num_inputs]
     init_states = flat_args[num_inputs:expected]
     lifted_args = tuple(flat_args[expected:])
+    _check_lifted_arg_arity(core_fn, num_inputs, num_states, lifted_args)
 
     def combine_fn(carry, step_inputs, additional_inputs):
         carry = tuple(carry)
@@ -501,6 +544,7 @@ def lowerable_while_loop_scan(
     input_seqs = tuple(flat_args[:num_inputs])
     init_states = tuple(flat_args[num_inputs:expected])
     lifted_args = tuple(flat_args[expected:])
+    _check_lifted_arg_arity(core_fn, num_inputs, num_states, lifted_args)
 
     T = input_seqs[0].shape[0]
     for i, x in enumerate(input_seqs):
@@ -658,6 +702,7 @@ def lowerable_while_loop_scan_final_state(
     input_seqs = tuple(flat_args[:num_inputs])
     init_states = tuple(flat_args[num_inputs:expected])
     lifted_args = tuple(flat_args[expected:])
+    _check_lifted_arg_arity(core_fn, num_inputs, num_states, lifted_args)
 
     T = input_seqs[0].shape[0]
     for i, x in enumerate(input_seqs):
@@ -823,6 +868,9 @@ def _register_dynamo_hop() -> None:
             return tx.output.install_subgraph(name, gm)
 
     class FlexSNScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
+        _HOP_NAME = "spikingjelly.flex_sn_scan"
+        _ALLOW_FALLBACK_TO_EAGER = False
+
         def call_function(self, tx, args, kwargs):
             if kwargs:
                 raise hop_vars.unimplemented("flex_sn_scan does not support kwargs")

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/kernel.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/kernel.py
@@ -12,6 +12,30 @@ from typing import Callable, List, Optional, Tuple
 import torch
 
 
+def _example_build_device(example_inputs: Optional[Tuple[torch.Tensor, ...]]):
+    if example_inputs is not None:
+        for tensor in example_inputs:
+            if tensor.device.type == "cuda":
+                return tensor.device
+    return torch.device("cuda", torch.cuda.current_device())
+
+
+def _prepare_example_inputs(
+    example_inputs: Optional[Tuple[torch.Tensor, ...]],
+    num_inputs: int,
+    num_states: int,
+) -> Tuple[torch.Tensor, ...]:
+    build_device = _example_build_device(example_inputs)
+    if example_inputs is None:
+        return tuple(
+            torch.zeros(1, device=build_device)
+            for _ in range(num_inputs + num_states)
+        )
+    # .clone() breaks aliasing: in-place ops inside core_fn during tracing
+    # must not silently mutate the caller's original buffers.
+    return tuple(x.detach().to(build_device).clone() for x in example_inputs)
+
+
 def build_inference_kernel(
     core_fn: Callable,
     num_inputs: int,
@@ -43,14 +67,7 @@ def build_inference_kernel(
     from ..torch2triton import generate_triton_code_str
     from ..flexsn import extract_info, get_flexsn_inference_kernel
 
-    if example_inputs is None:
-        example_inputs = tuple(
-            torch.zeros(1, device="cuda") for _ in range(num_inputs + num_states)
-        )
-    else:
-        # .clone() breaks aliasing: in-place ops inside core_fn during tracing
-        # must not silently mutate the caller's original buffers.
-        example_inputs = tuple(x.detach().to("cuda").clone() for x in example_inputs)
+    example_inputs = _prepare_example_inputs(example_inputs, num_inputs, num_states)
 
     # Trace core_fn to an aten-level FX graph (no PYTORCH_JIT=0 needed).
     traced = make_fx(core_fn)(*example_inputs)
@@ -84,12 +101,7 @@ def build_inference_final_state_kernel(
     from ..torch2triton import generate_triton_code_str
     from ..flexsn import extract_info, get_flexsn_inference_final_state_kernel
 
-    if example_inputs is None:
-        example_inputs = tuple(
-            torch.zeros(1, device="cuda") for _ in range(num_inputs + num_states)
-        )
-    else:
-        example_inputs = tuple(x.detach().to("cuda").clone() for x in example_inputs)
+    example_inputs = _prepare_example_inputs(example_inputs, num_inputs, num_states)
 
     traced = make_fx(core_fn)(*example_inputs)
     graph = traced.graph
@@ -182,13 +194,7 @@ def build_training_kernels(
     from ..torch2triton import generate_forward_and_backward_graph, generate_triton_code_str
     from ..flexsn import extract_info, get_flexsn_forward_kernel, get_flexsn_backward_kernel
 
-    if example_inputs is None:
-        example_inputs = tuple(
-            torch.zeros(1, device="cuda") for _ in range(num_inputs + num_states)
-        )
-    else:
-        # .clone() breaks aliasing so tracing cannot mutate the caller's buffers.
-        example_inputs = tuple(x.detach().to("cuda").clone() for x in example_inputs)
+    example_inputs = _prepare_example_inputs(example_inputs, num_inputs, num_states)
 
     # Build requires_grad mask: only float/complex tensors support autograd.
     # Passing the mask prevents generate_forward_and_backward_graph from calling

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/kernel.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/kernel.py
@@ -1,6 +1,6 @@
 """Build Triton scan kernels from a user-defined core_fn for FlexSN inductor backend.
 
-Two entry points:
+Three entry points:
 * build_inference_kernel  — no-grad fast path (make_fx, no PYTORCH_JIT=0 needed)
 * build_inference_final_state_kernel — inference path that returns final states only
 * build_training_kernels  — forward + backward kernels for full BPTT training
@@ -97,6 +97,24 @@ def build_inference_final_state_kernel(
     num_outputs: int,
     example_inputs: Optional[Tuple[torch.Tensor, ...]] = None,
 ):
+    """Build an inference kernel that returns output sequences and final states.
+
+    This final-state variant traces ``core_fn`` and generates a Triton kernel
+    like :func:`build_inference_kernel`, but returns only the final state
+    tensors instead of full state sequences.
+
+    Args:
+        core_fn: single-step dynamics callable with signature
+            ``(*inputs, *states) -> (*outputs, *updated_states)``.
+        num_inputs: number of per-step input tensors.
+        num_states: number of state tensors.
+        num_outputs: number of per-step output tensors.
+        example_inputs: optional example tensors ``[*inputs, *states]``.
+
+    Returns:
+        ``(kernel, info)`` from ``get_flexsn_inference_final_state_kernel``
+        and ``extract_info``.
+    """
     from torch.fx.experimental.proxy_tensor import make_fx
     from ..torch2triton import generate_triton_code_str
     from ..flexsn import extract_info, get_flexsn_inference_final_state_kernel

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/kernel.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/kernel.py
@@ -2,6 +2,7 @@
 
 Two entry points:
 * build_inference_kernel  — no-grad fast path (make_fx, no PYTORCH_JIT=0 needed)
+* build_inference_final_state_kernel — inference path that returns final states only
 * build_training_kernels  — forward + backward kernels for full BPTT training
 """
 from __future__ import annotations
@@ -69,6 +70,36 @@ def build_inference_kernel(
     # Build the scan kernel: single tl.static_range(T) loop.
     kernel = get_flexsn_inference_kernel(core_str, core_name, info=info)
 
+    return kernel, info
+
+
+def build_inference_final_state_kernel(
+    core_fn: Callable,
+    num_inputs: int,
+    num_states: int,
+    num_outputs: int,
+    example_inputs: Optional[Tuple[torch.Tensor, ...]] = None,
+):
+    from torch.fx.experimental.proxy_tensor import make_fx
+    from ..torch2triton import generate_triton_code_str
+    from ..flexsn import extract_info, get_flexsn_inference_final_state_kernel
+
+    if example_inputs is None:
+        example_inputs = tuple(
+            torch.zeros(1, device="cuda") for _ in range(num_inputs + num_states)
+        )
+    else:
+        example_inputs = tuple(x.detach().to("cuda").clone() for x in example_inputs)
+
+    traced = make_fx(core_fn)(*example_inputs)
+    graph = traced.graph
+
+    raw_name = getattr(core_fn, "__name__", type(core_fn).__name__)
+    safe_name = "".join(c if c.isalnum() else "_" for c in raw_name)
+    core_name = f"{safe_name}_inductor_scan_final_state"
+    core_str, core_name = generate_triton_code_str(graph, core_name)
+    info = extract_info(graph, num_inputs, num_states, num_outputs)
+    kernel = get_flexsn_inference_final_state_kernel(core_str, core_name, info=info)
     return kernel, info
 
 

--- a/spikingjelly/activation_based/triton_kernel/flexsn/template.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/template.py
@@ -159,9 +159,9 @@ def get_flexsn_inference_kernel(
         [f"v{i}_seq_ptr" for i in range(num_states)]
     )
 
-    autotune_restore = ", ".join([f'"s{i}_seq_ptr"' for i in range(num_outputs)])
-    autotune_restore += ", "
-    autotune_restore += ", ".join([f'"v{i}_seq_ptr"' for i in range(num_states)])
+    restore_names = [f'"s{i}_seq_ptr"' for i in range(num_outputs)]
+    restore_names += [f'"v{i}_seq_ptr"' for i in range(num_states)]
+    autotune_restore = ", ".join(restore_names)
 
     init_state_loads = "".join(
         [
@@ -176,9 +176,10 @@ def get_flexsn_inference_kernel(
     stores = "".join([store_template.format(name=f"s{i}") for i in range(num_outputs)])
     stores += "".join([store_template.format(name=f"v{i}") for i in range(num_states)])
 
-    lhs = ", ".join([f"s{i}" for i in range(num_outputs)])
-    lhs += ", "
-    lhs += ", ".join([f"v{i}" for i in range(num_states)])
+    lhs_list = [f"s{i}" for i in range(num_outputs)] + [
+        f"v{i}" for i in range(num_states)
+    ]
+    lhs = ", ".join(lhs_list)
     core_args = ", ".join([f"x{i}" for i in range(num_inputs)])
     core_args += ", "
     core_args += ", ".join([f"v{i}" for i in range(num_states)])
@@ -236,10 +237,9 @@ def get_flexsn_inference_final_state_kernel(
         [f"v{i}_final_ptr" for i in range(num_states)]
     )
 
-    autotune_restore = ", ".join([f'"s{i}_seq_ptr"' for i in range(num_outputs)])
-    if num_states > 0:
-        autotune_restore += ", "
-        autotune_restore += ", ".join([f'"v{i}_final_ptr"' for i in range(num_states)])
+    restore_names = [f'"s{i}_seq_ptr"' for i in range(num_outputs)]
+    restore_names += [f'"v{i}_final_ptr"' for i in range(num_states)]
+    autotune_restore = ", ".join(restore_names)
 
     init_state_loads = "".join(
         [init_state_load_template.format(name=f"v{i}") for i in range(num_states)]
@@ -251,9 +251,10 @@ def get_flexsn_inference_final_state_kernel(
         [final_state_store_template.format(name=f"v{i}") for i in range(num_states)]
     )
 
-    lhs = ", ".join([f"s{i}" for i in range(num_outputs)])
-    lhs += ", "
-    lhs += ", ".join([f"v{i}" for i in range(num_states)])
+    lhs_list = [f"s{i}" for i in range(num_outputs)] + [
+        f"v{i}" for i in range(num_states)
+    ]
+    lhs = ", ".join(lhs_list)
     core_args = ", ".join([f"x{i}" for i in range(num_inputs)])
     core_args += ", "
     core_args += ", ".join([f"v{i}" for i in range(num_states)])

--- a/spikingjelly/activation_based/triton_kernel/flexsn/template.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/template.py
@@ -138,7 +138,7 @@ def flexsn_{kernel_type}_kernel_{hash}(
 def get_flexsn_inference_kernel(
     core_str: str, core_name: str, info: FlexSNInfo, verbose: bool = False
 ):
-    hash = core_name[-8:]
+    kernel_hash = core_name[-8:]
     num_inputs = info.num_inputs
     num_states = info.num_states
     num_outputs = info.num_outputs
@@ -187,7 +187,7 @@ def get_flexsn_inference_kernel(
         core_str=core_str,
         autotune_restore=autotune_restore,
         kernel_type="inference",
-        hash=hash,
+        hash=kernel_hash,
         kernel_input_signature=kernel_input_signature,
         kernel_output_signature=kernel_output_signature,
         init_state_loads=init_state_loads,
@@ -197,7 +197,7 @@ def get_flexsn_inference_kernel(
         stores=stores,
         tail="",
     ).strip()
-    kernel_name = f"flexsn_inference_kernel_{hash}"
+    kernel_name = f"flexsn_inference_kernel_{kernel_hash}"
 
     if verbose:
         print("=" * 40, core_name, "=" * 40)
@@ -215,7 +215,7 @@ def get_flexsn_inference_kernel(
 def get_flexsn_inference_final_state_kernel(
     core_str: str, core_name: str, info: FlexSNInfo, verbose: bool = False
 ):
-    hash = core_name[-8:]
+    kernel_hash = core_name[-8:]
     num_inputs = info.num_inputs
     num_states = info.num_states
     num_outputs = info.num_outputs
@@ -262,7 +262,7 @@ def get_flexsn_inference_final_state_kernel(
         core_str=core_str,
         autotune_restore=autotune_restore,
         kernel_type="inference_final_state",
-        hash=hash,
+        hash=kernel_hash,
         kernel_input_signature=kernel_input_signature,
         kernel_output_signature=kernel_output_signature,
         init_state_loads=init_state_loads,
@@ -272,7 +272,7 @@ def get_flexsn_inference_final_state_kernel(
         stores=stores,
         tail=tail,
     ).strip()
-    kernel_name = f"flexsn_inference_final_state_kernel_{hash}"
+    kernel_name = f"flexsn_inference_final_state_kernel_{kernel_hash}"
 
     if verbose:
         print("=" * 40, core_name, "=" * 40)
@@ -293,7 +293,7 @@ def get_flexsn_forward_kernel(
     info: FlexSNInfo,
     verbose: bool = False,
 ):
-    hash = core_name[-8:]
+    kernel_hash = core_name[-8:]
     num_inputs = info.num_inputs
     num_states = info.num_states
     fwd_kernel_returns = info.fwd_kernel_returns  # unique
@@ -333,7 +333,7 @@ def get_flexsn_forward_kernel(
         core_str=core_str,
         autotune_restore=autotune_restore,
         kernel_type="forward",
-        hash=hash,
+        hash=kernel_hash,
         kernel_input_signature=kernel_input_signature,
         kernel_output_signature=kernel_output_signature,
         init_state_loads=init_state_loads,
@@ -343,7 +343,7 @@ def get_flexsn_forward_kernel(
         stores=stores,
         tail="",
     ).strip()
-    kernel_name = f"flexsn_forward_kernel_{hash}"
+    kernel_name = f"flexsn_forward_kernel_{kernel_hash}"
 
     if verbose:
         print("=" * 40, core_name, "=" * 40)
@@ -364,7 +364,7 @@ def get_flexsn_backward_kernel(
     info: FlexSNInfo,
     verbose: bool = False,
 ):
-    hash = core_name[-8:]
+    kernel_hash = core_name[-8:]
     num_outputs = info.num_outputs
     num_inputs = info.num_inputs
     num_states = info.num_states
@@ -446,7 +446,7 @@ def get_flexsn_backward_kernel(
         core_str=core_str,
         autotune_restore=autotune_restore,
         kernel_type="backward",
-        hash=hash,
+        hash=kernel_hash,
         kernel_input_signature=kernel_input_signature,
         kernel_output_signature=kernel_output_signature,
         init_state_loads=init_state_loads,
@@ -456,7 +456,7 @@ def get_flexsn_backward_kernel(
         stores=stores,
         tail=tail,
     ).strip()
-    kernel_name = f"flexsn_backward_kernel_{hash}"
+    kernel_name = f"flexsn_backward_kernel_{kernel_hash}"
 
     if verbose:
         print("=" * 40, core_name, "=" * 40)

--- a/spikingjelly/activation_based/triton_kernel/flexsn/template.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/template.py
@@ -21,6 +21,10 @@ __all__ = [
 
 INDENTATION = " " * 4
 
+
+def _signature(names):
+    return f",\n{INDENTATION}".join(names)
+
 init_state_load_template = """
     {name}_init_ptrs = tl.make_block_ptr(
         {name}_init_ptr,
@@ -143,20 +147,14 @@ def get_flexsn_inference_kernel(
     num_states = info.num_states
     num_outputs = info.num_outputs
 
-    kernel_input_signature = f",\n{INDENTATION}".join(
+    kernel_input_signature = _signature(
         [f"x{i}_seq_ptr" for i in range(num_inputs)]
-    )
-    kernel_input_signature += f",\n{INDENTATION}"
-    kernel_input_signature += f",\n{INDENTATION}".join(
-        [f"v{i}_init_ptr" for i in range(num_states)]
+        + [f"v{i}_init_ptr" for i in range(num_states)]
     )
 
-    kernel_output_signature = f",\n{INDENTATION}".join(
+    kernel_output_signature = _signature(
         [f"s{i}_seq_ptr" for i in range(num_outputs)]
-    )
-    kernel_output_signature += f",\n{INDENTATION}"
-    kernel_output_signature += f",\n{INDENTATION}".join(
-        [f"v{i}_seq_ptr" for i in range(num_states)]
+        + [f"v{i}_seq_ptr" for i in range(num_states)]
     )
 
     restore_names = [f'"s{i}_seq_ptr"' for i in range(num_outputs)]
@@ -221,20 +219,14 @@ def get_flexsn_inference_final_state_kernel(
     num_states = info.num_states
     num_outputs = info.num_outputs
 
-    kernel_input_signature = f",\n{INDENTATION}".join(
+    kernel_input_signature = _signature(
         [f"x{i}_seq_ptr" for i in range(num_inputs)]
-    )
-    kernel_input_signature += f",\n{INDENTATION}"
-    kernel_input_signature += f",\n{INDENTATION}".join(
-        [f"v{i}_init_ptr" for i in range(num_states)]
+        + [f"v{i}_init_ptr" for i in range(num_states)]
     )
 
-    kernel_output_signature = f",\n{INDENTATION}".join(
+    kernel_output_signature = _signature(
         [f"s{i}_seq_ptr" for i in range(num_outputs)]
-    )
-    kernel_output_signature += f",\n{INDENTATION}"
-    kernel_output_signature += f",\n{INDENTATION}".join(
-        [f"v{i}_final_ptr" for i in range(num_states)]
+        + [f"v{i}_final_ptr" for i in range(num_states)]
     )
 
     restore_names = [f'"s{i}_seq_ptr"' for i in range(num_outputs)]
@@ -300,17 +292,12 @@ def get_flexsn_forward_kernel(
     fwd_kernel_returns = info.fwd_kernel_returns  # unique
     fwd_core_recipients = info.fwd_core_recipients  # `_` for duplicates
 
-    kernel_input_signature = f",\n{INDENTATION}".join(
+    kernel_input_signature = _signature(
         [f"x{i}_seq_ptr" for i in range(num_inputs)]
-    )
-    kernel_input_signature += f",\n{INDENTATION}"
-    kernel_input_signature += f",\n{INDENTATION}".join(
-        [f"v{i}_init_ptr" for i in range(num_states)]
+        + [f"v{i}_init_ptr" for i in range(num_states)]
     )
 
-    kernel_output_signature = f",\n{INDENTATION}".join(
-        [f"{r}_seq_ptr" for r in fwd_kernel_returns]
-    )
+    kernel_output_signature = _signature([f"{r}_seq_ptr" for r in fwd_kernel_returns])
 
     autotune_restore = ", ".join([f'"{r}_seq_ptr"' for r in fwd_kernel_returns])
 
@@ -373,27 +360,17 @@ def get_flexsn_backward_kernel(
 
     assert n + num_outputs + num_states == len(info.fwd_core_returns)
 
-    kernel_input_signature = f",\n{INDENTATION}".join(
+    kernel_input_signature = _signature(
         [f"grad_s{i}_seq_ptr" for i in range(num_outputs)]
+        + [f"grad_v{i}_seq_ptr" for i in range(num_states)]
+        + [f"res{i}_b_seq_ptr" for i in range(n)]
     )
-    kernel_input_signature += f",\n{INDENTATION}"
-    kernel_input_signature += f",\n{INDENTATION}".join(
-        [f"grad_v{i}_seq_ptr" for i in range(num_states)]
-    )
-    if n > 0:
-        kernel_input_signature += f",\n{INDENTATION}"
-        kernel_input_signature += f",\n{INDENTATION}".join(
-            [f"res{i}_b_seq_ptr" for i in range(n)]
-        )
     # res{i}_b slightly different from res{i}_f in the forward kernel
     # as res{i}_b might be from s{i} or v{i}
 
-    kernel_output_signature = f",\n{INDENTATION}".join(
+    kernel_output_signature = _signature(
         [f"grad_x{i}_seq_ptr" for i in range(num_inputs)]
-    )
-    kernel_output_signature += f",\n{INDENTATION}"
-    kernel_output_signature += f",\n{INDENTATION}".join(
-        [f"grad_v{i}_init_ptr" for i in range(num_states)]
+        + [f"grad_v{i}_init_ptr" for i in range(num_states)]
     )
 
     autotune_restore = ", ".join([f'"grad_x{i}_seq_ptr"' for i in range(num_inputs)])

--- a/spikingjelly/activation_based/triton_kernel/flexsn/template.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/template.py
@@ -13,6 +13,7 @@ from .info import FlexSNInfo
 
 __all__ = [
     "get_flexsn_inference_kernel",
+    "get_flexsn_inference_final_state_kernel",
     "get_flexsn_forward_kernel",
     "get_flexsn_backward_kernel",
 ]
@@ -58,6 +59,18 @@ store_template = """
         )
         convert_and_store({name}_ptrs, {name}, boundary_check=(1,))
         # tl.store({name}_ptrs, {name}, boundary_check=(1,))
+"""
+
+final_state_store_template = """
+    {name}_final_ptrs = tl.make_block_ptr(
+        {name}_final_ptr,
+        shape=(1, NCL),
+        strides=(NCL, 1),
+        offsets=(0, ncl_offset),
+        block_shape=(1, BLOCK_NCL),
+        order=(1, 0)
+    )
+    convert_and_store({name}_final_ptrs, {name}, boundary_check=(1,))
 """
 
 load_template = """
@@ -189,6 +202,81 @@ def get_flexsn_inference_kernel(
     if verbose:
         print("=" * 40, core_name, "=" * 40)
         print("Generated flexsn inference kernel:")
+        print("```")
+        print(kernel_str)
+        print("```\n")
+        print(info)
+        print("=" * 40, "=" * len(core_name), "=" * 40)
+
+    kernel_exe = compile_triton_code_str(kernel_str, kernel_name, verbose)
+    return kernel_exe
+
+
+def get_flexsn_inference_final_state_kernel(
+    core_str: str, core_name: str, info: FlexSNInfo, verbose: bool = False
+):
+    hash = core_name[-8:]
+    num_inputs = info.num_inputs
+    num_states = info.num_states
+    num_outputs = info.num_outputs
+
+    kernel_input_signature = f",\n{INDENTATION}".join(
+        [f"x{i}_seq_ptr" for i in range(num_inputs)]
+    )
+    kernel_input_signature += f",\n{INDENTATION}"
+    kernel_input_signature += f",\n{INDENTATION}".join(
+        [f"v{i}_init_ptr" for i in range(num_states)]
+    )
+
+    kernel_output_signature = f",\n{INDENTATION}".join(
+        [f"s{i}_seq_ptr" for i in range(num_outputs)]
+    )
+    kernel_output_signature += f",\n{INDENTATION}"
+    kernel_output_signature += f",\n{INDENTATION}".join(
+        [f"v{i}_final_ptr" for i in range(num_states)]
+    )
+
+    autotune_restore = ", ".join([f'"s{i}_seq_ptr"' for i in range(num_outputs)])
+    if num_states > 0:
+        autotune_restore += ", "
+        autotune_restore += ", ".join([f'"v{i}_final_ptr"' for i in range(num_states)])
+
+    init_state_loads = "".join(
+        [init_state_load_template.format(name=f"v{i}") for i in range(num_states)]
+    )
+
+    loads = "".join([load_template.format(name=f"x{i}") for i in range(num_inputs)])
+    stores = "".join([store_template.format(name=f"s{i}") for i in range(num_outputs)])
+    tail = "".join(
+        [final_state_store_template.format(name=f"v{i}") for i in range(num_states)]
+    )
+
+    lhs = ", ".join([f"s{i}" for i in range(num_outputs)])
+    lhs += ", "
+    lhs += ", ".join([f"v{i}" for i in range(num_states)])
+    core_args = ", ".join([f"x{i}" for i in range(num_inputs)])
+    core_args += ", "
+    core_args += ", ".join([f"v{i}" for i in range(num_states)])
+
+    kernel_str = kernel_template.format(
+        core_str=core_str,
+        autotune_restore=autotune_restore,
+        kernel_type="inference_final_state",
+        hash=hash,
+        kernel_input_signature=kernel_input_signature,
+        kernel_output_signature=kernel_output_signature,
+        init_state_loads=init_state_loads,
+        loop_range="0, T, 1",
+        loads=loads,
+        computes=f"{lhs} = {core_name}({core_args})",
+        stores=stores,
+        tail=tail,
+    ).strip()
+    kernel_name = f"flexsn_inference_final_state_kernel_{hash}"
+
+    if verbose:
+        print("=" * 40, core_name, "=" * 40)
+        print("Generated flexsn inference-final-state kernel:")
         print("```")
         print(kernel_str)
         print("```\n")

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -15,7 +15,13 @@ from ..triton_utils import amp_custom_fwd, amp_custom_bwd
 from .info import FlexSNInfo
 
 
-__all__ = ["flexsn_inference", "flexsn_inference_final_state", "flexsn_forward", "flexsn_backward", "FlexSNFunction"]
+__all__ = [
+    "flexsn_inference",
+    "flexsn_inference_final_state",
+    "flexsn_forward",
+    "flexsn_backward",
+    "FlexSNFunction",
+]
 
 
 def flexsn_inference(f, info: FlexSNInfo, *args) -> tuple:

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -21,7 +21,7 @@ __all__ = ["flexsn_inference", "flexsn_inference_final_state", "flexsn_forward",
 def flexsn_inference(f, info: FlexSNInfo, *args) -> tuple:
     x_example = args[0]
     T = x_example.shape[0]
-    NCL = x_example[0].numel()
+    NCL = x_example.shape[1:].numel()
     dtype = x_example.dtype
     outputs = [
         torch.empty_like(x_example) for _ in range(info.num_outputs + info.num_states)
@@ -41,12 +41,15 @@ def flexsn_inference(f, info: FlexSNInfo, *args) -> tuple:
 def flexsn_inference_final_state(f, info: FlexSNInfo, *args) -> tuple:
     x_example = args[0]
     T = x_example.shape[0]
-    NCL = x_example[0].numel()
+    NCL = x_example.shape[1:].numel()
     dtype = x_example.dtype
     output_seqs = [torch.empty_like(x_example) for _ in range(info.num_outputs)]
     final_states = [
-        torch.empty_like(x_example[0]) for _ in range(info.num_states)
+        x_example.new_empty(x_example.shape[1:]) for _ in range(info.num_states)
     ]
+    if T == 0:
+        init_states = args[info.num_inputs : info.num_inputs + info.num_states]
+        return tuple([*output_seqs, *init_states])
     grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
 
     f[grid](
@@ -63,7 +66,7 @@ def flexsn_inference_final_state(f, info: FlexSNInfo, *args) -> tuple:
 def flexsn_forward(f, info: FlexSNInfo, *args) -> tuple:
     x_example = args[0]
     T = x_example.shape[0]
-    NCL = x_example[0].numel()
+    NCL = x_example.shape[1:].numel()
     returns = [torch.empty_like(x_example) for _ in range(info.num_fwd_kernel_returns)]
     dtype = x_example.dtype
     grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
@@ -81,9 +84,11 @@ def flexsn_forward(f, info: FlexSNInfo, *args) -> tuple:
 def flexsn_backward(f, info: FlexSNInfo, *args) -> tuple:
     grad_example = args[0]
     T = grad_example.shape[0]
-    NCL = grad_example[0].numel()
+    NCL = grad_example.shape[1:].numel()
     grad_inputs = [torch.empty_like(grad_example) for _ in range(info.num_inputs)]
-    grad_inputs += [torch.empty_like(grad_example[0]) for _ in range(info.num_states)]
+    grad_inputs += [
+        grad_example.new_empty(grad_example.shape[1:]) for _ in range(info.num_states)
+    ]
     dtype = grad_example.dtype
     grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
 

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -24,10 +24,16 @@ __all__ = [
 ]
 
 
+def _num_elements_per_step(x: torch.Tensor) -> int:
+    if x.shape[0] > 0:
+        return x[0].numel()
+    return x.new_empty(x.shape[1:]).numel()
+
+
 def flexsn_inference(f, info: FlexSNInfo, *args) -> tuple:
     x_example = args[0]
     T = x_example.shape[0]
-    NCL = x_example.stride(0)
+    NCL = _num_elements_per_step(x_example)
     dtype = x_example.dtype
     outputs = [
         torch.empty_like(x_example) for _ in range(info.num_outputs + info.num_states)
@@ -47,7 +53,7 @@ def flexsn_inference(f, info: FlexSNInfo, *args) -> tuple:
 def flexsn_inference_final_state(f, info: FlexSNInfo, *args) -> tuple:
     x_example = args[0]
     T = x_example.shape[0]
-    NCL = x_example.stride(0)
+    NCL = _num_elements_per_step(x_example)
     dtype = x_example.dtype
     output_seqs = [torch.empty_like(x_example) for _ in range(info.num_outputs)]
     final_states = [
@@ -73,7 +79,7 @@ def flexsn_inference_final_state(f, info: FlexSNInfo, *args) -> tuple:
 def flexsn_forward(f, info: FlexSNInfo, *args) -> tuple:
     x_example = args[0]
     T = x_example.shape[0]
-    NCL = x_example.stride(0)
+    NCL = _num_elements_per_step(x_example)
     returns = [torch.empty_like(x_example) for _ in range(info.num_fwd_kernel_returns)]
     dtype = x_example.dtype
     grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
@@ -91,7 +97,7 @@ def flexsn_forward(f, info: FlexSNInfo, *args) -> tuple:
 def flexsn_backward(f, info: FlexSNInfo, *args) -> tuple:
     grad_example = args[0]
     T = grad_example.shape[0]
-    NCL = grad_example.stride(0)
+    NCL = _num_elements_per_step(grad_example)
     grad_inputs = [torch.empty_like(grad_example) for _ in range(info.num_inputs)]
     grad_inputs += [
         grad_example.new_empty(grad_example.shape[1:]) for _ in range(info.num_states)

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -25,9 +25,17 @@ __all__ = [
 
 
 def _num_elements_per_step(x: torch.Tensor) -> int:
-    if x.shape[0] > 0:
-        return x[0].numel()
-    return x.new_empty(x.shape[1:]).numel()
+    n = 1
+    for dim in x.shape[1:]:
+        n *= dim
+    return n
+
+
+def _make_grid(ncl: int):
+    def grid(meta):
+        return (triton.cdiv(ncl, meta["BLOCK_NCL"]),)
+
+    return grid
 
 
 def flexsn_inference(f, info: FlexSNInfo, *args) -> tuple:
@@ -40,7 +48,7 @@ def flexsn_inference(f, info: FlexSNInfo, *args) -> tuple:
     ]
     if T == 0:
         return tuple(outputs)
-    grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
+    grid = _make_grid(NCL)
 
     f[grid](
         *args,
@@ -75,7 +83,7 @@ def flexsn_inference_final_state(f, info: FlexSNInfo, *args) -> tuple:
             for i in range(info.num_states)
         ]
         return tuple([*output_seqs, *final_states])
-    grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
+    grid = _make_grid(NCL)
 
     f[grid](
         *args,
@@ -96,7 +104,7 @@ def flexsn_forward(f, info: FlexSNInfo, *args) -> tuple:
     dtype = x_example.dtype
     if T == 0:
         return tuple(returns)
-    grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
+    grid = _make_grid(NCL)
 
     f[grid](
         *args,
@@ -144,7 +152,7 @@ def flexsn_backward(f, info: FlexSNInfo, *args) -> tuple:
     dtype = grad_example.dtype
     if T == 0:
         return tuple(grad_inputs)
-    grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
+    grid = _make_grid(NCL)
 
     f[grid](
         *args,

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -15,7 +15,7 @@ from ..triton_utils import amp_custom_fwd, amp_custom_bwd
 from .info import FlexSNInfo
 
 
-__all__ = ["FlexSNFunction"]
+__all__ = ["flexsn_inference", "flexsn_inference_final_state", "flexsn_forward", "flexsn_backward", "FlexSNFunction"]
 
 
 def flexsn_inference(f, info: FlexSNInfo, *args) -> tuple:
@@ -36,6 +36,28 @@ def flexsn_inference(f, info: FlexSNInfo, *args) -> tuple:
         dtype=type_dict[dtype],
     )
     return tuple(outputs)
+
+
+def flexsn_inference_final_state(f, info: FlexSNInfo, *args) -> tuple:
+    x_example = args[0]
+    T = x_example.shape[0]
+    NCL = x_example[0].numel()
+    dtype = x_example.dtype
+    output_seqs = [torch.empty_like(x_example) for _ in range(info.num_outputs)]
+    final_states = [
+        torch.empty_like(x_example[0]) for _ in range(info.num_states)
+    ]
+    grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
+
+    f[grid](
+        *args,
+        *output_seqs,
+        *final_states,
+        T=T,
+        NCL=NCL,
+        dtype=type_dict[dtype],
+    )
+    return tuple([*output_seqs, *final_states])
 
 
 def flexsn_forward(f, info: FlexSNInfo, *args) -> tuple:

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -38,6 +38,8 @@ def flexsn_inference(f, info: FlexSNInfo, *args) -> tuple:
     outputs = [
         torch.empty_like(x_example) for _ in range(info.num_outputs + info.num_states)
     ]
+    if T == 0:
+        return tuple(outputs)
     grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
 
     f[grid](
@@ -92,6 +94,8 @@ def flexsn_forward(f, info: FlexSNInfo, *args) -> tuple:
     NCL = _num_elements_per_step(x_example)
     returns = [torch.empty_like(x_example) for _ in range(info.num_fwd_kernel_returns)]
     dtype = x_example.dtype
+    if T == 0:
+        return tuple(returns)
     grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
 
     f[grid](
@@ -132,6 +136,8 @@ def flexsn_backward(f, info: FlexSNInfo, *args) -> tuple:
         for i in range(info.num_states)
     ]
     dtype = grad_example.dtype
+    if T == 0:
+        return tuple(grad_inputs)
     grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
 
     f[grid](

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -101,7 +101,14 @@ def flexsn_backward(f, info: FlexSNInfo, *args) -> tuple:
     grad_example = args[0]
     T = grad_example.shape[0]
     NCL = _num_elements_per_step(grad_example)
-    grad_inputs = [torch.empty_like(grad_example) for _ in range(info.num_inputs)]
+    grad_inputs = [
+        (
+            torch.zeros_like(grad_example)
+            if T == 0
+            else torch.empty_like(grad_example)
+        )
+        for _ in range(info.num_inputs)
+    ]
     grad_state_examples = args[info.num_outputs : info.num_outputs + info.num_states]
     grad_inputs += [
         (

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -120,14 +120,20 @@ def flexsn_backward(f, info: FlexSNInfo, *args) -> tuple:
         )
         for _ in range(info.num_inputs)
     ]
-    grad_state_examples = args[info.num_outputs : info.num_outputs + info.num_states]
+    grad_state_seq_examples = args[
+        info.num_outputs : info.num_outputs + info.num_states
+    ]
+    # State-sequence gradients include the leading time dimension. The wrapper
+    # returns gradients for the initial states, so their templates are shape[1:].
     grad_inputs += [
         (
-            grad_state_examples[i].new_zeros(grad_state_examples[i].shape[1:])
+            grad_state_seq_examples[i].new_zeros(grad_state_seq_examples[i].shape[1:])
             if T == 0
-            else grad_state_examples[i].new_empty(grad_state_examples[i].shape[1:])
+            else grad_state_seq_examples[i].new_empty(
+                grad_state_seq_examples[i].shape[1:]
+            )
         )
-        if i < len(grad_state_examples) and grad_state_examples[i] is not None
+        if i < len(grad_state_seq_examples) and grad_state_seq_examples[i] is not None
         else (
             grad_example.new_zeros(grad_example.shape[1:])
             if T == 0

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -64,7 +64,14 @@ def flexsn_inference_final_state(f, info: FlexSNInfo, *args) -> tuple:
         for i in range(info.num_states)
     ]
     if T == 0:
-        final_states = [state.clone() for state in init_states]
+        final_states = [
+            (
+                init_states[i].clone()
+                if i < len(init_states)
+                else x_example.new_zeros(x_example.shape[1:])
+            )
+            for i in range(info.num_states)
+        ]
         return tuple([*output_seqs, *final_states])
     grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
 

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -21,7 +21,7 @@ __all__ = ["flexsn_inference", "flexsn_inference_final_state", "flexsn_forward",
 def flexsn_inference(f, info: FlexSNInfo, *args) -> tuple:
     x_example = args[0]
     T = x_example.shape[0]
-    NCL = x_example.shape[1:].numel()
+    NCL = x_example.stride(0)
     dtype = x_example.dtype
     outputs = [
         torch.empty_like(x_example) for _ in range(info.num_outputs + info.num_states)
@@ -41,7 +41,7 @@ def flexsn_inference(f, info: FlexSNInfo, *args) -> tuple:
 def flexsn_inference_final_state(f, info: FlexSNInfo, *args) -> tuple:
     x_example = args[0]
     T = x_example.shape[0]
-    NCL = x_example.shape[1:].numel()
+    NCL = x_example.stride(0)
     dtype = x_example.dtype
     output_seqs = [torch.empty_like(x_example) for _ in range(info.num_outputs)]
     final_states = [
@@ -67,7 +67,7 @@ def flexsn_inference_final_state(f, info: FlexSNInfo, *args) -> tuple:
 def flexsn_forward(f, info: FlexSNInfo, *args) -> tuple:
     x_example = args[0]
     T = x_example.shape[0]
-    NCL = x_example.shape[1:].numel()
+    NCL = x_example.stride(0)
     returns = [torch.empty_like(x_example) for _ in range(info.num_fwd_kernel_returns)]
     dtype = x_example.dtype
     grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
@@ -85,7 +85,7 @@ def flexsn_forward(f, info: FlexSNInfo, *args) -> tuple:
 def flexsn_backward(f, info: FlexSNInfo, *args) -> tuple:
     grad_example = args[0]
     T = grad_example.shape[0]
-    NCL = grad_example.shape[1:].numel()
+    NCL = grad_example.stride(0)
     grad_inputs = [torch.empty_like(grad_example) for _ in range(info.num_inputs)]
     grad_inputs += [
         grad_example.new_empty(grad_example.shape[1:]) for _ in range(info.num_states)

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -56,11 +56,14 @@ def flexsn_inference_final_state(f, info: FlexSNInfo, *args) -> tuple:
     NCL = _num_elements_per_step(x_example)
     dtype = x_example.dtype
     output_seqs = [torch.empty_like(x_example) for _ in range(info.num_outputs)]
+    init_states = args[info.num_inputs : info.num_inputs + info.num_states]
     final_states = [
-        x_example.new_empty(x_example.shape[1:]) for _ in range(info.num_states)
+        init_states[i].new_empty(init_states[i].shape)
+        if i < len(init_states)
+        else x_example.new_empty(x_example.shape[1:])
+        for i in range(info.num_states)
     ]
     if T == 0:
-        init_states = args[info.num_inputs : info.num_inputs + info.num_states]
         final_states = [state.clone() for state in init_states]
         return tuple([*output_seqs, *final_states])
     grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
@@ -99,8 +102,20 @@ def flexsn_backward(f, info: FlexSNInfo, *args) -> tuple:
     T = grad_example.shape[0]
     NCL = _num_elements_per_step(grad_example)
     grad_inputs = [torch.empty_like(grad_example) for _ in range(info.num_inputs)]
+    grad_state_examples = args[info.num_outputs : info.num_outputs + info.num_states]
     grad_inputs += [
-        grad_example.new_empty(grad_example.shape[1:]) for _ in range(info.num_states)
+        (
+            grad_state_examples[i].new_zeros(grad_state_examples[i].shape[1:])
+            if T == 0
+            else grad_state_examples[i].new_empty(grad_state_examples[i].shape[1:])
+        )
+        if i < len(grad_state_examples) and grad_state_examples[i] is not None
+        else (
+            grad_example.new_zeros(grad_example.shape[1:])
+            if T == 0
+            else grad_example.new_empty(grad_example.shape[1:])
+        )
+        for i in range(info.num_states)
     ]
     dtype = grad_example.dtype
     grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -49,7 +49,8 @@ def flexsn_inference_final_state(f, info: FlexSNInfo, *args) -> tuple:
     ]
     if T == 0:
         init_states = args[info.num_inputs : info.num_inputs + info.num_states]
-        return tuple([*output_seqs, *init_states])
+        final_states = [state.clone() for state in init_states]
+        return tuple([*output_seqs, *final_states])
     grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
 
     f[grid](

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -313,7 +313,11 @@ def compile_triton_code_str(
     )
     fpath = _codegen_cache_dir() / f"{kernel_name}_{module_hash}.py"
 
-    if not fpath.exists() or fpath.read_text(encoding="utf-8") != triton_code:
+    try:
+        needs_write = (not fpath.exists()) or (fpath.read_text(encoding="utf-8") != triton_code)
+    except OSError:
+        needs_write = True
+    if needs_write:
         with tempfile.NamedTemporaryFile(
             "w", encoding="utf-8", dir=fpath.parent, delete=False, suffix=".tmp"
         ) as tmp_file:
@@ -350,7 +354,7 @@ def compile_triton_code_str(
                 if not isinstance(tl, types.ModuleType):
                     language_module.__dict__.update(getattr(tl, "__dict__", {}))
                 sys.modules["triton.language"] = language_module
-            setattr(triton_module, "language", language_module)
+            triton_module.language = language_module
             sys.modules[module_name] = module
             try:
                 spec.loader.exec_module(module)
@@ -362,14 +366,6 @@ def compile_triton_code_str(
                     sys.modules.pop("triton.language", None)
                 if restore_triton:
                     sys.modules.pop("triton", None)
-        else:
-            module.__dict__.update(
-                {
-                    "triton": triton,
-                    "tl": tl,
-                }
-            )
-
     name_space.update(module.__dict__)
     if kernel_name in module.__dict__:
         return module.__dict__[kernel_name]

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -320,7 +320,11 @@ def compile_triton_code_str(
         triton.JITFunction: The compiled Triton JIT function.
     """
     if name_space is None:
-        name_space = {}
+        name_space = {"triton": triton, "tl": tl}
+    else:
+        name_space = dict(name_space)
+        name_space.setdefault("triton", triton)
+        name_space.setdefault("tl", tl)
     cacheable = len(name_space) == 0
 
     module_hash = _generate_hash(f"{kernel_name}\n{triton_code}", w=16)
@@ -360,14 +364,18 @@ def compile_triton_code_str(
                     triton if isinstance(triton, types.ModuleType) else types.ModuleType("triton")
                 )
                 if not isinstance(triton, types.ModuleType):
-                    triton_module.__dict__.update(getattr(triton, "__dict__", {}))
+                    triton_dict = getattr(triton, "__dict__", None)
+                    if isinstance(triton_dict, dict):
+                        triton_module.__dict__.update(triton_dict)
                 sys.modules["triton"] = triton_module
             if language_module is None:
                 language_module = (
                     tl if isinstance(tl, types.ModuleType) else types.ModuleType("triton.language")
                 )
                 if not isinstance(tl, types.ModuleType):
-                    language_module.__dict__.update(getattr(tl, "__dict__", {}))
+                    tl_dict = getattr(tl, "__dict__", None)
+                    if isinstance(tl_dict, dict):
+                        language_module.__dict__.update(tl_dict)
                 sys.modules["triton.language"] = language_module
             had_language_attr = hasattr(triton_module, "language")
             original_language = getattr(triton_module, "language", None)

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -386,7 +386,10 @@ def compile_triton_code_str(
             except OSError:
                 pass
         except BaseException:
-            tmp_path.unlink(missing_ok=True)
+            try:
+                tmp_path.unlink()
+            except FileNotFoundError:
+                pass
             raise
     if verbose:
         print(f"Triton code `{kernel_name}` written to {fpath}")

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -76,8 +76,15 @@ def _codegen_cache_dir() -> Path:
             cache_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
             if uid is not None:
                 st = cache_dir.stat()
-                if st.st_uid != uid or stat.S_IMODE(st.st_mode) & 0o077:
+                mode = stat.S_IMODE(st.st_mode)
+                if (
+                    st.st_uid != uid
+                    or not (mode & stat.S_IWUSR)
+                    or (mode & 0o022)
+                ):
                     continue
+            with tempfile.NamedTemporaryFile(dir=cache_dir, delete=True):
+                pass
             return cache_dir
         except OSError as e:
             last_error = e

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -45,10 +45,12 @@ def _generate_hash(s: str, w: int = 8) -> str:
 
 
 def _codegen_cache_dir() -> Path:
-    candidates = [
-        Path.home() / ".spikingjelly" / "triton_codegen",
-        Path(tempfile.gettempdir()) / "spikingjelly_triton_codegen",
-    ]
+    candidates = []
+    try:
+        candidates.append(Path.home() / ".spikingjelly" / "triton_codegen")
+    except RuntimeError:
+        pass
+    candidates.append(Path(tempfile.gettempdir()) / "spikingjelly_triton_codegen")
     last_error = None
     for cache_dir in candidates:
         try:
@@ -328,10 +330,7 @@ def compile_triton_code_str(
     )
     fpath = _codegen_cache_dir() / f"{kernel_name}_{module_hash}.py"
 
-    try:
-        needs_write = (not fpath.exists()) or (fpath.read_text(encoding="utf-8") != triton_code)
-    except OSError:
-        needs_write = True
+    needs_write = not fpath.exists()
     if needs_write:
         with tempfile.NamedTemporaryFile(
             "w", encoding="utf-8", dir=fpath.parent, delete=False, suffix=".tmp"

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -1,4 +1,5 @@
 from typing import Tuple
+import errno
 import importlib.util
 import linecache
 import os
@@ -44,9 +45,22 @@ def _generate_hash(s: str, w: int = 8) -> str:
 
 
 def _codegen_cache_dir() -> Path:
-    cache_dir = Path.home() / ".spikingjelly" / "triton_codegen"
-    cache_dir.mkdir(parents=True, exist_ok=True)
-    return cache_dir
+    candidates = [
+        Path.home() / ".spikingjelly" / "triton_codegen",
+        Path(tempfile.gettempdir()) / "spikingjelly_triton_codegen",
+    ]
+    last_error = None
+    for cache_dir in candidates:
+        try:
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            return cache_dir
+        except OSError as e:
+            last_error = e
+            if e.errno not in (errno.EACCES, errno.EROFS, errno.EPERM):
+                raise
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("Failed to initialize Triton codegen cache directory")
 
 
 def _uw(arg) -> str:
@@ -356,6 +370,8 @@ def compile_triton_code_str(
                 if not isinstance(tl, types.ModuleType):
                     language_module.__dict__.update(getattr(tl, "__dict__", {}))
                 sys.modules["triton.language"] = language_module
+            had_language_attr = hasattr(triton_module, "language")
+            original_language = getattr(triton_module, "language", None)
             triton_module.language = language_module
             if cacheable:
                 sys.modules[module_name] = module
@@ -366,6 +382,13 @@ def compile_triton_code_str(
                     sys.modules.pop(module_name, None)
                 raise
             finally:
+                if had_language_attr:
+                    triton_module.language = original_language
+                else:
+                    try:
+                        delattr(triton_module, "language")
+                    except AttributeError:
+                        pass
                 if restore_language:
                     sys.modules.pop("triton.language", None)
                 if restore_triton:

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -95,14 +95,18 @@ def _resolve_codegen_cache_dir() -> Path:
             cache_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
             if uid is not None:
                 st = cache_dir.stat()
+                chmod_failed = False
                 if st.st_uid == uid:
-                    os.chmod(cache_dir, 0o700)
+                    try:
+                        os.chmod(cache_dir, 0o700)
+                    except OSError:
+                        chmod_failed = True
                     st = cache_dir.stat()
                 mode = stat.S_IMODE(st.st_mode)
                 if (
                     st.st_uid != uid
                     or not (mode & stat.S_IWUSR)
-                    or (mode & 0o077)
+                    or ((mode & 0o077) and not chmod_failed)
                 ):
                     continue
             with tempfile.NamedTemporaryFile(dir=cache_dir, delete=True):

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -44,7 +44,7 @@ def _generate_hash(s: str, w: int = 8) -> str:
 
 
 def _codegen_cache_dir() -> Path:
-    cache_dir = Path(tempfile.gettempdir()) / "spikingjelly_triton_codegen"
+    cache_dir = Path.home() / ".spikingjelly" / "triton_codegen"
     cache_dir.mkdir(parents=True, exist_ok=True)
     return cache_dir
 
@@ -354,6 +354,9 @@ def compile_triton_code_str(
             sys.modules[module_name] = module
             try:
                 spec.loader.exec_module(module)
+            except BaseException:
+                sys.modules.pop(module_name, None)
+                raise
             finally:
                 if restore_language:
                     sys.modules.pop("triton.language", None)

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -55,6 +55,10 @@ def _generate_hash(s: str, w: int = 8) -> str:
     return hasher.hexdigest()[:w]
 
 
+def _has_real_triton_runtime() -> bool:
+    return isinstance(triton, types.ModuleType) and isinstance(tl, types.ModuleType)
+
+
 def _codegen_cache_dir() -> Path:
     candidates = []
     uid = getattr(os, "getuid", lambda: None)()
@@ -339,6 +343,12 @@ def compile_triton_code_str(
     Returns:
         triton.JITFunction: The compiled Triton JIT function.
     """
+    if not _has_real_triton_runtime():
+        raise ImportError(
+            "compile_triton_code_str requires a real Triton installation; "
+            "the imported triton/tl modules are unavailable."
+        )
+
     caller_namespace = name_space
     cacheable = caller_namespace is None
     if caller_namespace is None:
@@ -381,23 +391,11 @@ def compile_triton_code_str(
             restore_triton = triton_module is None
             restore_language = language_module is None
             if triton_module is None:
-                triton_module = (
-                    triton if isinstance(triton, types.ModuleType) else types.ModuleType("triton")
-                )
-                if not isinstance(triton, types.ModuleType):
-                    triton_dict = getattr(triton, "__dict__", None)
-                    if isinstance(triton_dict, dict):
-                        triton_module.__dict__.update(triton_dict)
-                sys.modules["triton"] = triton_module
+                sys.modules["triton"] = triton
+                triton_module = triton
             if language_module is None:
-                language_module = (
-                    tl if isinstance(tl, types.ModuleType) else types.ModuleType("triton.language")
-                )
-                if not isinstance(tl, types.ModuleType):
-                    tl_dict = getattr(tl, "__dict__", None)
-                    if isinstance(tl_dict, dict):
-                        language_module.__dict__.update(tl_dict)
-                sys.modules["triton.language"] = language_module
+                sys.modules["triton.language"] = tl
+                language_module = tl
             had_language_attr = hasattr(triton_module, "language")
             original_language = getattr(triton_module, "language", None)
             triton_module.language = language_module

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -319,13 +319,13 @@ def compile_triton_code_str(
     Returns:
         triton.JITFunction: The compiled Triton JIT function.
     """
+    cacheable = name_space is None
     if name_space is None:
         name_space = {"triton": triton, "tl": tl}
     else:
         name_space = dict(name_space)
         name_space.setdefault("triton", triton)
         name_space.setdefault("tl", tl)
-    cacheable = len(name_space) == 0
 
     module_hash = _generate_hash(f"{kernel_name}\n{triton_code}", w=16)
     module_name = (

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -28,7 +28,6 @@ except BaseException as e:
     tl = dummy.DummyImport()
 
 from ..triton_utils import type_str_dict
-from ..triton_utils import ensure_cleanup_tmp_python_files
 
 
 __all__ = [
@@ -328,7 +327,6 @@ def generate_triton_code_str(
     return f"{prefix}\n\n{signature}\n{triton_code_lines}", fn_name
 
 
-@ensure_cleanup_tmp_python_files
 def compile_triton_code_str(
     triton_code: str,
     kernel_name: str,
@@ -389,7 +387,7 @@ def compile_triton_code_str(
                 os.chmod(fpath, 0o600)
             except OSError:
                 pass
-        except BaseException:
+        except Exception:
             try:
                 tmp_path.unlink()
             except FileNotFoundError:

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -5,6 +5,7 @@ import linecache
 import os
 from pathlib import Path
 import hashlib
+import stat
 import sys
 import tempfile
 import threading
@@ -46,15 +47,23 @@ def _generate_hash(s: str, w: int = 8) -> str:
 
 def _codegen_cache_dir() -> Path:
     candidates = []
+    uid = getattr(os, "getuid", lambda: None)()
     try:
         candidates.append(Path.home() / ".spikingjelly" / "triton_codegen")
     except RuntimeError:
         pass
-    candidates.append(Path(tempfile.gettempdir()) / "spikingjelly_triton_codegen")
+    temp_suffix = f"_{uid}" if uid is not None else ""
+    candidates.append(
+        Path(tempfile.gettempdir()) / f"spikingjelly_triton_codegen{temp_suffix}"
+    )
     last_error = None
     for cache_dir in candidates:
         try:
-            cache_dir.mkdir(parents=True, exist_ok=True)
+            cache_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+            if uid is not None:
+                st = cache_dir.stat()
+                if st.st_uid != uid or stat.S_IMODE(st.st_mode) & 0o077:
+                    continue
             return cache_dir
         except OSError as e:
             last_error = e
@@ -314,18 +323,20 @@ def compile_triton_code_str(
         triton_code (str): The Triton code string to compile.
         kernel_name (str): The name of the Triton function to extract.
         verbose (bool, optional): If True, print the path to the temporary file. Defaults to False.
-        name_space (dict, optional): A namespace dictionary to use for `exec`. Defaults to {}.
+        name_space (dict | None, optional): Optional globals injected before execution.
+            When provided, it will be updated with symbols defined by the compiled module.
 
     Returns:
         triton.JITFunction: The compiled Triton JIT function.
     """
-    cacheable = name_space is None
-    if name_space is None:
-        name_space = {"triton": triton, "tl": tl}
+    caller_namespace = name_space
+    cacheable = caller_namespace is None
+    if caller_namespace is None:
+        module_globals = {"triton": triton, "tl": tl}
     else:
-        name_space = dict(name_space)
-        name_space.setdefault("triton", triton)
-        name_space.setdefault("tl", tl)
+        module_globals = dict(caller_namespace)
+        module_globals.setdefault("triton", triton)
+        module_globals.setdefault("tl", tl)
 
     module_hash = _generate_hash(f"{kernel_name}\n{triton_code}", w=16)
     module_name = (
@@ -354,7 +365,7 @@ def compile_triton_code_str(
             if spec is None or spec.loader is None:
                 raise ImportError(f"Could not create import spec for {fpath}")
             module = importlib.util.module_from_spec(spec)
-            module.__dict__.update(name_space)
+            module.__dict__.update(module_globals)
             triton_module = sys.modules.get("triton")
             language_module = sys.modules.get("triton.language")
             restore_triton = triton_module is None
@@ -400,7 +411,8 @@ def compile_triton_code_str(
                     sys.modules.pop("triton.language", None)
                 if restore_triton:
                     sys.modules.pop("triton", None)
-    name_space.update(module.__dict__)
+    if caller_namespace is not None:
+        caller_namespace.update(module.__dict__)
     if kernel_name in module.__dict__:
         return module.__dict__[kernel_name]
     raise ValueError(f"Function {kernel_name} not found in compiled namespace")

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -361,7 +361,11 @@ def compile_triton_code_str(
     if caller_namespace is None:
         module_globals = {"triton": triton, "tl": tl}
     else:
-        module_globals = dict(caller_namespace)
+        module_globals = {
+            key: value
+            for key, value in caller_namespace.items()
+            if key not in _NAMESPACE_METADATA_KEYS
+        }
         module_globals.setdefault("triton", triton)
         module_globals.setdefault("tl", tl)
 

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -396,7 +396,8 @@ def compile_triton_code_str(
                 pass
             raise
     if verbose:
-        print(f"Triton code `{kernel_name}` written to {fpath}")
+        action = "written to" if needs_write else "loaded from cache"
+        print(f"Triton code `{kernel_name}` {action} {fpath}")
 
     linecache.checkcache(str(fpath))
 

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -401,19 +401,6 @@ def compile_triton_code_str(
                 raise ImportError(f"Could not create import spec for {fpath}")
             module = importlib.util.module_from_spec(spec)
             module.__dict__.update(module_globals)
-            triton_module = sys.modules.get("triton")
-            language_module = sys.modules.get("triton.language")
-            restore_triton = triton_module is None
-            restore_language = language_module is None
-            if triton_module is None:
-                sys.modules["triton"] = triton
-                triton_module = triton
-            if language_module is None:
-                sys.modules["triton.language"] = tl
-                language_module = tl
-            had_language_attr = hasattr(triton_module, "language")
-            original_language = getattr(triton_module, "language", None)
-            triton_module.language = language_module
             if cacheable:
                 sys.modules[module_name] = module
             try:
@@ -422,18 +409,6 @@ def compile_triton_code_str(
                 if cacheable:
                     sys.modules.pop(module_name, None)
                 raise
-            finally:
-                if had_language_attr:
-                    triton_module.language = original_language
-                else:
-                    try:
-                        delattr(triton_module, "language")
-                    except AttributeError:
-                        pass
-                if restore_language:
-                    sys.modules.pop("triton.language", None)
-                if restore_triton:
-                    sys.modules.pop("triton", None)
     if caller_namespace is not None:
         exported_symbols = {
             key: value

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -409,12 +409,7 @@ def compile_triton_code_str(
                 raise ImportError(f"Could not create import spec for {fpath}")
             module = importlib.util.module_from_spec(spec)
             module.__dict__.update(module_globals)
-            try:
-                spec.loader.exec_module(module)
-            except BaseException:
-                if cacheable:
-                    sys.modules.pop(module_name, None)
-                raise
+            spec.loader.exec_module(module)
             if cacheable:
                 sys.modules[module_name] = module
     if caller_namespace is not None:

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -38,6 +38,8 @@ __all__ = [
 
 _MODULE_CACHE_LOCK_GUARD = threading.Lock()
 _MODULE_CACHE_LOCKS = {}
+_CODEGEN_CACHE_DIR = None
+_CODEGEN_CACHE_DIR_LOCK = threading.Lock()
 _NAMESPACE_METADATA_KEYS = {
     "__name__",
     "__spec__",
@@ -65,6 +67,18 @@ def _has_real_triton_runtime() -> bool:
 
 
 def _codegen_cache_dir() -> Path:
+    global _CODEGEN_CACHE_DIR
+    if _CODEGEN_CACHE_DIR is not None:
+        return _CODEGEN_CACHE_DIR
+    with _CODEGEN_CACHE_DIR_LOCK:
+        if _CODEGEN_CACHE_DIR is not None:
+            return _CODEGEN_CACHE_DIR
+        cache_dir = _resolve_codegen_cache_dir()
+        _CODEGEN_CACHE_DIR = cache_dir
+        return cache_dir
+
+
+def _resolve_codegen_cache_dir() -> Path:
     candidates = []
     uid = getattr(os, "getuid", lambda: None)()
     try:

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -95,18 +95,17 @@ def _resolve_codegen_cache_dir() -> Path:
             cache_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
             if uid is not None:
                 st = cache_dir.stat()
-                chmod_failed = False
                 if st.st_uid == uid:
                     try:
                         os.chmod(cache_dir, 0o700)
                     except OSError:
-                        chmod_failed = True
+                        pass
                     st = cache_dir.stat()
                 mode = stat.S_IMODE(st.st_mode)
                 if (
                     st.st_uid != uid
                     or not (mode & stat.S_IWUSR)
-                    or ((mode & 0o077) and not chmod_failed)
+                    or (mode & 0o077)
                 ):
                     continue
             with tempfile.NamedTemporaryFile(dir=cache_dir, delete=True):

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -7,6 +7,7 @@ import hashlib
 import sys
 import tempfile
 import threading
+import types
 
 import torch
 import torch.fx as fx
@@ -286,7 +287,7 @@ def compile_triton_code_str(
     triton_code: str,
     kernel_name: str,
     verbose: bool = False,
-    name_space: dict = {},
+    name_space: dict | None = None,
 ):
     """Compile a Triton code string into a runnable Triton JIT function.
 
@@ -302,6 +303,9 @@ def compile_triton_code_str(
     Returns:
         triton.JITFunction: The compiled Triton JIT function.
     """
+    if name_space is None:
+        name_space = {}
+
     module_hash = _generate_hash(f"{kernel_name}\n{triton_code}", w=16)
     module_name = (
         "spikingjelly.activation_based.triton_kernel.codegen."
@@ -328,14 +332,33 @@ def compile_triton_code_str(
             if spec is None or spec.loader is None:
                 raise ImportError(f"Could not create import spec for {fpath}")
             module = importlib.util.module_from_spec(spec)
-            module.__dict__.update(
-                {
-                    "triton": triton,
-                    "tl": tl,
-                }
-            )
+            triton_module = sys.modules.get("triton")
+            language_module = sys.modules.get("triton.language")
+            restore_triton = triton_module is None
+            restore_language = language_module is None
+            if triton_module is None:
+                triton_module = (
+                    triton if isinstance(triton, types.ModuleType) else types.ModuleType("triton")
+                )
+                if not isinstance(triton, types.ModuleType):
+                    triton_module.__dict__.update(getattr(triton, "__dict__", {}))
+                sys.modules["triton"] = triton_module
+            if language_module is None:
+                language_module = (
+                    tl if isinstance(tl, types.ModuleType) else types.ModuleType("triton.language")
+                )
+                if not isinstance(tl, types.ModuleType):
+                    language_module.__dict__.update(getattr(tl, "__dict__", {}))
+                sys.modules["triton.language"] = language_module
+            setattr(triton_module, "language", language_module)
             sys.modules[module_name] = module
-            spec.loader.exec_module(module)
+            try:
+                spec.loader.exec_module(module)
+            finally:
+                if restore_language:
+                    sys.modules.pop("triton.language", None)
+                if restore_triton:
+                    sys.modules.pop("triton", None)
         else:
             module.__dict__.update(
                 {

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -5,6 +5,7 @@ import linecache
 import os
 from pathlib import Path
 import hashlib
+import re
 import stat
 import sys
 import tempfile
@@ -45,6 +46,7 @@ _NAMESPACE_METADATA_KEYS = {
     "__spec__",
     "__loader__",
     "__package__",
+    "__path__",
     "__file__",
     "__cached__",
     "__builtins__",
@@ -60,6 +62,12 @@ def _get_module_cache_lock(module_name: str) -> threading.Lock:
 def _generate_hash(s: str, w: int = 8) -> str:
     hasher = hashlib.sha256(s.encode("utf-8"))
     return hasher.hexdigest()[:w]
+
+
+def _safe_codegen_stem(kernel_name: str) -> str:
+    name = str(kernel_name).replace("\\", "/").rsplit("/", 1)[-1]
+    safe = re.sub(r"[^0-9A-Za-z_.-]+", "_", name).strip("._")
+    return (safe or "kernel")[:128]
 
 
 def _has_real_triton_runtime() -> bool:
@@ -396,12 +404,13 @@ def compile_triton_code_str(
         module_globals.setdefault("triton", triton)
         module_globals.setdefault("tl", tl)
 
+    safe_kernel_name = _safe_codegen_stem(kernel_name)
     module_hash = _generate_hash(f"{kernel_name}\n{triton_code}", w=16)
     module_name = (
         "spikingjelly.activation_based.triton_kernel.codegen."
-        f"{kernel_name}_{module_hash}"
+        f"{safe_kernel_name}_{module_hash}"
     )
-    fpath = _codegen_cache_dir() / f"{kernel_name}_{module_hash}.py"
+    fpath = _codegen_cache_dir() / f"{safe_kernel_name}_{module_hash}.py"
 
     needs_write = not fpath.exists()
     if needs_write:

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -88,7 +88,7 @@ def _codegen_cache_dir() -> Path:
                 if (
                     st.st_uid != uid
                     or not (mode & stat.S_IWUSR)
-                    or (mode & 0o022)
+                    or (mode & 0o077)
                 ):
                     continue
             with tempfile.NamedTemporaryFile(dir=cache_dir, delete=True):

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -401,6 +401,7 @@ def compile_triton_code_str(
             for key, value in caller_namespace.items()
             if key not in _NAMESPACE_METADATA_KEYS
         }
+        module_globals.pop(kernel_name, None)
         module_globals.setdefault("triton", triton)
         module_globals.setdefault("tl", tl)
 

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Optional, Tuple
 import errno
 import importlib.util
 import linecache
@@ -333,7 +333,7 @@ def compile_triton_code_str(
     triton_code: str,
     kernel_name: str,
     verbose: bool = False,
-    name_space: dict | None = None,
+    name_space: Optional[dict] = None,
 ):
     """Compile a Triton code string into a runnable Triton JIT function.
 
@@ -344,7 +344,7 @@ def compile_triton_code_str(
         triton_code (str): The Triton code string to compile.
         kernel_name (str): The name of the Triton function to extract.
         verbose (bool, optional): If True, print the path to the temporary file. Defaults to False.
-        name_space (dict | None, optional): Optional globals injected before execution.
+        name_space (Optional[dict], optional): Optional globals injected before execution.
             When provided, it will be updated with symbols defined by the compiled module.
 
     Returns:

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -372,7 +372,15 @@ def compile_triton_code_str(
         ) as tmp_file:
             tmp_file.write(triton_code)
             tmp_path = Path(tmp_file.name)
-        os.replace(tmp_path, fpath)
+        try:
+            os.replace(tmp_path, fpath)
+            try:
+                os.chmod(fpath, 0o600)
+            except OSError:
+                pass
+        except BaseException:
+            tmp_path.unlink(missing_ok=True)
+            raise
     if verbose:
         print(f"Triton code `{kernel_name}` written to {fpath}")
 

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -1,10 +1,12 @@
 from typing import Tuple
 import importlib.util
 import linecache
+import os
 from pathlib import Path
 import hashlib
 import sys
 import tempfile
+import threading
 
 import torch
 import torch.fx as fx
@@ -30,6 +32,9 @@ __all__ = [
     "generate_triton_code_str",
     "compile_triton_code_str",
 ]
+
+
+_MODULE_CACHE_LOCK = threading.Lock()
 
 
 def _generate_hash(s: str, w: int = 8) -> str:
@@ -305,33 +310,39 @@ def compile_triton_code_str(
     fpath = _codegen_cache_dir() / f"{kernel_name}_{module_hash}.py"
 
     if not fpath.exists() or fpath.read_text(encoding="utf-8") != triton_code:
-        fpath.write_text(triton_code, encoding="utf-8")
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", dir=fpath.parent, delete=False, suffix=".tmp"
+        ) as tmp_file:
+            tmp_file.write(triton_code)
+            tmp_path = Path(tmp_file.name)
+        os.replace(tmp_path, fpath)
     if verbose:
         print(f"Triton code `{kernel_name}` written to {fpath}")
 
     linecache.checkcache(str(fpath))
 
-    module = sys.modules.get(module_name)
-    if module is None:
-        spec = importlib.util.spec_from_file_location(module_name, fpath)
-        if spec is None or spec.loader is None:
-            raise ImportError(f"Could not create import spec for {fpath}")
-        module = importlib.util.module_from_spec(spec)
-        module.__dict__.update(
-            {
-                "triton": triton,
-                "tl": tl,
-            }
-        )
-        sys.modules[module_name] = module
-        spec.loader.exec_module(module)
-    else:
-        module.__dict__.update(
-            {
-                "triton": triton,
-                "tl": tl,
-            }
-        )
+    with _MODULE_CACHE_LOCK:
+        module = sys.modules.get(module_name)
+        if module is None:
+            spec = importlib.util.spec_from_file_location(module_name, fpath)
+            if spec is None or spec.loader is None:
+                raise ImportError(f"Could not create import spec for {fpath}")
+            module = importlib.util.module_from_spec(spec)
+            module.__dict__.update(
+                {
+                    "triton": triton,
+                    "tl": tl,
+                }
+            )
+            sys.modules[module_name] = module
+            spec.loader.exec_module(module)
+        else:
+            module.__dict__.update(
+                {
+                    "triton": triton,
+                    "tl": tl,
+                }
+            )
 
     name_space.update(module.__dict__)
     if kernel_name in module.__dict__:

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -38,6 +38,16 @@ __all__ = [
 
 
 _MODULE_CACHE_LOCK = threading.Lock()
+_NAMESPACE_METADATA_KEYS = {
+    "__name__",
+    "__spec__",
+    "__loader__",
+    "__package__",
+    "__file__",
+    "__cached__",
+    "__builtins__",
+    "__doc__",
+}
 
 
 def _generate_hash(s: str, w: int = 8) -> str:
@@ -412,7 +422,12 @@ def compile_triton_code_str(
                 if restore_triton:
                     sys.modules.pop("triton", None)
     if caller_namespace is not None:
-        caller_namespace.update(module.__dict__)
+        exported_symbols = {
+            key: value
+            for key, value in module.__dict__.items()
+            if key not in _NAMESPACE_METADATA_KEYS
+        }
+        caller_namespace.update(exported_symbols)
     if kernel_name in module.__dict__:
         return module.__dict__[kernel_name]
     raise ValueError(f"Function {kernel_name} not found in compiled namespace")

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -1,7 +1,10 @@
 from typing import Tuple
-import tempfile
+import importlib.util
+import linecache
 from pathlib import Path
 import hashlib
+import sys
+import tempfile
 
 import torch
 import torch.fx as fx
@@ -32,6 +35,12 @@ __all__ = [
 def _generate_hash(s: str, w: int = 8) -> str:
     hasher = hashlib.sha256(s.encode("utf-8"))
     return hasher.hexdigest()[:w]
+
+
+def _codegen_cache_dir() -> Path:
+    cache_dir = Path(tempfile.gettempdir()) / "spikingjelly_triton_codegen"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir
 
 
 def _uw(arg) -> str:
@@ -288,26 +297,43 @@ def compile_triton_code_str(
     Returns:
         triton.JITFunction: The compiled Triton JIT function.
     """
-    # create a temporary file
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-        f.write(triton_code)
-        fpath = Path(f.name)
-        if verbose:
-            print(f"Triton code `{kernel_name}` written to {fpath}")
-        # the file will not be deleted until the end of the program
-
-    name_space.update(
-        {
-            "triton": triton,
-            "tl": tl,
-            "__name__": "spikingjelly.activation_based.triton_kernel.codegen",
-        }
+    module_hash = _generate_hash(f"{kernel_name}\n{triton_code}", w=16)
+    module_name = (
+        "spikingjelly.activation_based.triton_kernel.codegen."
+        f"{kernel_name}_{module_hash}"
     )
-    with open(fpath, "r") as f:
-        code = compile(f.read(), fpath, "exec")
-        exec(code, name_space)  # name_space will be updated
+    fpath = _codegen_cache_dir() / f"{kernel_name}_{module_hash}.py"
 
-    if kernel_name in name_space:
-        return name_space[kernel_name]
+    if not fpath.exists() or fpath.read_text(encoding="utf-8") != triton_code:
+        fpath.write_text(triton_code, encoding="utf-8")
+    if verbose:
+        print(f"Triton code `{kernel_name}` written to {fpath}")
+
+    linecache.checkcache(str(fpath))
+
+    module = sys.modules.get(module_name)
+    if module is None:
+        spec = importlib.util.spec_from_file_location(module_name, fpath)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Could not create import spec for {fpath}")
+        module = importlib.util.module_from_spec(spec)
+        module.__dict__.update(
+            {
+                "triton": triton,
+                "tl": tl,
+            }
+        )
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
     else:
-        raise ValueError(f"Function {kernel_name} not found in compiled namespace")
+        module.__dict__.update(
+            {
+                "triton": triton,
+                "tl": tl,
+            }
+        )
+
+    name_space.update(module.__dict__)
+    if kernel_name in module.__dict__:
+        return module.__dict__[kernel_name]
+    raise ValueError(f"Function {kernel_name} not found in compiled namespace")

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -81,6 +81,9 @@ def _codegen_cache_dir() -> Path:
             cache_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
             if uid is not None:
                 st = cache_dir.stat()
+                if st.st_uid == uid:
+                    os.chmod(cache_dir, 0o700)
+                    st = cache_dir.stat()
                 mode = stat.S_IMODE(st.st_mode)
                 if (
                     st.st_uid != uid

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -305,6 +305,7 @@ def compile_triton_code_str(
     """
     if name_space is None:
         name_space = {}
+    cacheable = len(name_space) == 0
 
     module_hash = _generate_hash(f"{kernel_name}\n{triton_code}", w=16)
     module_name = (
@@ -330,12 +331,13 @@ def compile_triton_code_str(
     linecache.checkcache(str(fpath))
 
     with _MODULE_CACHE_LOCK:
-        module = sys.modules.get(module_name)
+        module = sys.modules.get(module_name) if cacheable else None
         if module is None:
             spec = importlib.util.spec_from_file_location(module_name, fpath)
             if spec is None or spec.loader is None:
                 raise ImportError(f"Could not create import spec for {fpath}")
             module = importlib.util.module_from_spec(spec)
+            module.__dict__.update(name_space)
             triton_module = sys.modules.get("triton")
             language_module = sys.modules.get("triton.language")
             restore_triton = triton_module is None
@@ -355,11 +357,13 @@ def compile_triton_code_str(
                     language_module.__dict__.update(getattr(tl, "__dict__", {}))
                 sys.modules["triton.language"] = language_module
             triton_module.language = language_module
-            sys.modules[module_name] = module
+            if cacheable:
+                sys.modules[module_name] = module
             try:
                 spec.loader.exec_module(module)
             except BaseException:
-                sys.modules.pop(module_name, None)
+                if cacheable:
+                    sys.modules.pop(module_name, None)
                 raise
             finally:
                 if restore_language:

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -36,7 +36,8 @@ __all__ = [
 ]
 
 
-_MODULE_CACHE_LOCK = threading.Lock()
+_MODULE_CACHE_LOCK_GUARD = threading.Lock()
+_MODULE_CACHE_LOCKS = {}
 _NAMESPACE_METADATA_KEYS = {
     "__name__",
     "__spec__",
@@ -47,6 +48,11 @@ _NAMESPACE_METADATA_KEYS = {
     "__builtins__",
     "__doc__",
 }
+
+
+def _get_module_cache_lock(module_name: str) -> threading.Lock:
+    with _MODULE_CACHE_LOCK_GUARD:
+        return _MODULE_CACHE_LOCKS.setdefault(module_name, threading.Lock())
 
 
 def _generate_hash(s: str, w: int = 8) -> str:
@@ -335,15 +341,18 @@ def compile_triton_code_str(
 ):
     """Compile a Triton code string into a runnable Triton JIT function.
 
-    Writes the Triton code to a temporary file, compiles it, and extracts the
-    JIT function from the compiled namespace.
+    Materializes the Triton code under the persistent codegen cache, loads or
+    reuses the matching module object, and extracts the requested JIT function.
 
     Args:
-        triton_code (str): The Triton code string to compile.
+        triton_code (str): The Triton code string to compile/cache.
         kernel_name (str): The name of the Triton function to extract.
-        verbose (bool, optional): If True, print the path to the temporary file. Defaults to False.
+        verbose (bool, optional): If True, print whether the cached source was
+            written or reused, along with its path. Defaults to False.
         name_space (Optional[dict], optional): Optional globals injected before execution.
             When provided, it will be updated with symbols defined by the compiled module.
+            Calls without ``name_space`` reuse a cached module keyed by the generated
+            source hash; calls with ``name_space`` reload so injected symbols stay fresh.
 
     Returns:
         triton.JITFunction: The compiled Triton JIT function.
@@ -399,7 +408,7 @@ def compile_triton_code_str(
 
     linecache.checkcache(str(fpath))
 
-    with _MODULE_CACHE_LOCK:
+    with _get_module_cache_lock(module_name):
         module = sys.modules.get(module_name) if cacheable else None
         if module is None:
             spec = importlib.util.spec_from_file_location(module_name, fpath)

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -408,14 +408,14 @@ def compile_triton_code_str(
                 raise ImportError(f"Could not create import spec for {fpath}")
             module = importlib.util.module_from_spec(spec)
             module.__dict__.update(module_globals)
-            if cacheable:
-                sys.modules[module_name] = module
             try:
                 spec.loader.exec_module(module)
             except BaseException:
                 if cacheable:
                     sys.modules.pop(module_name, None)
                 raise
+            if cacheable:
+                sys.modules[module_name] = module
     if caller_namespace is not None:
         exported_symbols = {
             key: value

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -388,22 +388,24 @@ def compile_triton_code_str(
 
     needs_write = not fpath.exists()
     if needs_write:
-        with tempfile.NamedTemporaryFile(
-            "w", encoding="utf-8", dir=fpath.parent, delete=False, suffix=".tmp"
-        ) as tmp_file:
-            tmp_file.write(triton_code)
-            tmp_path = Path(tmp_file.name)
+        tmp_path = None
         try:
+            with tempfile.NamedTemporaryFile(
+                "w", encoding="utf-8", dir=fpath.parent, delete=False, suffix=".tmp"
+            ) as tmp_file:
+                tmp_path = Path(tmp_file.name)
+                tmp_file.write(triton_code)
             os.replace(tmp_path, fpath)
             try:
                 os.chmod(fpath, 0o600)
             except OSError:
                 pass
         except Exception:
-            try:
-                tmp_path.unlink()
-            except FileNotFoundError:
-                pass
+            if tmp_path is not None:
+                try:
+                    tmp_path.unlink()
+                except FileNotFoundError:
+                    pass
             raise
     if verbose:
         action = "written to" if needs_write else "loaded from cache"

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/torch2graph.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/torch2graph.py
@@ -3,7 +3,7 @@ from typing import Callable, Optional, Tuple
 
 import torch
 import torch.fx as fx
-from functorch.compile import aot_function
+from functorch.compile import aot_function, min_cut_rematerialization_partition
 
 warnings.filterwarnings("ignore", category=UserWarning)
 
@@ -102,6 +102,7 @@ def generate_forward_and_backward_graph(
         fn,
         fw_compiler=collector.get_forward_compiler(),
         bw_compiler=collector.get_backward_compiler(),
+        partition_fn=min_cut_rematerialization_partition,
     )
 
     if requires_grad is not None:

--- a/spikingjelly/activation_based/triton_kernel/triton_utils.py
+++ b/spikingjelly/activation_based/triton_kernel/triton_utils.py
@@ -7,6 +7,7 @@ import atexit
 import contextlib
 import functools
 import os
+import tempfile
 import threading
 from pathlib import Path
 from typing import Callable
@@ -139,15 +140,32 @@ _CLEANUP_TMP_PYTHON_FILES_REGISTERED = False
 _CLEANUP_TMP_PYTHON_FILES_REGISTERED_LOCK = threading.Lock()
 
 
+def _triton_codegen_cache_dirs():
+    uid = getattr(os, "getuid", lambda: None)()
+    temp_suffix = f"_{uid}" if uid is not None else ""
+    candidates = [
+        Path(tempfile.gettempdir()) / f"spikingjelly_triton_codegen{temp_suffix}"
+    ]
+    try:
+        candidates.append(Path.home() / ".spikingjelly" / "triton_codegen")
+    except RuntimeError:
+        pass
+    return candidates
+
+
 def cleanup_tmp_python_files():
     print("Cleaning up temporary python files!")
-    for f in Path("/tmp").glob("*.py"):
-        try:
-            f.unlink()
-        except FileNotFoundError:
-            pass
-        except BaseException:
-            pass  # ignore the errors
+    for cache_dir in _triton_codegen_cache_dirs():
+        if not cache_dir.is_dir():
+            continue
+        for pattern in ("*.py", "*.py.tmp", "*.tmp"):
+            for f in cache_dir.glob(pattern):
+                try:
+                    f.unlink()
+                except FileNotFoundError:
+                    pass
+                except BaseException:
+                    pass  # ignore the errors
 
 
 def ensure_cleanup_tmp_python_files(fn):

--- a/spikingjelly/activation_based/triton_kernel/triton_utils.py
+++ b/spikingjelly/activation_based/triton_kernel/triton_utils.py
@@ -143,7 +143,9 @@ def cleanup_tmp_python_files():
     print("Cleaning up temporary python files!")
     for f in Path("/tmp").glob("*.py"):
         try:
-            f.unlink(missing_ok=True)
+            f.unlink()
+        except FileNotFoundError:
+            pass
         except BaseException:
             pass  # ignore the errors
 

--- a/spikingjelly/activation_based/triton_kernel/triton_utils.py
+++ b/spikingjelly/activation_based/triton_kernel/triton_utils.py
@@ -6,6 +6,7 @@ https://github.com/fla-org/flash-linear-attention/blob/main/fla/utils.py
 import atexit
 import contextlib
 import functools
+import logging
 import os
 import tempfile
 import threading
@@ -138,6 +139,7 @@ else:
 
 _CLEANUP_TMP_PYTHON_FILES_REGISTERED = False
 _CLEANUP_TMP_PYTHON_FILES_REGISTERED_LOCK = threading.Lock()
+_logger = logging.getLogger(__name__)
 
 
 def _triton_codegen_cache_dirs():
@@ -164,8 +166,10 @@ def cleanup_tmp_python_files():
                     f.unlink()
                 except FileNotFoundError:
                     pass
-                except BaseException:
-                    pass  # ignore the errors
+                except Exception as exc:
+                    _logger.warning(
+                        "failed to remove temporary Triton file %s: %s", f, exc
+                    )
 
 
 def ensure_cleanup_tmp_python_files(fn):

--- a/spikingjelly/activation_based/triton_kernel/triton_utils.py
+++ b/spikingjelly/activation_based/triton_kernel/triton_utils.py
@@ -131,14 +131,3 @@ if _check_pytorch_version("2.4"):
 else:
     amp_custom_fwd = torch.cuda.amp.custom_fwd
     amp_custom_bwd = torch.cuda.amp.custom_bwd
-
-def cleanup_tmp_python_files():
-    return None
-
-
-def ensure_cleanup_tmp_python_files(fn):
-    @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
-        return fn(*args, **kwargs)
-
-    return wrapper

--- a/spikingjelly/activation_based/triton_kernel/triton_utils.py
+++ b/spikingjelly/activation_based/triton_kernel/triton_utils.py
@@ -3,14 +3,9 @@ https://github.com/AllenYolk/flash-snn/tree/main/flashsnn/utils
 https://github.com/fla-org/flash-linear-attention/blob/main/fla/utils.py
 """
 
-import atexit
 import contextlib
 import functools
-import logging
 import os
-import tempfile
-import threading
-from pathlib import Path
 from typing import Callable
 
 import torch
@@ -137,49 +132,13 @@ else:
     amp_custom_fwd = torch.cuda.amp.custom_fwd
     amp_custom_bwd = torch.cuda.amp.custom_bwd
 
-_CLEANUP_TMP_PYTHON_FILES_REGISTERED = False
-_CLEANUP_TMP_PYTHON_FILES_REGISTERED_LOCK = threading.Lock()
-_logger = logging.getLogger(__name__)
-
-
-def _triton_codegen_cache_dirs():
-    uid = getattr(os, "getuid", lambda: None)()
-    temp_suffix = f"_{uid}" if uid is not None else ""
-    candidates = [
-        Path(tempfile.gettempdir()) / f"spikingjelly_triton_codegen{temp_suffix}"
-    ]
-    try:
-        candidates.append(Path.home() / ".spikingjelly" / "triton_codegen")
-    except RuntimeError:
-        pass
-    return candidates
-
-
 def cleanup_tmp_python_files():
-    print("Cleaning up temporary python files!")
-    for cache_dir in _triton_codegen_cache_dirs():
-        if not cache_dir.is_dir():
-            continue
-        for pattern in ("*.py", "*.py.tmp", "*.tmp"):
-            for f in cache_dir.glob(pattern):
-                try:
-                    f.unlink()
-                except FileNotFoundError:
-                    pass
-                except Exception as exc:
-                    _logger.warning(
-                        "failed to remove temporary Triton file %s: %s", f, exc
-                    )
+    return None
 
 
 def ensure_cleanup_tmp_python_files(fn):
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        global _CLEANUP_TMP_PYTHON_FILES_REGISTERED
-        with _CLEANUP_TMP_PYTHON_FILES_REGISTERED_LOCK:
-            if not _CLEANUP_TMP_PYTHON_FILES_REGISTERED:
-                atexit.register(cleanup_tmp_python_files)
-                _CLEANUP_TMP_PYTHON_FILES_REGISTERED = True
         return fn(*args, **kwargs)
 
     return wrapper

--- a/test/activation_based/test_checkpointing.py
+++ b/test/activation_based/test_checkpointing.py
@@ -3,6 +3,7 @@ import copy
 import torch
 import torch.nn as nn
 
+import spikingjelly.activation_based.memopt as memopt
 from spikingjelly.activation_based.memopt.checkpointing import (
     in_gc_1st_forward,
     query_autocast,
@@ -16,7 +17,9 @@ from spikingjelly.activation_based.memopt.checkpointing import (
 )
 from spikingjelly.activation_based.memopt.compress import (
     BaseSpikeCompressor,
+    BitSpikeCompressor,
     NullSpikeCompressor,
+    SparseSpikeCompressor,
 )
 from spikingjelly.activation_based import neuron
 
@@ -53,6 +56,10 @@ def test_thread_local_functions():
             assert in_gc_1st_forward()
         assert in_gc_1st_forward()
     assert not in_gc_1st_forward()
+
+
+def test_memopt_package_imports_pipeline_api():
+    assert hasattr(memopt, "memory_optimization")
 
 
 def test_autocast_query():
@@ -97,6 +104,23 @@ def test_argument_separate_combine():
     assert torch.equal(combined[0], tensor1)
     assert combined[1] == "string"
     assert torch.equal(combined[2], tensor2)
+
+
+def test_compressors_accept_tuple_shapes_on_decompress():
+    bit_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    bit_spikes = torch.tensor(
+        [[1.0, 0.0, 1.0], [0.0, 1.0, 0.0]], device=bit_device
+    )
+    shape = tuple(bit_spikes.shape)
+
+    bit = BitSpikeCompressor()
+    bit_decompressed = bit.decompress(bit.compress(bit_spikes), shape)
+    torch.testing.assert_close(bit_decompressed, bit_spikes)
+
+    spikes = torch.tensor([[1.0, 0.0, 1.0], [0.0, 1.0, 0.0]])
+    sparse = SparseSpikeCompressor()
+    sparse_decompressed = sparse.decompress(sparse.compress(spikes), shape)
+    torch.testing.assert_close(sparse_decompressed, spikes)
 
 
 def test_input_compressed_gc():

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -861,8 +861,8 @@ def test_compile_spiking_vgg_hop_lowerable_while_loop_matches_eager(monkeypatch)
     def core(x, v):
         tau, v_th = 2.0, 1.0
         h = v + (x - v) / tau
-        s = (h >= v_th).to(h.dtype)
-        return s, h * (1.0 - s)
+        s = (h >= v_th).to(h.dtype).contiguous()
+        return s, (h * (1.0 - s)).contiguous()
 
     def make_flexsn(**kwargs):
         return FlexSN(
@@ -880,20 +880,27 @@ def test_compile_spiking_vgg_hop_lowerable_while_loop_matches_eager(monkeypatch)
     x_compiled = x_eager.detach().clone()
 
     torch.manual_seed(0)
-    model = spiking_vgg16_bn(
+    eager_model = spiking_vgg16_bn(
+        spiking_neuron=make_flexsn,
+        step_mode="m",
+    ).cuda().eval()
+    torch.manual_seed(0)
+    compiled_model = spiking_vgg16_bn(
         spiking_neuron=make_flexsn,
         step_mode="m",
     ).cuda().eval()
 
     from spikingjelly.activation_based import functional as sj_functional
-    sj_functional.set_step_mode(model, "m")
+    sj_functional.set_step_mode(eager_model, "m")
+    sj_functional.set_step_mode(compiled_model, "m")
 
     monkeypatch.setenv("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP", "1")
 
-    with torch.no_grad():
-        eager_out = model(x_eager)
-        compiled_model = torch.compile(model, fullgraph=True)
-        compiled_out = compiled_model(x_compiled)
+    with torch.backends.cudnn.flags(enabled=False):
+        with torch.no_grad():
+            eager_out = eager_model(x_eager)
+            compiled_model = torch.compile(compiled_model, fullgraph=True)
+            compiled_out = compiled_model(x_compiled)
 
     torch.testing.assert_close(compiled_out, eager_out, atol=1e-5, rtol=1e-4)
 

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -19,6 +19,7 @@ from spikingjelly.activation_based.neuron.flexsn import (
     FlexSN,
     _make_inductor_final_state_warmup_args,
 )
+from spikingjelly.activation_based.neuron import flexsn as flexsn_module
 from spikingjelly.activation_based.model.spiking_vgg import spiking_vgg16_bn
 from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
     flex_sn_scan,
@@ -128,6 +129,59 @@ def test_inductor_training_final_state_impl_t0_returns_non_aliased_states(
     assert tuple(y_seq.shape) == (0, 3)
     torch.testing.assert_close(v_final, v)
     assert v_final.data_ptr() != v.data_ptr()
+
+
+def test_inductor_training_final_state_backward_pads_missing_grads(monkeypatch):
+    from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
+        custom_ops,
+    )
+
+    x = torch.randn(2, 3)
+    v = torch.randn(3)
+    y = torch.randn(2, 3)
+    bundle = SimpleNamespace(
+        backward_kernel=object(),
+        training_info=SimpleNamespace(num_inputs=1, num_outputs=1, num_states=1),
+    )
+    ctx = SimpleNamespace(
+        handle=1,
+        input_template_specs=[
+            (tuple(x.shape), x.dtype, x.device),
+            (tuple(v.shape), v.dtype, v.device),
+        ],
+        output_template_specs=[(tuple(y.shape), y.dtype, y.device)],
+        state_seq_template_specs=[((x.shape[0], *v.shape), v.dtype, v.device)],
+        saved_tensors=[],
+        _active_ref_finalizer=SimpleNamespace(
+            alive=False,
+            detach=lambda: None,
+        ),
+    )
+    seen = {}
+
+    def fake_backward(handle, grad_inputs, saved_tensors, input_templates):
+        seen["grad_inputs"] = grad_inputs
+        assert handle == ctx.handle
+        assert saved_tensors == []
+        return [torch.zeros_like(x), torch.zeros_like(v)]
+
+    monkeypatch.setattr(custom_ops, "_lookup_kernel_handle", lambda handle: bundle)
+    monkeypatch.setattr(custom_ops, "flexsn_inductor_backward", fake_backward)
+    monkeypatch.setattr(
+        custom_ops,
+        "release_active_flexsn_kernel_handle",
+        lambda handle: None,
+    )
+
+    _, grads = custom_ops._flexsn_training_final_state_backward(ctx, [])
+
+    assert len(seen["grad_inputs"]) == 2
+    torch.testing.assert_close(seen["grad_inputs"][0], torch.zeros_like(y))
+    torch.testing.assert_close(
+        seen["grad_inputs"][1], torch.zeros((x.shape[0], *v.shape))
+    )
+    torch.testing.assert_close(grads[0], torch.zeros_like(x))
+    torch.testing.assert_close(grads[1], torch.zeros_like(v))
 
 
 @pytest.mark.parametrize("T", [1, 4, 16])
@@ -338,6 +392,31 @@ def test_hop_registers_with_dynamo():
 
     hop_var = TorchHigherOrderOperatorVariable.make(flex_sn_scan)
     assert hop_var.value is flex_sn_scan
+
+
+def test_run_hop_scan_compiled_falls_back_when_dynamo_hop_unavailable(monkeypatch):
+    x = torch.randn(2, 3)
+    v = torch.zeros(3)
+
+    def fake_hop(*args):
+        return ("hop",)
+
+    def fake_eager(*args):
+        return ("eager",)
+
+    monkeypatch.setattr(flexsn_module, "_is_compiling", lambda: True)
+    monkeypatch.setattr(flexsn_module, "_flexsn_lowerable_scan", None)
+    monkeypatch.setattr(flexsn_module, "_flexsn_lowerable_while_loop_scan", None)
+    monkeypatch.setattr(flexsn_module, "_flexsn_hop_scan", fake_hop)
+    monkeypatch.setattr(flexsn_module, "_flexsn_eager_scan", fake_eager)
+    monkeypatch.setattr(flexsn_module, "_flexsn_dynamo_hop_available", lambda: False)
+
+    result = flexsn_module._run_hop_scan(None, 1, 1, 1, True, x, v)
+    assert result == ("eager",)
+
+    monkeypatch.setattr(flexsn_module, "_flexsn_dynamo_hop_available", lambda: True)
+    result = flexsn_module._run_hop_scan(None, 1, 1, 1, True, x, v)
+    assert result == ("hop",)
 
 
 def test_lowerable_scan_matches_manual_loop(rng):

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -481,6 +481,36 @@ def test_compile_fullgraph_hop_backend_matches_eager(rng):
     torch.testing.assert_close(compiled_out, eager_out)
 
 
+def test_compile_fullgraph_hop_backend_matches_eager_with_closure(rng):
+    if sys.platform == "win32":
+        pytest.skip("torch.compile is not supported on Windows")
+
+    T, N = 4, 8
+    x_eager = torch.randn(T, N, generator=rng)
+    x_compiled = x_eager.detach().clone()
+    bias = torch.randn(N, generator=rng)
+
+    def core_with_bias(x, v):
+        return _differentiable_lif_core(x + bias, v)
+
+    def make_neuron():
+        return FlexSN(
+            core=core_with_bias,
+            num_inputs=1,
+            num_states=1,
+            num_outputs=1,
+            step_mode="m",
+            backend="hop",
+            example_inputs=(torch.zeros(N), torch.zeros(N)),
+        )
+
+    eager_out = make_neuron()(x_eager)
+    compiled_fn = torch.compile(make_neuron(), fullgraph=True)
+    compiled_out = compiled_fn(x_compiled)
+
+    torch.testing.assert_close(compiled_out, eager_out)
+
+
 def test_compile_fuses_surrounding_linear_layers(rng):
     """Linear -> FlexSN -> Linear must compile under fullgraph=True.
     On GPU this is the case Inductor fuses into a single kernel stack;

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -507,7 +507,8 @@ def test_compile_fullgraph_lowerable_while_loop_matches_eager(rng):
     eager_out = run_scan(x_eager, v0_eager)
     compiled_out = torch.compile(run_scan, fullgraph=True)(x_compiled, v0_compiled)
 
-    for compiled_tensor, eager_tensor in zip(compiled_out, eager_out, strict=True):
+    assert len(compiled_out) == len(eager_out)
+    for compiled_tensor, eager_tensor in zip(compiled_out, eager_out):
         torch.testing.assert_close(compiled_tensor, eager_tensor)
 
 

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -897,6 +897,34 @@ def test_run_hop_scan_forwards_output_template_specs(monkeypatch):
     assert captured["output_template_specs"] is specs
 
 
+def test_run_hop_scan_forwards_output_template_specs_to_hop(monkeypatch):
+    x = torch.empty(0, 2)
+    v = torch.zeros(3)
+    specs = (((4,), torch.float64, torch.device("cpu")),)
+    captured = {}
+
+    def fake_hop(*args, output_template_specs=None):
+        captured["output_template_specs"] = output_template_specs
+        return ("hop",)
+
+    monkeypatch.setattr(flexsn_module, "_is_compiling", lambda: False)
+    monkeypatch.setattr(flexsn_module, "_flexsn_hop_scan", fake_hop)
+
+    result = flexsn_module._run_hop_scan(
+        None,
+        1,
+        1,
+        1,
+        True,
+        x,
+        v,
+        output_template_specs=specs,
+    )
+
+    assert result == ("hop",)
+    assert captured["output_template_specs"] is specs
+
+
 def test_lowerable_scan_matches_manual_loop(rng):
     if not callable(lowerable_scan_available) or not lowerable_scan_available():
         pytest.skip("PyTorch scan HOP is unavailable in this environment")

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -33,6 +33,7 @@ from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
     lowerable_while_loop_scan,
     lowerable_while_loop_available,
 )
+from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import hop as hop_module
 
 
 def _lif_core(x: torch.Tensor, v: torch.Tensor):
@@ -165,6 +166,18 @@ def test_flexsn_rejects_invalid_example_output_template():
             backend="torch",
             example_outputs=(),
         )
+
+
+def test_output_template_specs_from_examples_use_first_input_contract():
+    specs = flexsn_module._make_output_template_specs_from_examples(
+        2,
+        (
+            torch.zeros(2, dtype=torch.float16),
+            torch.zeros(3, dtype=torch.float64),
+        ),
+    )
+
+    assert specs == (((2,), torch.float16), ((2,), torch.float16))
 
 
 def test_multi_step_forward_initializes_states_for_torch_backend():
@@ -697,6 +710,36 @@ def test_hop_registers_with_dynamo():
 
     hop_var = TorchHigherOrderOperatorVariable.make(flex_sn_scan)
     assert hop_var.value is flex_sn_scan
+
+
+def test_dynamo_body_result_templates_use_speculated_outputs():
+    class _FakeVar:
+        def __init__(self, example_value):
+            self._proxy = SimpleNamespace(
+                node=SimpleNamespace(meta={"example_value": example_value})
+            )
+
+        def as_proxy(self):
+            return self._proxy
+
+    class _FakeTupleVariable:
+        def __init__(self, items):
+            self.items = items
+
+    body_result = _FakeTupleVariable(
+        [
+            _FakeVar(torch.empty(2, dtype=torch.float64)),
+            _FakeVar(torch.empty(3, dtype=torch.float16)),
+            _FakeVar(torch.empty(4, dtype=torch.float32)),
+        ]
+    )
+
+    specs = hop_module._output_template_specs_from_dynamo_body_result(
+        body_result,
+        num_outputs=2,
+    )
+
+    assert specs == (((2,), torch.float64), ((3,), torch.float16))
 
 
 def test_run_hop_scan_compiled_falls_back_when_dynamo_hop_unavailable(monkeypatch):
@@ -1286,6 +1329,28 @@ def test_compile_fullgraph_hop_backend_matches_eager(rng):
     compiled_out = compiled_fn(x_compiled)
 
     torch.testing.assert_close(compiled_out, eager_out)
+
+
+def test_compile_fullgraph_hop_direct_zero_length_scan_uses_body_template():
+    if sys.platform == "win32":
+        pytest.skip("torch.compile is not supported on Windows")
+    _skip_if_dynamo_hop_unavailable()
+
+    def core(x_step, state):
+        return state + 1, state
+
+    x = torch.empty(0, 2)
+    state = torch.zeros(3)
+
+    @torch.compile(fullgraph=True)
+    def compiled_scan(x_seq, init_state):
+        return flex_sn_scan(core, 1, 1, 1, x_seq, init_state)
+
+    out, state_seq = compiled_scan(x, state)
+
+    assert out.shape == (0, 3)
+    assert state_seq.shape == (0, 3)
+    assert out.dtype == state.dtype
 
 
 def test_compile_fullgraph_hop_backend_matches_eager_with_closure(rng):

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -221,6 +221,20 @@ def test_flexsn_rejects_invalid_example_output_template():
         )
 
 
+def test_scan_backends_reject_mismatched_example_output_template():
+    with pytest.raises(ValueError, match="example_outputs"):
+        FlexSN(
+            core=_lif_core,
+            num_inputs=1,
+            num_states=1,
+            num_outputs=1,
+            step_mode="m",
+            backend="inductor",
+            example_inputs=(torch.zeros(3), torch.zeros(3)),
+            example_outputs=(torch.zeros(4),),
+        )
+
+
 def test_output_template_specs_from_outputs_preserve_device():
     output = torch.zeros(4, dtype=torch.float64)
 
@@ -1301,7 +1315,7 @@ def test_hop_backend_zero_length_sequence_matches_torch_backend():
     torch.testing.assert_close(hop_neuron.states[0], torch_neuron.states[0])
 
 
-def test_hop_backend_zero_length_sequence_uses_closure_output_shape():
+def test_hop_backend_zero_length_sequence_uses_example_output_template():
     x = torch.randn(0, 2)
     bias = torch.zeros(3)
     calls = {"count": 0}
@@ -1325,6 +1339,41 @@ def test_hop_backend_zero_length_sequence_uses_closure_output_shape():
     hop_out = hop_neuron(x)
     assert calls["count"] == 0
     assert hop_out.shape == (0, 3)
+
+
+def test_hop_backend_zero_length_sequence_delegates_to_hop_scan(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_run_hop_scan(
+        core,
+        num_inputs,
+        num_states,
+        num_outputs,
+        store_state_seqs,
+        *flat_args,
+        output_template_specs=None,
+    ):
+        calls["count"] += 1
+        assert flat_args[0].shape[0] == 0
+        assert output_template_specs is None
+        return (flat_args[0].new_empty((0, 5)),)
+
+    monkeypatch.setattr(flexsn_module, "_run_hop_scan", fake_run_hop_scan)
+    hop_neuron = FlexSN(
+        core=lambda x: (x.new_empty(5),),
+        num_inputs=1,
+        num_states=0,
+        num_outputs=1,
+        step_mode="m",
+        backend="hop",
+        store_state_seqs=False,
+        example_inputs=(torch.zeros(2),),
+    )
+
+    hop_out = hop_neuron(torch.empty(0, 2))
+
+    assert calls["count"] == 1
+    assert hop_out.shape == (0, 5)
 
 
 def test_compile_fullgraph_hop_store_state_seqs_false_matches_eager_with_lowerable_while_loop(

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -34,6 +34,8 @@ from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
     lowerable_while_loop_available,
 )
 from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import hop as hop_module
+from spikingjelly.activation_based.triton_kernel.flexsn import template as template_module
+from spikingjelly.activation_based.triton_kernel.flexsn.info import FlexSNInfo
 
 
 def _lif_core(x: torch.Tensor, v: torch.Tensor):
@@ -128,6 +130,30 @@ def test_torch_backend_empty_sequence_requires_example_output_template():
     assert calls["count"] == 0
 
 
+def test_torch_backend_empty_state_only_sequence_does_not_require_output_template():
+    calls = {"count": 0}
+
+    def core(x, v):
+        calls["count"] += 1
+        raise AssertionError("core should not run for an empty multi-step input")
+
+    m = FlexSN(
+        core=core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=0,
+        step_mode="m",
+        backend="torch",
+    )
+    m.states = [torch.zeros(3)]
+
+    outputs = m.multi_step_forward(torch.empty(0, 3))
+
+    assert calls["count"] == 0
+    assert outputs == []
+    torch.testing.assert_close(m.states[0], torch.zeros(3))
+
+
 def test_torch_backend_empty_sequence_uses_example_output_template_without_core_probe():
     calls = {"count": 0}
 
@@ -181,6 +207,14 @@ def test_output_template_specs_from_examples_use_first_input_contract():
         ((2,), torch.float16),
         ((2,), torch.float16),
     )
+
+
+def test_output_template_specs_from_outputs_preserve_device():
+    output = torch.zeros(4, dtype=torch.float64)
+
+    specs = flexsn_module._make_output_template_specs_from_outputs(1, (output,))
+
+    assert specs == (((4,), torch.float64, output.device),)
 
 
 def test_multi_step_forward_initializes_states_for_torch_backend():
@@ -947,6 +981,55 @@ def test_eager_scan_empty_sequence_uses_template_without_core_call():
     assert y_final.dtype == torch.float64
     torch.testing.assert_close(v_final, v0)
     assert v_final is not v0
+
+
+def test_eager_scan_empty_state_only_does_not_require_output_template():
+    calls = {"count": 0}
+
+    def core(x, v):
+        calls["count"] += 1
+        raise AssertionError("core should not run for an empty eager scan")
+
+    x = torch.empty(0, 2)
+    v0 = torch.ones(3)
+
+    (v_seq,) = eager_scan(core, 1, 1, 0, x, v0)
+    (v_final,) = eager_scan_final_state(core, 1, 1, 0, x, v0)
+
+    assert calls["count"] == 0
+    assert v_seq.shape == (0, 3)
+    torch.testing.assert_close(v_final, v0)
+    assert v_final is not v0
+
+
+def test_inference_final_state_template_handles_zero_states(monkeypatch):
+    captured = {}
+
+    def fake_compile(kernel_str, kernel_name, verbose):
+        compile(kernel_str, kernel_name, "exec")
+        captured["kernel_str"] = kernel_str
+        return object()
+
+    monkeypatch.setattr(template_module, "compile_triton_code_str", fake_compile)
+    info = FlexSNInfo(
+        num_inputs=1,
+        num_outputs=1,
+        num_states=0,
+        fwd_core_args=["x"],
+        fwd_core_returns=["s"],
+        fwd_core_recipients=["s0"],
+        fwd_kernel_returns=["s0"],
+        num_fwd_kernel_returns=1,
+        c2k_return_mapping=[],
+    )
+
+    template_module.get_flexsn_inference_final_state_kernel(
+        "@triton.jit\ndef core_12345678(x0):\n    return x0",
+        "core_12345678",
+        info,
+    )
+
+    assert "\n    , # inputs" not in captured["kernel_str"]
 
 
 def test_lowerable_while_loop_matches_manual_loop(rng):

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -133,12 +133,12 @@ def test_torch_backend_empty_sequence_requires_example_output_template():
     assert calls["count"] == 0
 
 
-def test_torch_backend_empty_sequence_can_use_example_input_template():
+def test_torch_backend_empty_sequence_rejects_example_input_template():
     calls = {"count": 0}
 
     def core(x, v):
         calls["count"] += 1
-        raise AssertionError("core should not run for an empty multi-step input")
+        return x.new_zeros(5), v
 
     m = FlexSN(
         core=core,
@@ -151,10 +151,10 @@ def test_torch_backend_empty_sequence_can_use_example_input_template():
     )
     m.states = [torch.zeros(3)]
 
-    out = m.multi_step_forward(torch.empty(0, 4))[0]
+    with pytest.raises(ValueError, match="requires example_outputs"):
+        m.multi_step_forward(torch.empty(0, 4))
 
     assert calls["count"] == 0
-    assert out.shape == (0, 4)
 
 
 def test_torch_backend_empty_state_only_sequence_does_not_require_output_template():
@@ -219,21 +219,6 @@ def test_flexsn_rejects_invalid_example_output_template():
             backend="torch",
             example_outputs=(),
         )
-
-
-def test_output_template_specs_from_examples_use_first_input_contract():
-    specs = flexsn_module._make_output_template_specs_from_examples(
-        2,
-        (
-            torch.zeros(2, dtype=torch.float16),
-            torch.zeros(3, dtype=torch.float64),
-        ),
-    )
-
-    assert specs == (
-        ((2,), torch.float16),
-        ((2,), torch.float16),
-    )
 
 
 def test_output_template_specs_from_outputs_preserve_device():
@@ -432,6 +417,25 @@ def test_codegen_stem_sanitizes_cache_filenames():
     assert graph2triton_module._safe_codegen_stem("bad/name?x") == "name_x"
     assert graph2triton_module._safe_codegen_stem("..") == "kernel"
     assert "__path__" in graph2triton_module._NAMESPACE_METADATA_KEYS
+
+
+def test_compile_triton_code_str_rejects_stale_namespace_symbol(
+    tmp_path, monkeypatch
+):
+    stale = object()
+    namespace = {"missing_kernel": stale}
+
+    monkeypatch.setattr(graph2triton_module, "_CODEGEN_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(graph2triton_module, "_has_real_triton_runtime", lambda: True)
+
+    with pytest.raises(ValueError, match="missing_kernel"):
+        graph2triton_module.compile_triton_code_str(
+            "other_symbol = 1\n",
+            "missing_kernel",
+            name_space=namespace,
+        )
+
+    assert namespace["missing_kernel"] is stale
 
 
 def test_flexsn_wrapper_t0_final_states_preserve_num_states_without_init():

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -100,6 +100,46 @@ def test_torch_backend_empty_sequence_does_not_probe_core_at_construction():
     assert out.shape == (0, 2)
 
 
+def test_torch_backend_empty_sequence_uses_example_output_template_without_core_probe():
+    calls = {"count": 0}
+
+    def core(x, v):
+        calls["count"] += 1
+        raise AssertionError("core should not run for an empty multi-step input")
+
+    m = FlexSN(
+        core=core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+        example_inputs=(torch.zeros(2), torch.zeros(3)),
+        example_outputs=(torch.zeros(4, dtype=torch.float64),),
+    )
+    assert calls["count"] == 0
+    m.states = [torch.zeros(3)]
+
+    out = m.multi_step_forward(torch.empty(0, 2))[0]
+
+    assert calls["count"] == 0
+    assert out.shape == (0, 4)
+    assert out.dtype == torch.float64
+
+
+def test_flexsn_rejects_invalid_example_output_template():
+    with pytest.raises(ValueError, match="expected 1 example output tensors"):
+        FlexSN(
+            core=_lif_core,
+            num_inputs=1,
+            num_states=1,
+            num_outputs=1,
+            step_mode="m",
+            backend="torch",
+            example_outputs=(),
+        )
+
+
 def test_multi_step_forward_initializes_states_for_torch_backend():
     m = FlexSN(
         core=_lif_core,

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -381,6 +381,36 @@ def test_hop_backend_store_state_seqs_false_matches_torch_backend(rng):
     torch.testing.assert_close(hop_neuron.states[0], torch_neuron.states[0])
 
 
+def test_hop_backend_zero_length_sequence_matches_torch_backend():
+    x = torch.randn(0, 8)
+
+    hop_neuron = FlexSN(
+        core=_differentiable_lif_core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="hop",
+        store_state_seqs=False,
+        example_inputs=(torch.zeros(8), torch.zeros(8)),
+    )
+    torch_neuron = FlexSN(
+        core=_differentiable_lif_core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+        store_state_seqs=False,
+    )
+
+    hop_out = hop_neuron(x)
+    torch_out = torch_neuron(x)
+
+    torch.testing.assert_close(hop_out, torch_out)
+    torch.testing.assert_close(hop_neuron.states[0], torch_neuron.states[0])
+
+
 def test_compile_fullgraph_hop_store_state_seqs_false_matches_eager_with_lowerable_while_loop(
     rng, monkeypatch
 ):

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -24,6 +24,8 @@ from spikingjelly.activation_based import base as base_module
 from spikingjelly.activation_based.model.spiking_vgg import spiking_vgg16_bn
 from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
     dynamo_hop_available,
+    eager_scan,
+    eager_scan_final_state,
     flex_sn_scan,
     lowerable_scan,
     lowerable_scan_final_state,
@@ -752,18 +754,51 @@ def test_lowerable_scan_empty_sequence_returns_templates_without_scan_op():
 
     def core(x, v):
         calls["count"] += 1
-        return x.new_empty(4), v.new_empty(5)
+        raise AssertionError("core should not run for an empty lowerable scan")
 
     x = torch.empty(0, 2)
     v0 = torch.zeros(3)
+    specs = (((4,), torch.float64),)
 
-    y_seq, v_seq = lowerable_scan(core, 1, 1, 1, x, v0)
-    y_final, v_final = lowerable_scan_final_state(core, 1, 1, 1, x, v0)
+    y_seq, v_seq = lowerable_scan(
+        core, 1, 1, 1, x, v0, output_template_specs=specs
+    )
+    y_final, v_final = lowerable_scan_final_state(
+        core, 1, 1, 1, x, v0, output_template_specs=specs
+    )
 
-    assert calls["count"] == 2
+    assert calls["count"] == 0
     assert y_seq.shape == (0, 4)
-    assert v_seq.shape == (0, 5)
+    assert y_seq.dtype == torch.float64
+    assert v_seq.shape == (0, 3)
     assert y_final.shape == (0, 4)
+    assert y_final.dtype == torch.float64
+    torch.testing.assert_close(v_final, v0)
+    assert v_final is not v0
+
+
+def test_eager_scan_empty_sequence_uses_template_without_core_call():
+    calls = {"count": 0}
+
+    def core(x, v):
+        calls["count"] += 1
+        raise AssertionError("core should not run for an empty eager scan")
+
+    x = torch.empty(0, 2)
+    v0 = torch.zeros(3)
+    specs = (((4,), torch.float64),)
+
+    y_seq, v_seq = eager_scan(core, 1, 1, 1, x, v0, output_template_specs=specs)
+    y_final, v_final = eager_scan_final_state(
+        core, 1, 1, 1, x, v0, output_template_specs=specs
+    )
+
+    assert calls["count"] == 0
+    assert y_seq.shape == (0, 4)
+    assert y_seq.dtype == torch.float64
+    assert v_seq.shape == (0, 3)
+    assert y_final.shape == (0, 4)
+    assert y_final.dtype == torch.float64
     torch.testing.assert_close(v_final, v0)
     assert v_final is not v0
 
@@ -899,6 +934,7 @@ def test_hop_backend_zero_length_sequence_matches_torch_backend():
         backend="hop",
         store_state_seqs=True,
         example_inputs=(torch.zeros(8), torch.zeros(8)),
+        example_outputs=(torch.zeros(8),),
     )
     torch_neuron = FlexSN(
         core=_differentiable_lif_core,
@@ -921,9 +957,11 @@ def test_hop_backend_zero_length_sequence_matches_torch_backend():
 def test_hop_backend_zero_length_sequence_uses_closure_output_shape():
     x = torch.randn(0, 2)
     bias = torch.zeros(3)
+    calls = {"count": 0}
 
     def core_with_closure(x_step):
-        return bias
+        calls["count"] += 1
+        raise AssertionError("core should not run for an empty hop input")
 
     hop_neuron = FlexSN(
         core=core_with_closure,
@@ -934,9 +972,11 @@ def test_hop_backend_zero_length_sequence_uses_closure_output_shape():
         backend="hop",
         store_state_seqs=False,
         example_inputs=(torch.zeros(2),),
+        example_outputs=(bias,),
     )
 
     hop_out = hop_neuron(x)
+    assert calls["count"] == 0
     assert hop_out.shape == (0, 3)
 
 

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -635,6 +635,30 @@ def test_compile_fullgraph_backward_matches_eager(rng):
     torch.testing.assert_close(x_compiled.grad, x_eager.grad)
 
 
+def test_compile_fullgraph_backward_store_state_seqs_false_matches_eager(rng):
+    T, N = 5, 8
+    x_eager = torch.randn(T, N, generator=rng, requires_grad=True)
+    x_compiled = x_eager.detach().clone().requires_grad_(True)
+
+    def make_neuron():
+        return FlexSN(
+            core=_differentiable_lif_core,
+            num_inputs=1,
+            num_states=1,
+            num_outputs=1,
+            step_mode="m",
+            backend="inductor",
+            store_state_seqs=False,
+        )
+
+    make_neuron()(x_eager).sum().backward()
+
+    compiled_fn = torch.compile(make_neuron(), fullgraph=True)
+    compiled_fn(x_compiled).sum().backward()
+
+    torch.testing.assert_close(x_compiled.grad, x_eager.grad)
+
+
 def test_compile_fullgraph_hop_backend_matches_eager(rng):
     if sys.platform == "win32":
         pytest.skip("torch.compile is not supported on Windows")
@@ -879,6 +903,46 @@ def test_inductor_compile_graph_elides_explicit_zero_state_init():
         for target in targets
     )
     assert not any("zeros_like" in target for target in targets)
+
+
+def test_inductor_compile_training_graph_uses_final_state_custom_op():
+    if sys.platform == "win32":
+        pytest.skip("torch.compile is not supported on Windows")
+    if not torch.cuda.is_available():
+        pytest.skip("inductor custom-op graph coverage is exercised on CUDA")
+
+    from torch._dynamo import explain
+
+    def core(x, v):
+        tau, v_th = 2.0, 1.0
+        h = v + (x - v) / tau
+        s = (h >= v_th).to(h.dtype)
+        return s, h * (1.0 - s)
+
+    T, N = 4, 8
+    torch.manual_seed(42)
+    x = torch.randn((T, N), device="cuda", requires_grad=True)
+    neuron = FlexSN(
+        core=core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="inductor",
+        store_state_seqs=False,
+    ).cuda().train()
+
+    explanation = explain(lambda inp: neuron(inp).sum())(x)
+    targets = [
+        str(node.target)
+        for graph in explanation.graphs
+        for node in graph.graph.nodes
+    ]
+
+    assert any(
+        "sj.flexsn_inductor_training_final_state.default" in target
+        for target in targets
+    )
 
 
 def test_aot_function_backward_numerical_match(rng):

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -10,11 +10,15 @@ so these tests do not require a CUDA GPU.
 from __future__ import annotations
 
 import sys
+from types import SimpleNamespace
 
 import pytest
 import torch
 
-from spikingjelly.activation_based.neuron.flexsn import FlexSN
+from spikingjelly.activation_based.neuron.flexsn import (
+    FlexSN,
+    _make_inductor_final_state_warmup_args,
+)
 from spikingjelly.activation_based.model.spiking_vgg import spiking_vgg16_bn
 from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
     flex_sn_scan,
@@ -38,6 +42,35 @@ def _lif_core(x: torch.Tensor, v: torch.Tensor):
 @pytest.fixture
 def rng():
     return torch.Generator().manual_seed(42)
+
+
+def test_inductor_final_state_warmup_args_use_example_shapes():
+    info = SimpleNamespace(num_inputs=2, num_states=2)
+    specs = (
+        ((3, 4), torch.float32),
+        ((5,), torch.float64),
+        ((3, 4), torch.float32),
+        ((2, 3), torch.float64),
+    )
+
+    warm_args = _make_inductor_final_state_warmup_args(
+        info,
+        torch.device("cpu"),
+        specs,
+    )
+
+    assert [tuple(arg.shape) for arg in warm_args] == [
+        (1, 3, 4),
+        (1, 5),
+        (3, 4),
+        (2, 3),
+    ]
+    assert [arg.dtype for arg in warm_args] == [
+        torch.float32,
+        torch.float64,
+        torch.float32,
+        torch.float64,
+    ]
 
 
 @pytest.mark.parametrize("T", [1, 4, 16])

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -177,7 +177,10 @@ def test_output_template_specs_from_examples_use_first_input_contract():
         ),
     )
 
-    assert specs == (((2,), torch.float16), ((2,), torch.float16))
+    assert specs == (
+        ((2,), torch.float16, torch.device("cpu")),
+        ((2,), torch.float16, torch.device("cpu")),
+    )
 
 
 def test_multi_step_forward_initializes_states_for_torch_backend():
@@ -309,6 +312,23 @@ def test_flexsn_wrapper_final_states_use_init_state_templates():
     assert final_state.dtype == torch.float64
     assert final_state.data_ptr() != state.data_ptr()
     torch.testing.assert_close(final_state, state)
+
+
+def test_flexsn_wrapper_t0_final_states_preserve_num_states_without_init():
+    from spikingjelly.activation_based.triton_kernel.flexsn.wrapper import (
+        flexsn_inference_final_state,
+    )
+
+    info = SimpleNamespace(num_inputs=1, num_states=2, num_outputs=1)
+    x = torch.empty(0, 3)
+
+    out, state0, state1 = flexsn_inference_final_state(None, info, x)
+
+    assert out.shape == (0, 3)
+    assert state0.shape == (3,)
+    assert state1.shape == (3,)
+    torch.testing.assert_close(state0, torch.zeros_like(state0))
+    torch.testing.assert_close(state1, torch.zeros_like(state1))
 
 
 def test_flexsn_wrapper_t0_backward_state_grads_use_state_templates(monkeypatch):
@@ -739,7 +759,10 @@ def test_dynamo_body_result_templates_use_speculated_outputs():
         num_outputs=2,
     )
 
-    assert specs == (((2,), torch.float64), ((3,), torch.float16))
+    assert specs == (
+        ((2,), torch.float64, torch.device("cpu")),
+        ((3,), torch.float16, torch.device("cpu")),
+    )
 
 
 def test_run_hop_scan_compiled_falls_back_when_dynamo_hop_unavailable(monkeypatch):
@@ -765,6 +788,35 @@ def test_run_hop_scan_compiled_falls_back_when_dynamo_hop_unavailable(monkeypatc
     monkeypatch.setattr(flexsn_module, "_flexsn_dynamo_hop_available", lambda: True)
     result = flexsn_module._run_hop_scan(None, 1, 1, 1, True, x, v)
     assert result == ("hop",)
+
+
+def test_run_hop_scan_forwards_output_template_specs(monkeypatch):
+    x = torch.empty(0, 2)
+    v = torch.zeros(3)
+    specs = (((4,), torch.float64, torch.device("cpu")),)
+    captured = {}
+
+    def fake_eager(*args, output_template_specs=None):
+        captured["output_template_specs"] = output_template_specs
+        return ("eager",)
+
+    monkeypatch.setattr(flexsn_module, "_is_compiling", lambda: False)
+    monkeypatch.setattr(flexsn_module, "_flexsn_hop_scan", None)
+    monkeypatch.setattr(flexsn_module, "_flexsn_eager_scan", fake_eager)
+
+    result = flexsn_module._run_hop_scan(
+        None,
+        1,
+        1,
+        1,
+        True,
+        x,
+        v,
+        output_template_specs=specs,
+    )
+
+    assert result == ("eager",)
+    assert captured["output_template_specs"] is specs
 
 
 def test_lowerable_scan_matches_manual_loop(rng):

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -329,7 +329,12 @@ def test_hop_rejects_mismatched_T():
 
 
 def test_hop_registers_with_dynamo():
-    from torch._dynamo.variables.higher_order_ops import TorchHigherOrderOperatorVariable
+    try:
+        from torch._dynamo.variables.higher_order_ops import (
+            TorchHigherOrderOperatorVariable,
+        )
+    except (ImportError, ModuleNotFoundError, AttributeError):
+        pytest.skip("torch._dynamo higher-order-op internals are unavailable")
 
     hop_var = TorchHigherOrderOperatorVariable.make(flex_sn_scan)
     assert hop_var.value is flex_sn_scan

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -156,6 +156,23 @@ def test_multi_step_forward_initializes_states_for_triton_backend():
     assert m.states[0].shape == (3,)
 
 
+def test_multi_step_forward_initializes_states_for_inductor_training_fallback():
+    m = FlexSN(
+        core=_lif_core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="inductor",
+    )
+
+    out = m.multi_step_forward(torch.randn(2, 3, requires_grad=True))[0]
+
+    assert out.shape == (2, 3)
+    assert m.states is not None
+    assert m.states[0].shape == (3,)
+
+
 def test_core_requires_grad_detects_functor_tensor_attributes():
     class Core:
         def __init__(self, weight):

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -20,6 +20,7 @@ from spikingjelly.activation_based.neuron.flexsn import (
     _make_inductor_final_state_warmup_args,
 )
 from spikingjelly.activation_based.neuron import flexsn as flexsn_module
+from spikingjelly.activation_based import base as base_module
 from spikingjelly.activation_based.model.spiking_vgg import spiking_vgg16_bn
 from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
     dynamo_hop_available,
@@ -51,14 +52,12 @@ def _skip_if_dynamo_hop_unavailable():
         pytest.skip("FlexSN Dynamo HOP registration is unavailable")
 
 
-def test_torch_backend_empty_sequence_uses_core_output_shape_and_cloned_states():
+def test_torch_backend_empty_sequence_does_not_call_core():
     calls = {"count": 0}
-    initial_state = torch.ones(3)
 
     def core(x, v):
         calls["count"] += 1
-        v.add_(1)
-        return x.new_zeros(4), v
+        raise AssertionError("core should not run for an empty multi-step input")
 
     m = FlexSN(
         core=core,
@@ -68,14 +67,12 @@ def test_torch_backend_empty_sequence_uses_core_output_shape_and_cloned_states()
         step_mode="m",
         backend="torch",
     )
-    m.states = [initial_state.clone()]
 
     out = m(torch.empty(0, 3))
 
-    assert calls["count"] == 1
-    assert out.shape == (0, 4)
+    assert calls["count"] == 0
+    assert out.shape == (0, 3)
     assert m.states[0].shape == (3,)
-    torch.testing.assert_close(m.states[0], initial_state)
 
 
 def test_torch_backend_empty_sequence_does_not_probe_core_at_construction():
@@ -99,8 +96,8 @@ def test_torch_backend_empty_sequence_does_not_probe_core_at_construction():
 
     out = m.multi_step_forward(torch.empty(0, 2))[0]
 
-    assert calls["count"] == 1
-    assert out.shape == (0, 4)
+    assert calls["count"] == 0
+    assert out.shape == (0, 2)
 
 
 def test_multi_step_forward_initializes_states_for_torch_backend():
@@ -137,7 +134,7 @@ def test_multi_step_forward_initializes_states_for_hop_backend():
     assert m.states[0].shape == (3,)
 
 
-def test_multi_step_forward_initializes_states_for_triton_backend():
+def test_multi_step_forward_initializes_states_for_triton_backend(monkeypatch):
     class FakeKernel:
         def __call__(self, x_seq, v):
             assert v.shape == x_seq.shape[1:]
@@ -151,7 +148,8 @@ def test_multi_step_forward_initializes_states_for_triton_backend():
         step_mode="m",
         backend="torch",
     )
-    m._backend = "triton"
+    monkeypatch.setattr(base_module, "triton", object())
+    m.backend = "triton"
     m.kernel = FakeKernel()
 
     out = m.multi_step_forward(torch.randn(2, 3))[0]
@@ -190,6 +188,18 @@ def test_core_requires_grad_detects_functor_tensor_attributes():
     assert not flexsn_module._core_requires_grad(
         Core(torch.ones(3, requires_grad=False))
     )
+
+
+def test_core_requires_grad_detects_bound_method_self_parameters():
+    class Core(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.ones(3))
+
+        def forward(self, x, v):
+            return x * self.weight, v
+
+    assert flexsn_module._core_requires_grad(Core().forward)
 
 
 def test_flexsn_wrapper_final_states_use_init_state_templates():

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -132,6 +132,44 @@ def test_multi_step_forward_initializes_states_for_hop_backend():
     assert m.states[0].shape == (3,)
 
 
+def test_multi_step_forward_initializes_states_for_triton_backend():
+    class FakeKernel:
+        def __call__(self, x_seq, v):
+            assert v.shape == x_seq.shape[1:]
+            return x_seq.new_zeros(x_seq.shape), x_seq.new_zeros(x_seq.shape)
+
+    m = FlexSN(
+        core=_lif_core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+    )
+    m._backend = "triton"
+    m.kernel = FakeKernel()
+
+    out = m.multi_step_forward(torch.randn(2, 3))[0]
+
+    assert out.shape == (2, 3)
+    assert m.states is not None
+    assert m.states[0].shape == (3,)
+
+
+def test_core_requires_grad_detects_functor_tensor_attributes():
+    class Core:
+        def __init__(self, weight):
+            self.weight = weight
+
+        def __call__(self, x, v):
+            return x * self.weight, v
+
+    assert flexsn_module._core_requires_grad(Core(torch.ones(3, requires_grad=True)))
+    assert not flexsn_module._core_requires_grad(
+        Core(torch.ones(3, requires_grad=False))
+    )
+
+
 def test_flexsn_wrapper_final_states_use_init_state_templates():
     from spikingjelly.activation_based.triton_kernel.flexsn.wrapper import (
         flexsn_inference_final_state,

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -797,19 +797,19 @@ def test_inductor_compile_graph_elides_explicit_zero_state_init():
             backend="inductor",
         )
 
-    T, B, C, H, W = 4, 8, 3, 32, 32
+    T, N = 4, 8
     torch.manual_seed(42)
-    x = torch.randn((T, B, C, H, W), device="cuda")
-    model = spiking_vgg16_bn(
-        spiking_neuron=make_flexsn,
-        step_mode="m",
-    ).cuda().eval()
+    x = torch.randn((T, N), device="cuda")
+    neuron = make_flexsn(store_state_seqs=False).cuda().eval()
 
     with torch.no_grad():
-        explanation = explain(model)(x)
-    targets = [str(node.target) for node in explanation.graphs[0].graph.nodes]
+        explanation = explain(neuron)(x)
+    targets = [str(node.target) for graph in explanation.graphs for node in graph.graph.nodes]
 
-    assert any("sj.flexsn_inductor_inference.default" in target for target in targets)
+    assert any(
+        "sj.flexsn_inductor_inference_final_state.default" in target
+        for target in targets
+    )
     assert not any("zeros_like" in target for target in targets)
 
 

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -411,6 +411,28 @@ def test_hop_backend_zero_length_sequence_matches_torch_backend():
     torch.testing.assert_close(hop_neuron.states[0], torch_neuron.states[0])
 
 
+def test_hop_backend_zero_length_sequence_uses_closure_output_shape():
+    x = torch.randn(0, 2)
+    bias = torch.zeros(3)
+
+    def core_with_closure(x_step):
+        return bias
+
+    hop_neuron = FlexSN(
+        core=core_with_closure,
+        num_inputs=1,
+        num_states=0,
+        num_outputs=1,
+        step_mode="m",
+        backend="hop",
+        store_state_seqs=False,
+        example_inputs=(torch.zeros(2),),
+    )
+
+    hop_out = hop_neuron(x)
+    assert hop_out.shape == (0, 3)
+
+
 def test_compile_fullgraph_hop_store_state_seqs_false_matches_eager_with_lowerable_while_loop(
     rng, monkeypatch
 ):

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -217,6 +217,21 @@ def test_output_template_specs_from_outputs_preserve_device():
     assert specs == (((4,), torch.float64, output.device),)
 
 
+def test_empty_multistep_outputs_honor_template_device():
+    specs = (((4,), torch.float64, torch.device("meta")),)
+
+    outputs = flexsn_module._empty_multistep_outputs((torch.empty(0, 3),), [], 1, specs)
+
+    assert outputs[0].shape == (0, 4)
+    assert outputs[0].dtype == torch.float64
+    assert outputs[0].device.type == "meta"
+
+
+def test_empty_multistep_outputs_rejects_missing_template_reference():
+    with pytest.raises(ValueError, match="at least one input or state"):
+        flexsn_module._empty_multistep_outputs((), [], 1)
+
+
 def test_multi_step_forward_initializes_states_for_torch_backend():
     m = FlexSN(
         core=_lif_core,

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -26,6 +26,7 @@ from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
     dynamo_hop_available,
     flex_sn_scan,
     lowerable_scan,
+    lowerable_scan_final_state,
     lowerable_scan_available,
     lowerable_while_loop_scan,
     lowerable_while_loop_available,
@@ -66,6 +67,7 @@ def test_torch_backend_empty_sequence_does_not_call_core():
         num_outputs=1,
         step_mode="m",
         backend="torch",
+        example_outputs=(torch.zeros(3),),
     )
 
     out = m(torch.empty(0, 3))
@@ -90,6 +92,7 @@ def test_torch_backend_empty_sequence_does_not_probe_core_at_construction():
         step_mode="m",
         backend="torch",
         example_inputs=(torch.zeros(2), torch.zeros(3)),
+        example_outputs=(torch.zeros(4),),
     )
     assert calls["count"] == 0
     m.states = [torch.zeros(3)]
@@ -97,7 +100,29 @@ def test_torch_backend_empty_sequence_does_not_probe_core_at_construction():
     out = m.multi_step_forward(torch.empty(0, 2))[0]
 
     assert calls["count"] == 0
-    assert out.shape == (0, 2)
+    assert out.shape == (0, 4)
+
+
+def test_torch_backend_empty_sequence_requires_example_output_template():
+    calls = {"count": 0}
+
+    def core(x, v):
+        calls["count"] += 1
+        return x, v
+
+    m = FlexSN(
+        core=core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+    )
+
+    with pytest.raises(ValueError, match="requires example_outputs"):
+        m(torch.empty(0, 3))
+
+    assert calls["count"] == 0
 
 
 def test_torch_backend_empty_sequence_uses_example_output_template_without_core_probe():
@@ -235,6 +260,17 @@ def test_core_requires_grad_detects_bound_method_self_parameters():
         def __init__(self):
             super().__init__()
             self.weight = torch.nn.Parameter(torch.ones(3))
+
+        def forward(self, x, v):
+            return x * self.weight, v
+
+    assert flexsn_module._core_requires_grad(Core().forward)
+
+
+def test_core_requires_grad_detects_plain_bound_method_self_tensors():
+    class Core:
+        def __init__(self):
+            self.weight = torch.ones(3, requires_grad=True)
 
         def forward(self, x, v):
             return x * self.weight, v
@@ -708,6 +744,30 @@ def test_lowerable_scan_matches_manual_loop(rng):
     torch.testing.assert_close(v_seq, torch.stack(expected_v, dim=0))
 
 
+def test_lowerable_scan_empty_sequence_returns_templates_without_scan_op():
+    if not callable(lowerable_scan_available) or not lowerable_scan_available():
+        pytest.skip("PyTorch scan HOP is unavailable in this environment")
+
+    calls = {"count": 0}
+
+    def core(x, v):
+        calls["count"] += 1
+        return x.new_empty(4), v.new_empty(5)
+
+    x = torch.empty(0, 2)
+    v0 = torch.zeros(3)
+
+    y_seq, v_seq = lowerable_scan(core, 1, 1, 1, x, v0)
+    y_final, v_final = lowerable_scan_final_state(core, 1, 1, 1, x, v0)
+
+    assert calls["count"] == 2
+    assert y_seq.shape == (0, 4)
+    assert v_seq.shape == (0, 5)
+    assert y_final.shape == (0, 4)
+    torch.testing.assert_close(v_final, v0)
+    assert v_final is not v0
+
+
 def test_lowerable_while_loop_matches_manual_loop(rng):
     if (
         not callable(lowerable_while_loop_available)
@@ -848,6 +908,7 @@ def test_hop_backend_zero_length_sequence_matches_torch_backend():
         step_mode="m",
         backend="torch",
         store_state_seqs=True,
+        example_outputs=(torch.zeros(8),),
     )
 
     hop_out = hop_neuron(x)

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -36,6 +36,9 @@ from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
 from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import hop as hop_module
 from spikingjelly.activation_based.triton_kernel.flexsn import template as template_module
 from spikingjelly.activation_based.triton_kernel.flexsn.info import FlexSNInfo
+from spikingjelly.activation_based.triton_kernel.torch2triton import (
+    graph2triton as graph2triton_module,
+)
 
 
 def _lif_core(x: torch.Tensor, v: torch.Tensor):
@@ -379,6 +382,18 @@ def test_core_requires_grad_detects_bound_method_self_parameters():
     assert flexsn_module._core_requires_grad(Core().forward)
 
 
+def test_core_requires_grad_detects_module_unregistered_tensors():
+    class Core(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.ones(3, requires_grad=True)
+
+        def forward(self, x, v):
+            return x * self.weight, v
+
+    assert flexsn_module._core_requires_grad(Core().forward)
+
+
 def test_core_requires_grad_detects_plain_bound_method_self_tensors():
     class Core:
         def __init__(self):
@@ -393,11 +408,14 @@ def test_core_requires_grad_detects_plain_bound_method_self_tensors():
 def test_flexsn_wrapper_final_states_use_init_state_templates():
     from spikingjelly.activation_based.triton_kernel.flexsn.wrapper import (
         flexsn_inference_final_state,
+        _num_elements_per_step,
     )
 
     info = SimpleNamespace(num_inputs=1, num_states=1, num_outputs=1)
     x = torch.empty(0, 2)
     state = torch.ones(3, dtype=torch.float64)
+
+    assert _num_elements_per_step(x) == 2
 
     out, final_state = flexsn_inference_final_state(None, info, x, state)
 
@@ -406,6 +424,14 @@ def test_flexsn_wrapper_final_states_use_init_state_templates():
     assert final_state.dtype == torch.float64
     assert final_state.data_ptr() != state.data_ptr()
     torch.testing.assert_close(final_state, state)
+
+
+def test_codegen_stem_sanitizes_cache_filenames():
+    assert graph2triton_module._safe_codegen_stem("../escape") == "escape"
+    assert graph2triton_module._safe_codegen_stem("/tmp/absolute") == "absolute"
+    assert graph2triton_module._safe_codegen_stem("bad/name?x") == "name_x"
+    assert graph2triton_module._safe_codegen_stem("..") == "kernel"
+    assert "__path__" in graph2triton_module._NAMESPACE_METADATA_KEYS
 
 
 def test_flexsn_wrapper_t0_final_states_preserve_num_states_without_init():

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -176,6 +176,13 @@ def test_hop_rejects_mismatched_T():
         flex_sn_scan(two_input_core, 2, 1, 1, x1, x2, v0)
 
 
+def test_hop_registers_with_dynamo():
+    from torch._dynamo.variables.higher_order_ops import TorchHigherOrderOperatorVariable
+
+    hop_var = TorchHigherOrderOperatorVariable.make(flex_sn_scan)
+    assert hop_var.value is flex_sn_scan
+
+
 # -------------------------------------------------------------------------
 # M2: backward / autograd tests
 # -------------------------------------------------------------------------

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -45,6 +45,29 @@ def rng():
     return torch.Generator().manual_seed(42)
 
 
+def test_torch_backend_empty_sequence_does_not_call_core():
+    calls = {"count": 0}
+
+    def core(x, v):
+        calls["count"] += 1
+        raise AssertionError("core should not run for an empty multi-step input")
+
+    m = FlexSN(
+        core=core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+    )
+
+    out = m(torch.empty(0, 3))
+
+    assert calls["count"] == 0
+    assert out.shape == (0, 3)
+    assert m.states[0].shape == (3,)
+
+
 def test_inductor_final_state_warmup_args_use_example_shapes():
     info = SimpleNamespace(num_inputs=2, num_states=2)
     specs = (

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -130,6 +130,30 @@ def test_torch_backend_empty_sequence_requires_example_output_template():
     assert calls["count"] == 0
 
 
+def test_torch_backend_empty_sequence_can_use_example_input_template():
+    calls = {"count": 0}
+
+    def core(x, v):
+        calls["count"] += 1
+        raise AssertionError("core should not run for an empty multi-step input")
+
+    m = FlexSN(
+        core=core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+        example_inputs=(torch.zeros(4), torch.zeros(3)),
+    )
+    m.states = [torch.zeros(3)]
+
+    out = m.multi_step_forward(torch.empty(0, 4))[0]
+
+    assert calls["count"] == 0
+    assert out.shape == (0, 4)
+
+
 def test_torch_backend_empty_state_only_sequence_does_not_require_output_template():
     calls = {"count": 0}
 
@@ -225,6 +249,27 @@ def test_empty_multistep_outputs_honor_template_device():
     assert outputs[0].shape == (0, 4)
     assert outputs[0].dtype == torch.float64
     assert outputs[0].device.type == "meta"
+
+
+def test_flexsn_empty_multistep_outputs_follow_runtime_device():
+    def core(x, v):
+        raise AssertionError("core should not run for an empty multi-step input")
+
+    m = FlexSN(
+        core=core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+        example_outputs=(torch.empty(4, device="meta"),),
+    )
+    m.states = [torch.zeros(3)]
+
+    out = m.multi_step_forward(torch.empty(0, 2))[0]
+
+    assert out.shape == (0, 4)
+    assert out.device.type == "cpu"
 
 
 def test_empty_multistep_outputs_rejects_missing_template_reference():

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -9,6 +9,8 @@ so these tests do not require a CUDA GPU.
 """
 from __future__ import annotations
 
+import sys
+
 import pytest
 import torch
 
@@ -82,6 +84,37 @@ def test_inductor_backend_matches_torch_backend(rng, T, shape):
     torch.testing.assert_close(inductor_out, torch_out)
     assert len(inductor_neuron.states) == 1
     torch.testing.assert_close(inductor_neuron.states[0], torch_neuron.states[0])
+
+
+@pytest.mark.parametrize("T", [1, 4, 16])
+@pytest.mark.parametrize("shape", [(8,), (4, 8)])
+def test_hop_backend_matches_torch_backend(rng, T, shape):
+    x = torch.randn((T, *shape), generator=rng)
+
+    torch_neuron = FlexSN(
+        core=_lif_core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+    )
+    hop_neuron = FlexSN(
+        core=_lif_core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="hop",
+        example_inputs=(torch.zeros(shape), torch.zeros(shape)),
+    )
+
+    torch_out = torch_neuron(x)
+    hop_out = hop_neuron(x)
+
+    torch.testing.assert_close(hop_out, torch_out)
+    assert len(hop_neuron.states) == 1
+    torch.testing.assert_close(hop_neuron.states[0], torch_neuron.states[0])
 
 
 def test_inductor_backend_store_state_seqs(rng):
@@ -358,6 +391,32 @@ def test_compile_fullgraph_backward_matches_eager(rng):
     compiled_fn(x_compiled).sum().backward()
 
     torch.testing.assert_close(x_compiled.grad, x_eager.grad)
+
+
+def test_compile_fullgraph_hop_backend_matches_eager(rng):
+    if sys.platform == "win32":
+        pytest.skip("torch.compile is not supported on Windows")
+
+    T, N = 4, 8
+    x_eager = torch.randn(T, N, generator=rng)
+    x_compiled = x_eager.detach().clone()
+
+    def make_neuron():
+        return FlexSN(
+            core=_differentiable_lif_core,
+            num_inputs=1,
+            num_states=1,
+            num_outputs=1,
+            step_mode="m",
+            backend="hop",
+            example_inputs=(torch.zeros(N), torch.zeros(N)),
+        )
+
+    eager_out = make_neuron()(x_eager)
+    compiled_fn = torch.compile(make_neuron(), fullgraph=True)
+    compiled_out = compiled_fn(x_compiled)
+
+    torch.testing.assert_close(compiled_out, eager_out)
 
 
 def test_compile_fuses_surrounding_linear_layers(rng):

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -51,12 +51,14 @@ def _skip_if_dynamo_hop_unavailable():
         pytest.skip("FlexSN Dynamo HOP registration is unavailable")
 
 
-def test_torch_backend_empty_sequence_does_not_call_core():
+def test_torch_backend_empty_sequence_uses_core_output_shape_and_cloned_states():
     calls = {"count": 0}
+    initial_state = torch.ones(3)
 
     def core(x, v):
         calls["count"] += 1
-        raise AssertionError("core should not run for an empty multi-step input")
+        v.add_(1)
+        return x.new_zeros(4), v
 
     m = FlexSN(
         core=core,
@@ -66,15 +68,17 @@ def test_torch_backend_empty_sequence_does_not_call_core():
         step_mode="m",
         backend="torch",
     )
+    m.states = [initial_state.clone()]
 
     out = m(torch.empty(0, 3))
 
-    assert calls["count"] == 0
-    assert out.shape == (0, 3)
+    assert calls["count"] == 1
+    assert out.shape == (0, 4)
     assert m.states[0].shape == (3,)
+    torch.testing.assert_close(m.states[0], initial_state)
 
 
-def test_torch_backend_empty_sequence_uses_example_input_template_without_core_probe():
+def test_torch_backend_empty_sequence_does_not_probe_core_at_construction():
     calls = {"count": 0}
 
     def core(x, v):
@@ -90,12 +94,13 @@ def test_torch_backend_empty_sequence_uses_example_input_template_without_core_p
         backend="torch",
         example_inputs=(torch.zeros(2), torch.zeros(3)),
     )
+    assert calls["count"] == 0
     m.states = [torch.zeros(3)]
 
     out = m.multi_step_forward(torch.empty(0, 2))[0]
 
-    assert calls["count"] == 0
-    assert out.shape == (0, 2)
+    assert calls["count"] == 1
+    assert out.shape == (0, 4)
 
 
 def test_multi_step_forward_initializes_states_for_torch_backend():

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -22,6 +22,7 @@ from spikingjelly.activation_based.neuron.flexsn import (
 from spikingjelly.activation_based.neuron import flexsn as flexsn_module
 from spikingjelly.activation_based.model.spiking_vgg import spiking_vgg16_bn
 from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
+    dynamo_hop_available,
     flex_sn_scan,
     lowerable_scan,
     lowerable_scan_available,
@@ -45,6 +46,11 @@ def rng():
     return torch.Generator().manual_seed(42)
 
 
+def _skip_if_dynamo_hop_unavailable():
+    if not callable(dynamo_hop_available) or not dynamo_hop_available():
+        pytest.skip("FlexSN Dynamo HOP registration is unavailable")
+
+
 def test_torch_backend_empty_sequence_does_not_call_core():
     calls = {"count": 0}
 
@@ -66,6 +72,116 @@ def test_torch_backend_empty_sequence_does_not_call_core():
     assert calls["count"] == 0
     assert out.shape == (0, 3)
     assert m.states[0].shape == (3,)
+
+
+def test_torch_backend_empty_sequence_uses_example_output_template():
+    calls = {"count": 0}
+
+    def core(x, v):
+        calls["count"] += 1
+        return x.new_zeros(4), v
+
+    m = FlexSN(
+        core=core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+        example_inputs=(torch.zeros(2), torch.zeros(3)),
+    )
+    m.states = [torch.zeros(3)]
+    calls["count"] = 0
+
+    out = m.multi_step_forward(torch.empty(0, 2))[0]
+
+    assert calls["count"] == 0
+    assert out.shape == (0, 4)
+
+
+def test_multi_step_forward_initializes_states_for_torch_backend():
+    m = FlexSN(
+        core=_lif_core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+    )
+
+    out = m.multi_step_forward(torch.randn(2, 3))[0]
+
+    assert out.shape == (2, 3)
+    assert m.states is not None
+    assert m.states[0].shape == (3,)
+
+
+def test_multi_step_forward_initializes_states_for_hop_backend():
+    m = FlexSN(
+        core=_lif_core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="hop",
+    )
+
+    out = m.multi_step_forward(torch.randn(2, 3))[0]
+
+    assert out.shape == (2, 3)
+    assert m.states is not None
+    assert m.states[0].shape == (3,)
+
+
+def test_flexsn_wrapper_final_states_use_init_state_templates():
+    from spikingjelly.activation_based.triton_kernel.flexsn.wrapper import (
+        flexsn_inference_final_state,
+    )
+
+    info = SimpleNamespace(num_inputs=1, num_states=1, num_outputs=1)
+    x = torch.empty(0, 2)
+    state = torch.ones(3, dtype=torch.float64)
+
+    out, final_state = flexsn_inference_final_state(None, info, x, state)
+
+    assert out.shape == (0, 2)
+    assert final_state.shape == (3,)
+    assert final_state.dtype == torch.float64
+    assert final_state.data_ptr() != state.data_ptr()
+    torch.testing.assert_close(final_state, state)
+
+
+def test_flexsn_wrapper_t0_backward_state_grads_use_state_templates(monkeypatch):
+    from spikingjelly.activation_based.triton_kernel.flexsn import wrapper
+
+    class _FakeKernel:
+        def __getitem__(self, grid):
+            def _run(*args, **kwargs):
+                return None
+
+            return _run
+
+    info = SimpleNamespace(num_inputs=1, num_states=2, num_outputs=1)
+    grad_y = torch.empty(0, 2)
+    grad_s0 = torch.empty(0, 3)
+    grad_s1 = torch.empty(0, 4, dtype=torch.float64)
+
+    monkeypatch.setitem(wrapper.type_dict, grad_y.dtype, "float32")
+
+    grad_x, grad_v0, grad_v1 = wrapper.flexsn_backward(
+        _FakeKernel(),
+        info,
+        grad_y,
+        grad_s0,
+        grad_s1,
+    )
+
+    assert grad_x.shape == (0, 2)
+    assert grad_v0.shape == (3,)
+    assert grad_v1.shape == (4,)
+    assert grad_v1.dtype == torch.float64
+    torch.testing.assert_close(grad_v0, torch.zeros_like(grad_v0))
+    torch.testing.assert_close(grad_v1, torch.zeros_like(grad_v1))
 
 
 def test_inductor_final_state_warmup_args_use_example_shapes():
@@ -937,6 +1053,7 @@ def test_compile_fullgraph_backward_store_state_seqs_false_matches_eager(rng):
 def test_compile_fullgraph_hop_backend_matches_eager(rng):
     if sys.platform == "win32":
         pytest.skip("torch.compile is not supported on Windows")
+    _skip_if_dynamo_hop_unavailable()
 
     T, N = 4, 8
     x_eager = torch.randn(T, N, generator=rng)
@@ -964,6 +1081,7 @@ def test_compile_fullgraph_hop_backend_matches_eager(rng):
 def test_compile_fullgraph_hop_backend_matches_eager_with_closure(rng):
     if sys.platform == "win32":
         pytest.skip("torch.compile is not supported on Windows")
+    _skip_if_dynamo_hop_unavailable()
 
     T, N = 4, 8
     x_eager = torch.randn(T, N, generator=rng)

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -331,6 +331,35 @@ def test_flexsn_wrapper_t0_final_states_preserve_num_states_without_init():
     torch.testing.assert_close(state1, torch.zeros_like(state1))
 
 
+def test_flexsn_wrappers_skip_kernel_launch_for_t0():
+    from spikingjelly.activation_based.triton_kernel.flexsn import wrapper
+
+    class _RaisingKernel:
+        def __getitem__(self, grid):
+            raise AssertionError("T == 0 wrappers should not launch Triton")
+
+    x = torch.empty(0, 3)
+    info = SimpleNamespace(
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        num_fwd_kernel_returns=2,
+    )
+
+    inference_outputs = wrapper.flexsn_inference(_RaisingKernel(), info, x)
+    forward_outputs = wrapper.flexsn_forward(_RaisingKernel(), info, x)
+    backward_outputs = wrapper.flexsn_backward(_RaisingKernel(), info, x)
+
+    assert [tuple(t.shape) for t in inference_outputs] == [(0, 3), (0, 3)]
+    assert [tuple(t.shape) for t in forward_outputs] == [(0, 3), (0, 3)]
+    assert [tuple(t.shape) for t in backward_outputs] == [(0, 3), (3,)]
+    torch.testing.assert_close(backward_outputs[0], torch.zeros_like(x))
+    torch.testing.assert_close(
+        backward_outputs[1],
+        torch.zeros_like(backward_outputs[1]),
+    )
+
+
 def test_flexsn_wrapper_t0_backward_state_grads_use_state_templates(monkeypatch):
     from spikingjelly.activation_based.triton_kernel.flexsn import wrapper
 
@@ -839,6 +868,28 @@ def test_lowerable_scan_matches_manual_loop(rng):
 
     torch.testing.assert_close(s_seq, torch.stack(expected_s, dim=0))
     torch.testing.assert_close(v_seq, torch.stack(expected_v, dim=0))
+
+
+def test_lowerable_scan_return_order_with_unequal_outputs_and_states():
+    if not callable(lowerable_scan_available) or not lowerable_scan_available():
+        pytest.skip("PyTorch scan HOP is unavailable in this environment")
+
+    def core(x, v):
+        next_v = v + x
+        return x, x + 1, next_v
+
+    x = torch.arange(6, dtype=torch.float32).reshape(3, 2)
+    v0 = torch.zeros(2)
+
+    y0_seq, y1_seq, v_seq = lowerable_scan(core, 1, 1, 2, x, v0)
+    y0_final, y1_final, v_final = lowerable_scan_final_state(core, 1, 1, 2, x, v0)
+
+    torch.testing.assert_close(y0_seq, x)
+    torch.testing.assert_close(y1_seq, x + 1)
+    torch.testing.assert_close(v_seq, x.cumsum(dim=0))
+    torch.testing.assert_close(y0_final, x)
+    torch.testing.assert_close(y1_final, x + 1)
+    torch.testing.assert_close(v_final, x.sum(dim=0))
 
 
 def test_lowerable_scan_empty_sequence_returns_templates_without_scan_op():

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -350,6 +350,74 @@ def test_compile_fullgraph_hop_backend_matches_eager_with_lowerable_while_loop(
     torch.testing.assert_close(compiled_out, eager_out)
 
 
+def test_hop_backend_store_state_seqs_false_matches_torch_backend(rng):
+    T, N = 4, 8
+    x = torch.randn(T, N, generator=rng)
+
+    hop_neuron = FlexSN(
+        core=_differentiable_lif_core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="hop",
+        store_state_seqs=False,
+        example_inputs=(torch.zeros(N), torch.zeros(N)),
+    )
+    torch_neuron = FlexSN(
+        core=_differentiable_lif_core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+        store_state_seqs=False,
+    )
+
+    hop_out = hop_neuron(x)
+    torch_out = torch_neuron(x)
+
+    torch.testing.assert_close(hop_out, torch_out)
+    torch.testing.assert_close(hop_neuron.states[0], torch_neuron.states[0])
+
+
+def test_compile_fullgraph_hop_store_state_seqs_false_matches_eager_with_lowerable_while_loop(
+    rng, monkeypatch
+):
+    if sys.platform == "win32":
+        pytest.skip("torch.compile is not supported on Windows")
+    if (
+        not callable(lowerable_while_loop_available)
+        or not lowerable_while_loop_available()
+    ):
+        pytest.skip("PyTorch while_loop HOP is unavailable in this environment")
+
+    T, N = 4, 8
+    x_eager = torch.randn(T, N, generator=rng)
+    x_compiled = x_eager.detach().clone()
+
+    def make_neuron():
+        return FlexSN(
+            core=_differentiable_lif_core,
+            num_inputs=1,
+            num_states=1,
+            num_outputs=1,
+            step_mode="m",
+            backend="hop",
+            store_state_seqs=False,
+            example_inputs=(torch.zeros(N), torch.zeros(N)),
+        )
+
+    eager_neuron = make_neuron()
+    eager_out = eager_neuron(x_eager)
+    monkeypatch.setenv("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP", "1")
+    compiled_fn = torch.compile(make_neuron(), fullgraph=True)
+    compiled_out = compiled_fn(x_compiled)
+
+    torch.testing.assert_close(compiled_out, eager_out)
+    torch.testing.assert_close(compiled_fn._orig_mod.states[0], eager_neuron.states[0])
+
+
 # -------------------------------------------------------------------------
 # M2: backward / autograd tests
 # -------------------------------------------------------------------------

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -131,6 +131,25 @@ def test_inductor_training_final_state_impl_t0_returns_non_aliased_states(
     assert v_final.data_ptr() != v.data_ptr()
 
 
+def test_inductor_fake_final_state_templates_use_explicit_states():
+    from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
+        custom_ops,
+    )
+
+    info = SimpleNamespace(num_inputs=1, num_states=2)
+    x = torch.randn(4, 3, dtype=torch.float32)
+    state_a = torch.randn(5, dtype=torch.float64)
+    state_b = torch.empty(2, 3, dtype=torch.float16)
+
+    templates = custom_ops._make_state_templates_like(info, [x, state_a, state_b])
+
+    assert [tuple(template.shape) for template in templates] == [(5,), (2, 3)]
+    assert [template.dtype for template in templates] == [
+        torch.float64,
+        torch.float16,
+    ]
+
+
 def test_inductor_training_final_state_backward_pads_missing_grads(monkeypatch):
     from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
         custom_ops,

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -178,8 +178,8 @@ def test_output_template_specs_from_examples_use_first_input_contract():
     )
 
     assert specs == (
-        ((2,), torch.float16, torch.device("cpu")),
-        ((2,), torch.float16, torch.device("cpu")),
+        ((2,), torch.float16),
+        ((2,), torch.float16),
     )
 
 
@@ -1454,6 +1454,37 @@ def test_compile_fullgraph_hop_direct_zero_length_scan_uses_body_template():
     assert out.shape == (0, 3)
     assert state_seq.shape == (0, 3)
     assert out.dtype == state.dtype
+
+
+def test_compile_fullgraph_hop_direct_accepts_output_template_specs():
+    if sys.platform == "win32":
+        pytest.skip("torch.compile is not supported on Windows")
+    _skip_if_dynamo_hop_unavailable()
+
+    def core(x_step, state):
+        return state + 1, state
+
+    x = torch.empty(0, 2)
+    state = torch.zeros(3)
+    specs = (((5,), torch.float64),)
+
+    @torch.compile(fullgraph=True)
+    def compiled_scan(x_seq, init_state):
+        return flex_sn_scan(
+            core,
+            1,
+            1,
+            1,
+            x_seq,
+            init_state,
+            output_template_specs=specs,
+        )
+
+    out, state_seq = compiled_scan(x, state)
+
+    assert out.shape == (0, 5)
+    assert out.dtype == torch.float64
+    assert state_seq.shape == (0, 3)
 
 
 def test_compile_fullgraph_hop_backend_matches_eager_with_closure(rng):

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -17,6 +17,8 @@ import torch
 from spikingjelly.activation_based.neuron.flexsn import FlexSN
 from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
     flex_sn_scan,
+    lowerable_scan,
+    lowerable_scan_available,
 )
 
 
@@ -236,6 +238,52 @@ def test_hop_registers_with_dynamo():
 
     hop_var = TorchHigherOrderOperatorVariable.make(flex_sn_scan)
     assert hop_var.value is flex_sn_scan
+
+
+def test_lowerable_scan_matches_manual_loop(rng):
+    if not callable(lowerable_scan_available) or not lowerable_scan_available():
+        pytest.skip("PyTorch scan HOP is unavailable in this environment")
+
+    T, N = 4, 8
+    x = torch.randn((T, N), generator=rng)
+    v0 = torch.zeros(N)
+
+    with torch.no_grad():
+        s_seq, v_seq = lowerable_scan(_lif_core, 1, 1, 1, x, v0)
+
+    expected_s, expected_v = [], []
+    v = v0.clone()
+    for t in range(T):
+        s, v = _lif_core(x[t], v)
+        expected_s.append(s)
+        expected_v.append(v)
+
+    torch.testing.assert_close(s_seq, torch.stack(expected_s, dim=0))
+    torch.testing.assert_close(v_seq, torch.stack(expected_v, dim=0))
+
+
+def test_lowerable_scan_traces_as_single_scan_node(rng):
+    if not callable(lowerable_scan_available) or not lowerable_scan_available():
+        pytest.skip("PyTorch scan HOP is unavailable in this environment")
+
+    if not hasattr(torch.fx.experimental, "proxy_tensor"):
+        pytest.skip("make_fx is unavailable in this environment")
+
+    from torch.fx.experimental.proxy_tensor import make_fx
+
+    T, N = 4, 8
+    x = torch.randn((T, N), generator=rng)
+    v0 = torch.zeros(N)
+
+    with torch.no_grad():
+        gm = make_fx(lambda x, v: lowerable_scan(_lif_core, 1, 1, 1, x, v))(x, v0)
+
+    hop_targets = [
+        node.target
+        for node in gm.graph.nodes
+        if node.op == "call_function" and "scan" in str(node.target)
+    ]
+    assert len(hop_targets) == 1
 
 
 # -------------------------------------------------------------------------

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -74,7 +74,7 @@ def test_torch_backend_empty_sequence_does_not_call_core():
     assert m.states[0].shape == (3,)
 
 
-def test_torch_backend_empty_sequence_uses_example_output_template():
+def test_torch_backend_empty_sequence_uses_example_input_template_without_core_probe():
     calls = {"count": 0}
 
     def core(x, v):
@@ -91,12 +91,11 @@ def test_torch_backend_empty_sequence_uses_example_output_template():
         example_inputs=(torch.zeros(2), torch.zeros(3)),
     )
     m.states = [torch.zeros(3)]
-    calls["count"] = 0
 
     out = m.multi_step_forward(torch.empty(0, 2))[0]
 
     assert calls["count"] == 0
-    assert out.shape == (0, 4)
+    assert out.shape == (0, 2)
 
 
 def test_multi_step_forward_initializes_states_for_torch_backend():

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -531,8 +531,8 @@ def test_compile_fullgraph_lowerable_while_loop_matches_eager(rng):
     compiled_out = torch.compile(run_scan, fullgraph=True)(x_compiled, v0_compiled)
 
     assert len(compiled_out) == len(eager_out)
-    for compiled_tensor, eager_tensor in zip(compiled_out, eager_out):
-        torch.testing.assert_close(compiled_tensor, eager_tensor)
+    for i in range(len(eager_out)):
+        torch.testing.assert_close(compiled_out[i], eager_out[i])
 
 
 def test_compile_fullgraph_hop_backend_matches_eager_with_lowerable_while_loop(

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -56,6 +56,28 @@ def test_hop_matches_manual_loop(rng, T, shape):
     torch.testing.assert_close(v_seq, expected_v)
 
 
+def test_hop_matches_manual_loop_with_lifted_tensor(rng):
+    T, N = 4, 8
+    x = torch.randn((T, N), generator=rng)
+    v0 = torch.zeros(N)
+    bias = torch.randn(N, generator=rng)
+
+    def core_with_bias(x_step, v, bias_term):
+        return _lif_core(x_step + bias_term, v)
+
+    s_seq, v_seq = flex_sn_scan(core_with_bias, 1, 1, 1, x, v0, bias)
+
+    expected_s, expected_v = [], []
+    v = v0.clone()
+    for t in range(T):
+        s, v = core_with_bias(x[t], v, bias)
+        expected_s.append(s)
+        expected_v.append(v)
+
+    torch.testing.assert_close(s_seq, torch.stack(expected_s, dim=0))
+    torch.testing.assert_close(v_seq, torch.stack(expected_v, dim=0))
+
+
 @pytest.mark.parametrize("T", [1, 4, 16])
 @pytest.mark.parametrize("shape", [(8,), (4, 8)])
 def test_inductor_backend_matches_torch_backend(rng, T, shape):
@@ -114,6 +136,39 @@ def test_hop_backend_matches_torch_backend(rng, T, shape):
 
     torch.testing.assert_close(hop_out, torch_out)
     assert len(hop_neuron.states) == 1
+    torch.testing.assert_close(hop_neuron.states[0], torch_neuron.states[0])
+
+
+def test_hop_backend_matches_torch_backend_with_closure(rng):
+    T, N = 4, 8
+    x = torch.randn((T, N), generator=rng)
+    bias = torch.randn(N, generator=rng)
+
+    def core_with_bias(x_step, v):
+        return _lif_core(x_step + bias, v)
+
+    torch_neuron = FlexSN(
+        core=core_with_bias,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+    )
+    hop_neuron = FlexSN(
+        core=core_with_bias,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="hop",
+        example_inputs=(torch.zeros(N), torch.zeros(N)),
+    )
+
+    torch_out = torch_neuron(x)
+    hop_out = hop_neuron(x)
+
+    torch.testing.assert_close(hop_out, torch_out)
     torch.testing.assert_close(hop_neuron.states[0], torch_neuron.states[0])
 
 

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -312,7 +312,7 @@ def test_compile_fullgraph_lowerable_while_loop_matches_eager(rng):
     eager_out = run_scan(x_eager, v0_eager)
     compiled_out = torch.compile(run_scan, fullgraph=True)(x_compiled, v0_compiled)
 
-    for compiled_tensor, eager_tensor in zip(compiled_out, eager_out):
+    for compiled_tensor, eager_tensor in zip(compiled_out, eager_out, strict=True):
         torch.testing.assert_close(compiled_tensor, eager_tensor)
 
 
@@ -411,11 +411,12 @@ def test_compile_fullgraph_hop_store_state_seqs_false_matches_eager_with_lowerab
     eager_neuron = make_neuron()
     eager_out = eager_neuron(x_eager)
     monkeypatch.setenv("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP", "1")
-    compiled_fn = torch.compile(make_neuron(), fullgraph=True)
+    compiled_neuron = make_neuron()
+    compiled_fn = torch.compile(compiled_neuron, fullgraph=True)
     compiled_out = compiled_fn(x_compiled)
 
     torch.testing.assert_close(compiled_out, eager_out)
-    torch.testing.assert_close(compiled_fn._orig_mod.states[0], eager_neuron.states[0])
+    torch.testing.assert_close(compiled_neuron.states[0], eager_neuron.states[0])
 
 
 # -------------------------------------------------------------------------

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -15,10 +15,13 @@ import pytest
 import torch
 
 from spikingjelly.activation_based.neuron.flexsn import FlexSN
+from spikingjelly.activation_based.model.spiking_vgg import spiking_vgg16_bn
 from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
     flex_sn_scan,
     lowerable_scan,
     lowerable_scan_available,
+    lowerable_while_loop_scan,
+    lowerable_while_loop_available,
 )
 
 
@@ -262,28 +265,89 @@ def test_lowerable_scan_matches_manual_loop(rng):
     torch.testing.assert_close(v_seq, torch.stack(expected_v, dim=0))
 
 
-def test_lowerable_scan_traces_as_single_scan_node(rng):
-    if not callable(lowerable_scan_available) or not lowerable_scan_available():
-        pytest.skip("PyTorch scan HOP is unavailable in this environment")
-
-    if not hasattr(torch.fx.experimental, "proxy_tensor"):
-        pytest.skip("make_fx is unavailable in this environment")
-
-    from torch.fx.experimental.proxy_tensor import make_fx
+def test_lowerable_while_loop_matches_manual_loop(rng):
+    if (
+        not callable(lowerable_while_loop_available)
+        or not lowerable_while_loop_available()
+    ):
+        pytest.skip("PyTorch while_loop HOP is unavailable in this environment")
 
     T, N = 4, 8
     x = torch.randn((T, N), generator=rng)
     v0 = torch.zeros(N)
 
     with torch.no_grad():
-        gm = make_fx(lambda x, v: lowerable_scan(_lif_core, 1, 1, 1, x, v))(x, v0)
+        s_seq, v_seq = lowerable_while_loop_scan(_lif_core, 1, 1, 1, x, v0)
 
-    hop_targets = [
-        node.target
-        for node in gm.graph.nodes
-        if node.op == "call_function" and "scan" in str(node.target)
-    ]
-    assert len(hop_targets) == 1
+    expected_s, expected_v = [], []
+    v = v0.clone()
+    for t in range(T):
+        s, v = _lif_core(x[t], v)
+        expected_s.append(s)
+        expected_v.append(v)
+
+    torch.testing.assert_close(s_seq, torch.stack(expected_s, dim=0))
+    torch.testing.assert_close(v_seq, torch.stack(expected_v, dim=0))
+
+
+def test_compile_fullgraph_lowerable_while_loop_matches_eager(rng):
+    if sys.platform == "win32":
+        pytest.skip("torch.compile is not supported on Windows")
+    if (
+        not callable(lowerable_while_loop_available)
+        or not lowerable_while_loop_available()
+    ):
+        pytest.skip("PyTorch while_loop HOP is unavailable in this environment")
+
+    T, N = 4, 8
+    x_eager = torch.randn((T, N), generator=rng)
+    x_compiled = x_eager.detach().clone()
+    v0_eager = torch.zeros(N)
+    v0_compiled = v0_eager.detach().clone()
+
+    def run_scan(x, v0):
+        with torch.no_grad():
+            return lowerable_while_loop_scan(_lif_core, 1, 1, 1, x, v0)
+
+    eager_out = run_scan(x_eager, v0_eager)
+    compiled_out = torch.compile(run_scan, fullgraph=True)(x_compiled, v0_compiled)
+
+    for compiled_tensor, eager_tensor in zip(compiled_out, eager_out):
+        torch.testing.assert_close(compiled_tensor, eager_tensor)
+
+
+def test_compile_fullgraph_hop_backend_matches_eager_with_lowerable_while_loop(
+    rng, monkeypatch
+):
+    if sys.platform == "win32":
+        pytest.skip("torch.compile is not supported on Windows")
+    if (
+        not callable(lowerable_while_loop_available)
+        or not lowerable_while_loop_available()
+    ):
+        pytest.skip("PyTorch while_loop HOP is unavailable in this environment")
+
+    T, N = 4, 8
+    x_eager = torch.randn(T, N, generator=rng)
+    x_compiled = x_eager.detach().clone()
+
+    def make_neuron():
+        return FlexSN(
+            core=_differentiable_lif_core,
+            num_inputs=1,
+            num_states=1,
+            num_outputs=1,
+            step_mode="m",
+            backend="hop",
+            example_inputs=(torch.zeros(N), torch.zeros(N)),
+        )
+
+    eager_out = make_neuron()(x_eager)
+    monkeypatch.setenv("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP", "1")
+    compiled_fn = torch.compile(make_neuron(), fullgraph=True)
+    compiled_out = compiled_fn(x_compiled)
+
+    torch.testing.assert_close(compiled_out, eager_out)
 
 
 # -------------------------------------------------------------------------
@@ -589,6 +653,104 @@ def test_compile_fuses_surrounding_linear_layers(rng):
     x_e = torch.randn(T, N, generator=rng)
     x_c = x_e.detach().clone()
     torch.testing.assert_close(compiled_net(x_c), eager_net(x_e))
+
+
+def test_compile_fuses_surrounding_linear_layers_with_hop_lowerable_while_loop(rng, monkeypatch):
+    if sys.platform == "win32":
+        pytest.skip("torch.compile is not supported on Windows")
+    if (
+        not callable(lowerable_while_loop_available)
+        or not lowerable_while_loop_available()
+    ):
+        pytest.skip("PyTorch while_loop HOP is unavailable in this environment")
+
+    T, N = 4, 8
+
+    class Net(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.pre = torch.nn.Linear(N, N)
+            self.neuron = FlexSN(
+                core=_differentiable_lif_core,
+                num_inputs=1,
+                num_states=1,
+                num_outputs=1,
+                step_mode="m",
+                backend="hop",
+                example_inputs=(torch.zeros(N), torch.zeros(N)),
+            )
+            self.post = torch.nn.Linear(N, N)
+
+        def forward(self, x):
+            pre = self.pre(x)
+            spikes = self.neuron(pre)
+            return self.post(spikes)
+
+    torch.manual_seed(0)
+    eager_net = Net().eval()
+    torch.manual_seed(0)
+    compiled_net = Net().eval()
+    monkeypatch.setenv("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP", "1")
+    compiled_net = torch.compile(compiled_net, fullgraph=True)
+
+    x_e = torch.randn(T, N, generator=rng)
+    x_c = x_e.detach().clone()
+    with torch.no_grad():
+        eager_out = eager_net(x_e)
+        compiled_out = compiled_net(x_c)
+
+    torch.testing.assert_close(compiled_out, eager_out)
+
+
+def test_compile_spiking_vgg_hop_lowerable_while_loop_matches_eager(monkeypatch):
+    if sys.platform == "win32":
+        pytest.skip("torch.compile is not supported on Windows")
+    if (
+        not callable(lowerable_while_loop_available)
+        or not lowerable_while_loop_available()
+    ):
+        pytest.skip("PyTorch while_loop HOP is unavailable in this environment")
+    if not torch.cuda.is_available():
+        pytest.skip("SpikingVGG compile coverage is only exercised on CUDA")
+
+    def core(x, v):
+        tau, v_th = 2.0, 1.0
+        h = v + (x - v) / tau
+        s = (h >= v_th).to(h.dtype)
+        return s, h * (1.0 - s)
+
+    def make_flexsn(**kwargs):
+        return FlexSN(
+            core=core,
+            num_inputs=1,
+            num_states=1,
+            num_outputs=1,
+            step_mode=kwargs.get("step_mode", "m"),
+            backend="hop",
+        )
+
+    T, B, C, H, W = 4, 8, 3, 32, 32
+    torch.manual_seed(42)
+    x_eager = torch.randn((T, B, C, H, W), device="cuda")
+    x_compiled = x_eager.detach().clone()
+
+    torch.manual_seed(0)
+    model = spiking_vgg16_bn(
+        spiking_neuron=make_flexsn,
+        step_mode="m",
+    ).cuda().eval()
+
+    from spikingjelly.activation_based import functional as sj_functional
+    sj_functional.set_step_mode(model, "m")
+
+    monkeypatch.setenv("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP", "1")
+
+    with torch.no_grad():
+        eager_out = model(x_eager)
+        compiled_model = torch.compile(model, fullgraph=True)
+        compiled_out = compiled_model(x_compiled)
+
+    torch.testing.assert_close(compiled_out, eager_out, atol=1e-5, rtol=1e-4)
 
 
 def test_compile_captures_core_ops_in_fx_graph(rng):

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -73,6 +73,63 @@ def test_inductor_final_state_warmup_args_use_example_shapes():
     ]
 
 
+def test_inductor_final_state_wrapper_t0_returns_non_aliased_states():
+    from spikingjelly.activation_based.triton_kernel.flexsn.wrapper import (
+        flexsn_inference_final_state,
+    )
+
+    info = SimpleNamespace(num_inputs=1, num_outputs=1, num_states=1)
+    x = torch.randn(0, 3)
+    v = torch.randn(3)
+
+    y_seq, v_final = flexsn_inference_final_state(None, info, x, v)
+
+    assert tuple(y_seq.shape) == (0, 3)
+    torch.testing.assert_close(v_final, v)
+    assert v_final.data_ptr() != v.data_ptr()
+
+
+def test_inductor_training_final_state_impl_t0_returns_non_aliased_states(
+    monkeypatch,
+):
+    from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
+        custom_ops,
+    )
+
+    info = SimpleNamespace(
+        num_inputs=1,
+        num_outputs=1,
+        num_states=1,
+        c2k_return_mapping=[],
+    )
+    bundle = SimpleNamespace(training_info=info)
+    x = torch.randn(0, 3)
+    v = torch.randn(3)
+    full_returns = [x.new_empty(x.shape), x.new_empty((0, *v.shape))]
+
+    def fake_training_impl(bundle_arg, flat_args):
+        assert bundle_arg is bundle
+        assert len(flat_args) == 2
+        assert flat_args[0] is x
+        assert flat_args[1] is v
+        return full_returns
+
+    monkeypatch.setattr(
+        custom_ops,
+        "_flexsn_inductor_training_impl",
+        fake_training_impl,
+    )
+
+    y_seq, v_final = custom_ops._flexsn_inductor_training_final_state_impl(
+        bundle,
+        [x, v],
+    )
+
+    assert tuple(y_seq.shape) == (0, 3)
+    torch.testing.assert_close(v_final, v)
+    assert v_final.data_ptr() != v.data_ptr()
+
+
 @pytest.mark.parametrize("T", [1, 4, 16])
 @pytest.mark.parametrize("shape", [(8,), (4, 8), (2, 3, 8)])
 def test_hop_matches_manual_loop(rng, T, shape):
@@ -166,6 +223,7 @@ def test_hop_backend_matches_torch_backend(rng, T, shape):
         num_outputs=1,
         step_mode="m",
         backend="hop",
+        store_state_seqs=True,
         example_inputs=(torch.zeros(shape), torch.zeros(shape)),
     )
 
@@ -200,6 +258,7 @@ def test_hop_backend_matches_torch_backend_with_closure(rng):
         num_outputs=1,
         step_mode="m",
         backend="hop",
+        store_state_seqs=True,
         example_inputs=(torch.zeros(N), torch.zeros(N)),
     )
 
@@ -372,13 +431,15 @@ def test_compile_fullgraph_hop_backend_matches_eager_with_lowerable_while_loop(
             num_outputs=1,
             step_mode="m",
             backend="hop",
+            store_state_seqs=True,
             example_inputs=(torch.zeros(N), torch.zeros(N)),
         )
 
-    eager_out = make_neuron()(x_eager)
     monkeypatch.setenv("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP", "1")
-    compiled_fn = torch.compile(make_neuron(), fullgraph=True)
-    compiled_out = compiled_fn(x_compiled)
+    with torch.no_grad():
+        eager_out = make_neuron()(x_eager)
+        compiled_fn = torch.compile(make_neuron(), fullgraph=True)
+        compiled_out = compiled_fn(x_compiled)
 
     torch.testing.assert_close(compiled_out, eager_out)
 
@@ -424,7 +485,7 @@ def test_hop_backend_zero_length_sequence_matches_torch_backend():
         num_outputs=1,
         step_mode="m",
         backend="hop",
-        store_state_seqs=False,
+        store_state_seqs=True,
         example_inputs=(torch.zeros(8), torch.zeros(8)),
     )
     torch_neuron = FlexSN(
@@ -434,7 +495,7 @@ def test_hop_backend_zero_length_sequence_matches_torch_backend():
         num_outputs=1,
         step_mode="m",
         backend="torch",
-        store_state_seqs=False,
+        store_state_seqs=True,
     )
 
     hop_out = hop_neuron(x)
@@ -493,12 +554,13 @@ def test_compile_fullgraph_hop_store_state_seqs_false_matches_eager_with_lowerab
             example_inputs=(torch.zeros(N), torch.zeros(N)),
         )
 
-    eager_neuron = make_neuron()
-    eager_out = eager_neuron(x_eager)
     monkeypatch.setenv("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP", "1")
-    compiled_neuron = make_neuron()
-    compiled_fn = torch.compile(compiled_neuron, fullgraph=True)
-    compiled_out = compiled_fn(x_compiled)
+    with torch.no_grad():
+        eager_neuron = make_neuron()
+        eager_out = eager_neuron(x_eager)
+        compiled_neuron = make_neuron()
+        compiled_fn = torch.compile(compiled_neuron, fullgraph=True)
+        compiled_out = compiled_fn(x_compiled)
 
     torch.testing.assert_close(compiled_out, eager_out)
     torch.testing.assert_close(compiled_neuron.states[0], eager_neuron.states[0])
@@ -761,6 +823,7 @@ def test_compile_fullgraph_hop_backend_matches_eager(rng):
             num_outputs=1,
             step_mode="m",
             backend="hop",
+            store_state_seqs=True,
             example_inputs=(torch.zeros(N), torch.zeros(N)),
         )
 
@@ -791,6 +854,7 @@ def test_compile_fullgraph_hop_backend_matches_eager_with_closure(rng):
             num_outputs=1,
             step_mode="m",
             backend="hop",
+            store_state_seqs=True,
             example_inputs=(torch.zeros(N), torch.zeros(N)),
         )
 

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -773,6 +773,46 @@ def test_compile_captures_core_ops_in_fx_graph(rng):
     )
 
 
+def test_inductor_compile_graph_elides_explicit_zero_state_init():
+    if sys.platform == "win32":
+        pytest.skip("torch.compile is not supported on Windows")
+    if not torch.cuda.is_available():
+        pytest.skip("inductor custom-op graph coverage is exercised on CUDA")
+
+    from torch._dynamo import explain
+
+    def core(x, v):
+        tau, v_th = 2.0, 1.0
+        h = v + (x - v) / tau
+        s = (h >= v_th).to(h.dtype)
+        return s, h * (1.0 - s)
+
+    def make_flexsn(**kwargs):
+        return FlexSN(
+            core=core,
+            num_inputs=1,
+            num_states=1,
+            num_outputs=1,
+            step_mode=kwargs.get("step_mode", "m"),
+            backend="inductor",
+        )
+
+    T, B, C, H, W = 4, 8, 3, 32, 32
+    torch.manual_seed(42)
+    x = torch.randn((T, B, C, H, W), device="cuda")
+    model = spiking_vgg16_bn(
+        spiking_neuron=make_flexsn,
+        step_mode="m",
+    ).cuda().eval()
+
+    with torch.no_grad():
+        explanation = explain(model)(x)
+    targets = [str(node.target) for node in explanation.graphs[0].graph.nodes]
+
+    assert any("sj.flexsn_inductor_inference.default" in target for target in targets)
+    assert not any("zeros_like" in target for target in targets)
+
+
 def test_aot_function_backward_numerical_match(rng):
     """AOTAutograd-compiled backward must produce the same gradients as
     the eager backward."""

--- a/test/activation_based/test_fuse_conv_bn.py
+++ b/test/activation_based/test_fuse_conv_bn.py
@@ -46,7 +46,7 @@ def test_fuse_conv_bn_eval_modules_matches_step_block():
 
     with torch.no_grad():
         y_ref = model(x)
-        fused = functional.fuse_conv_bn_eval_modules(model)
+        fused = functional.fuse_conv_bn_eval_modules(copy.deepcopy(model))
         y_fused = fused(x)
 
     torch.testing.assert_close(y_fused, y_ref, atol=1e-5, rtol=1e-4)

--- a/test/activation_based/test_fuse_conv_bn.py
+++ b/test/activation_based/test_fuse_conv_bn.py
@@ -1,5 +1,6 @@
 import copy
 
+import pytest
 import torch
 from torch import nn
 
@@ -73,6 +74,28 @@ class _SharedTrainConvBnBlock(nn.Module):
         return a + b
 
 
+class _SharedConvDifferentBnEvalBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(8)
+        self.bn2 = nn.BatchNorm2d(8)
+
+    def forward(self, x):
+        return self.bn1(self.conv(x)) + self.bn2(self.conv(x))
+
+
+class _SharedConvDifferentBnTrainBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(8)
+        self.bn2 = nn.BatchNorm2d(8)
+
+    def forward(self, x):
+        return self.bn1(self.conv(x)) + self.bn2(self.conv(x))
+
+
 def test_fuse_conv_bn_eval_modules_matches_step_block():
     torch.manual_seed(0)
     model = _StepBlock().eval()
@@ -104,12 +127,8 @@ def test_fuse_conv_bn_eval_modules_matches_native_block():
 def test_fuse_conv_bn_eval_modules_rejects_missing_running_stats():
     model = _NoRunningStatsBlock().eval()
 
-    try:
+    with pytest.raises(ValueError, match="track running stats"):
         functional.fuse_conv_bn_eval_modules(copy.deepcopy(model))
-    except ValueError as e:
-        assert "track running stats" in str(e)
-    else:
-        raise AssertionError("Expected ValueError for BatchNorm without running stats")
 
 
 def test_fuse_conv_bn_eval_modules_handles_shared_conv_bn_pairs():
@@ -124,6 +143,20 @@ def test_fuse_conv_bn_eval_modules_handles_shared_conv_bn_pairs():
 
     torch.testing.assert_close(y_fused, y_ref, atol=1e-5, rtol=1e-4)
     assert not any(isinstance(m, nn.BatchNorm2d) for m in fused.modules())
+
+
+def test_fuse_conv_bn_eval_modules_skips_shared_conv_with_different_bn():
+    torch.manual_seed(0)
+    model = _SharedConvDifferentBnEvalBlock().eval()
+    x = torch.randn(2, 3, 16, 16)
+
+    with torch.no_grad():
+        y_ref = model(x)
+        fused = functional.fuse_conv_bn_eval_modules(copy.deepcopy(model))
+        y_fused = fused(x)
+
+    torch.testing.assert_close(y_fused, y_ref, atol=1e-5, rtol=1e-4)
+    assert sum(isinstance(m, nn.BatchNorm2d) for m in fused.modules()) == 2
 
 
 def test_pack_conv_bn_train_modules_matches_step_block():
@@ -241,3 +274,23 @@ def test_pack_conv_bn_train_modules_handles_shared_conv_bn_pairs():
     loss_packed.backward()
 
     torch.testing.assert_close(x_packed.grad, x.grad, atol=1e-5, rtol=1e-4)
+
+
+def test_pack_conv_bn_train_modules_skips_shared_conv_with_different_bn():
+    torch.manual_seed(0)
+    model = _SharedConvDifferentBnTrainBlock().train()
+    packed = functional.pack_conv_bn_train_modules(copy.deepcopy(model))
+    x = torch.randn(2, 3, 16, 16, requires_grad=True)
+    x_packed = x.detach().clone().requires_grad_(True)
+
+    y_ref = model(x)
+    y_packed = packed(x_packed)
+    torch.testing.assert_close(y_packed, y_ref, atol=1e-5, rtol=1e-4)
+
+    loss_ref = y_ref.square().mean()
+    loss_packed = y_packed.square().mean()
+    loss_ref.backward()
+    loss_packed.backward()
+
+    torch.testing.assert_close(x_packed.grad, x.grad, atol=1e-5, rtol=1e-4)
+    assert not any(isinstance(m, _TrainConvBnWrapper) for m in packed.modules())

--- a/test/activation_based/test_fuse_conv_bn.py
+++ b/test/activation_based/test_fuse_conv_bn.py
@@ -117,3 +117,30 @@ def test_pack_conv_bn_train_modules_matches_native_block():
         packed.conv.bn.weight.grad, model.bn.weight.grad, atol=1e-5, rtol=1e-4
     )
     assert any(isinstance(m, _TrainConvBnWrapper) for m in packed.modules())
+
+
+def test_train_conv_bn_wrapper_packs_native_multistep_inputs():
+    torch.manual_seed(0)
+    model = _NativeStepBlock().train()
+    wrapped = _TrainConvBnWrapper(copy.deepcopy(model.conv), copy.deepcopy(model.bn)).train()
+    x = torch.randn(4, 2, 3, 16, 16, requires_grad=True)
+    x_packed = x.detach().clone().requires_grad_(True)
+
+    y_packed = wrapped(x_packed)
+
+    x_ref = x.flatten(0, 1)
+    y_ref = model.bn(model.conv(x_ref)).view_as(y_packed)
+    torch.testing.assert_close(y_packed, y_ref, atol=1e-5, rtol=1e-4)
+
+    loss_ref = y_ref.square().mean()
+    loss_packed = y_packed.square().mean()
+    loss_ref.backward()
+    loss_packed.backward()
+
+    torch.testing.assert_close(x_packed.grad, x.grad, atol=1e-5, rtol=1e-4)
+    torch.testing.assert_close(
+        wrapped.conv.weight.grad, model.conv.weight.grad, atol=1e-5, rtol=1e-4
+    )
+    torch.testing.assert_close(
+        wrapped.bn.weight.grad, model.bn.weight.grad, atol=1e-5, rtol=1e-4
+    )

--- a/test/activation_based/test_fuse_conv_bn.py
+++ b/test/activation_based/test_fuse_conv_bn.py
@@ -96,6 +96,16 @@ class _SharedConvDifferentBnTrainBlock(nn.Module):
         return self.bn1(self.conv(x)) + self.bn2(self.conv(x))
 
 
+class _PartialConvBnBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn = nn.BatchNorm2d(8)
+
+    def forward(self, x):
+        return self.bn(self.conv(x)) + self.conv(x)
+
+
 def test_fuse_conv_bn_eval_modules_matches_step_block():
     torch.manual_seed(0)
     model = _StepBlock().eval()
@@ -157,6 +167,20 @@ def test_fuse_conv_bn_eval_modules_skips_shared_conv_with_different_bn():
 
     torch.testing.assert_close(y_fused, y_ref, atol=1e-5, rtol=1e-4)
     assert sum(isinstance(m, nn.BatchNorm2d) for m in fused.modules()) == 2
+
+
+def test_fuse_conv_bn_eval_modules_skips_partial_conv_bn_callsites():
+    torch.manual_seed(0)
+    model = _PartialConvBnBlock().eval()
+    x = torch.randn(2, 3, 16, 16)
+
+    with torch.no_grad():
+        y_ref = model(x)
+        fused = functional.fuse_conv_bn_eval_modules(copy.deepcopy(model))
+        y_fused = fused(x)
+
+    torch.testing.assert_close(y_fused, y_ref, atol=1e-5, rtol=1e-4)
+    assert any(isinstance(m, nn.BatchNorm2d) for m in fused.modules())
 
 
 def test_pack_conv_bn_train_modules_matches_step_block():
@@ -279,6 +303,26 @@ def test_pack_conv_bn_train_modules_handles_shared_conv_bn_pairs():
 def test_pack_conv_bn_train_modules_skips_shared_conv_with_different_bn():
     torch.manual_seed(0)
     model = _SharedConvDifferentBnTrainBlock().train()
+    packed = functional.pack_conv_bn_train_modules(copy.deepcopy(model))
+    x = torch.randn(2, 3, 16, 16, requires_grad=True)
+    x_packed = x.detach().clone().requires_grad_(True)
+
+    y_ref = model(x)
+    y_packed = packed(x_packed)
+    torch.testing.assert_close(y_packed, y_ref, atol=1e-5, rtol=1e-4)
+
+    loss_ref = y_ref.square().mean()
+    loss_packed = y_packed.square().mean()
+    loss_ref.backward()
+    loss_packed.backward()
+
+    torch.testing.assert_close(x_packed.grad, x.grad, atol=1e-5, rtol=1e-4)
+    assert not any(isinstance(m, _TrainConvBnWrapper) for m in packed.modules())
+
+
+def test_pack_conv_bn_train_modules_skips_partial_conv_bn_callsites():
+    torch.manual_seed(0)
+    model = _PartialConvBnBlock().train()
     packed = functional.pack_conv_bn_train_modules(copy.deepcopy(model))
     x = torch.randn(2, 3, 16, 16, requires_grad=True)
     x_packed = x.detach().clone().requires_grad_(True)

--- a/test/activation_based/test_fuse_conv_bn.py
+++ b/test/activation_based/test_fuse_conv_bn.py
@@ -2,6 +2,7 @@ import torch
 from torch import nn
 
 from spikingjelly.activation_based import functional, layer
+from spikingjelly.activation_based.functional.misc import _TrainConvBnWrapper
 
 
 class _StepBlock(nn.Module):
@@ -34,3 +35,29 @@ def test_fuse_conv_bn_eval_modules_matches_step_block():
 
     torch.testing.assert_close(y_fused, y_ref, atol=1e-5, rtol=1e-4)
     assert not any(isinstance(m, layer.BatchNorm2d) for m in fused.modules())
+
+
+def test_pack_conv_bn_train_modules_matches_step_block():
+    torch.manual_seed(0)
+    model = _StepBlock().train()
+    packed = functional.pack_conv_bn_train_modules(model)
+    x = torch.randn(4, 2, 3, 16, 16, requires_grad=True)
+    x_packed = x.detach().clone().requires_grad_(True)
+
+    y_ref = model(x)
+    y_packed = packed(x_packed)
+    torch.testing.assert_close(y_packed, y_ref, atol=1e-5, rtol=1e-4)
+
+    loss_ref = y_ref.square().mean()
+    loss_packed = y_packed.square().mean()
+    loss_ref.backward()
+    loss_packed.backward()
+
+    torch.testing.assert_close(x_packed.grad, x.grad, atol=1e-5, rtol=1e-4)
+    torch.testing.assert_close(
+        packed.conv.conv.weight.grad, model.conv.weight.grad, atol=1e-5, rtol=1e-4
+    )
+    torch.testing.assert_close(
+        packed.conv.bn.weight.grad, model.bn.weight.grad, atol=1e-5, rtol=1e-4
+    )
+    assert any(isinstance(m, _TrainConvBnWrapper) for m in packed.modules())

--- a/test/activation_based/test_fuse_conv_bn.py
+++ b/test/activation_based/test_fuse_conv_bn.py
@@ -39,6 +39,16 @@ class _NativeStepBlock(nn.Module):
         return x
 
 
+class _NoRunningStatsBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn = nn.BatchNorm2d(8, track_running_stats=False)
+
+    def forward(self, x):
+        return self.bn(self.conv(x))
+
+
 def test_fuse_conv_bn_eval_modules_matches_step_block():
     torch.manual_seed(0)
     model = _StepBlock().eval()
@@ -65,6 +75,17 @@ def test_fuse_conv_bn_eval_modules_matches_native_block():
 
     torch.testing.assert_close(y_fused, y_ref, atol=1e-5, rtol=1e-4)
     assert not any(isinstance(m, nn.BatchNorm2d) for m in fused.modules())
+
+
+def test_fuse_conv_bn_eval_modules_rejects_missing_running_stats():
+    model = _NoRunningStatsBlock().eval()
+
+    try:
+        functional.fuse_conv_bn_eval_modules(copy.deepcopy(model))
+    except ValueError as e:
+        assert "track running stats" in str(e)
+    else:
+        raise AssertionError("Expected ValueError for BatchNorm without running stats")
 
 
 def test_pack_conv_bn_train_modules_matches_step_block():
@@ -144,3 +165,22 @@ def test_train_conv_bn_wrapper_packs_native_multistep_inputs():
     torch.testing.assert_close(
         wrapped.bn.weight.grad, model.bn.weight.grad, atol=1e-5, rtol=1e-4
     )
+
+
+def test_train_conv_bn_wrapper_keeps_conv_hooks_active():
+    torch.manual_seed(0)
+    model = _StepBlock().train()
+    wrapped = _TrainConvBnWrapper(copy.deepcopy(model.conv), copy.deepcopy(model.bn)).train()
+    x = torch.randn(4, 2, 3, 16, 16)
+    hook_calls = []
+
+    def hook(module, args, output):
+        hook_calls.append((args[0].shape, output.shape))
+
+    handle = wrapped.conv.register_forward_hook(hook)
+    try:
+        wrapped(x)
+    finally:
+        handle.remove()
+
+    assert hook_calls == [((8, 3, 16, 16), (8, 8, 16, 16))]

--- a/test/activation_based/test_fuse_conv_bn.py
+++ b/test/activation_based/test_fuse_conv_bn.py
@@ -1,0 +1,36 @@
+import torch
+from torch import nn
+
+from spikingjelly.activation_based import functional, layer
+
+
+class _StepBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = layer.Conv2d(
+            3, 8, kernel_size=3, stride=1, padding=1, bias=False, step_mode="m"
+        )
+        self.bn = layer.BatchNorm2d(8, step_mode="m")
+        self.tail = layer.Conv2d(
+            8, 8, kernel_size=3, stride=1, padding=1, bias=False, step_mode="m"
+        )
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.bn(x)
+        x = self.tail(x)
+        return x
+
+
+def test_fuse_conv_bn_eval_modules_matches_step_block():
+    torch.manual_seed(0)
+    model = _StepBlock().eval()
+    x = torch.randn(4, 2, 3, 16, 16)
+
+    with torch.no_grad():
+        y_ref = model(x)
+        fused = functional.fuse_conv_bn_eval_modules(model)
+        y_fused = fused(x)
+
+    torch.testing.assert_close(y_fused, y_ref, atol=1e-5, rtol=1e-4)
+    assert not any(isinstance(m, layer.BatchNorm2d) for m in fused.modules())

--- a/test/activation_based/test_fuse_conv_bn.py
+++ b/test/activation_based/test_fuse_conv_bn.py
@@ -49,6 +49,30 @@ class _NoRunningStatsBlock(nn.Module):
         return self.bn(self.conv(x))
 
 
+class _SharedEvalConvBnBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn = nn.BatchNorm2d(8)
+
+    def forward(self, x):
+        a = self.bn(self.conv(x))
+        b = self.bn(self.conv(x))
+        return a + b
+
+
+class _SharedTrainConvBnBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn = nn.BatchNorm2d(8)
+
+    def forward(self, x):
+        a = self.bn(self.conv(x))
+        b = self.bn(self.conv(x))
+        return a + b
+
+
 def test_fuse_conv_bn_eval_modules_matches_step_block():
     torch.manual_seed(0)
     model = _StepBlock().eval()
@@ -86,6 +110,20 @@ def test_fuse_conv_bn_eval_modules_rejects_missing_running_stats():
         assert "track running stats" in str(e)
     else:
         raise AssertionError("Expected ValueError for BatchNorm without running stats")
+
+
+def test_fuse_conv_bn_eval_modules_handles_shared_conv_bn_pairs():
+    torch.manual_seed(0)
+    model = _SharedEvalConvBnBlock().eval()
+    x = torch.randn(2, 3, 16, 16)
+
+    with torch.no_grad():
+        y_ref = model(x)
+        fused = functional.fuse_conv_bn_eval_modules(copy.deepcopy(model))
+        y_fused = fused(x)
+
+    torch.testing.assert_close(y_fused, y_ref, atol=1e-5, rtol=1e-4)
+    assert not any(isinstance(m, nn.BatchNorm2d) for m in fused.modules())
 
 
 def test_pack_conv_bn_train_modules_matches_step_block():
@@ -184,3 +222,22 @@ def test_train_conv_bn_wrapper_keeps_conv_hooks_active():
         handle.remove()
 
     assert hook_calls == [((8, 3, 16, 16), (8, 8, 16, 16))]
+
+
+def test_pack_conv_bn_train_modules_handles_shared_conv_bn_pairs():
+    torch.manual_seed(0)
+    model = _SharedTrainConvBnBlock().train()
+    packed = functional.pack_conv_bn_train_modules(copy.deepcopy(model))
+    x = torch.randn(2, 3, 16, 16, requires_grad=True)
+    x_packed = x.detach().clone().requires_grad_(True)
+
+    y_ref = model(x)
+    y_packed = packed(x_packed)
+    torch.testing.assert_close(y_packed, y_ref, atol=1e-5, rtol=1e-4)
+
+    loss_ref = y_ref.square().mean()
+    loss_packed = y_packed.square().mean()
+    loss_ref.backward()
+    loss_packed.backward()
+
+    torch.testing.assert_close(x_packed.grad, x.grad, atol=1e-5, rtol=1e-4)

--- a/test/activation_based/test_fuse_conv_bn.py
+++ b/test/activation_based/test_fuse_conv_bn.py
@@ -1,3 +1,5 @@
+import copy
+
 import torch
 from torch import nn
 
@@ -23,6 +25,20 @@ class _StepBlock(nn.Module):
         return x
 
 
+class _NativeStepBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn = nn.BatchNorm2d(8)
+        self.tail = nn.Conv2d(8, 8, kernel_size=3, stride=1, padding=1, bias=False)
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.bn(x)
+        x = self.tail(x)
+        return x
+
+
 def test_fuse_conv_bn_eval_modules_matches_step_block():
     torch.manual_seed(0)
     model = _StepBlock().eval()
@@ -37,11 +53,51 @@ def test_fuse_conv_bn_eval_modules_matches_step_block():
     assert not any(isinstance(m, layer.BatchNorm2d) for m in fused.modules())
 
 
+def test_fuse_conv_bn_eval_modules_matches_native_block():
+    torch.manual_seed(0)
+    model = _NativeStepBlock().eval()
+    x = torch.randn(2, 3, 16, 16)
+
+    with torch.no_grad():
+        y_ref = model(x)
+        fused = functional.fuse_conv_bn_eval_modules(copy.deepcopy(model))
+        y_fused = fused(x)
+
+    torch.testing.assert_close(y_fused, y_ref, atol=1e-5, rtol=1e-4)
+    assert not any(isinstance(m, nn.BatchNorm2d) for m in fused.modules())
+
+
 def test_pack_conv_bn_train_modules_matches_step_block():
     torch.manual_seed(0)
     model = _StepBlock().train()
-    packed = functional.pack_conv_bn_train_modules(model)
+    packed = functional.pack_conv_bn_train_modules(copy.deepcopy(model))
     x = torch.randn(4, 2, 3, 16, 16, requires_grad=True)
+    x_packed = x.detach().clone().requires_grad_(True)
+
+    y_ref = model(x)
+    y_packed = packed(x_packed)
+    torch.testing.assert_close(y_packed, y_ref, atol=1e-5, rtol=1e-4)
+
+    loss_ref = y_ref.square().mean()
+    loss_packed = y_packed.square().mean()
+    loss_ref.backward()
+    loss_packed.backward()
+
+    torch.testing.assert_close(x_packed.grad, x.grad, atol=1e-5, rtol=1e-4)
+    torch.testing.assert_close(
+        packed.conv.conv.weight.grad, model.conv.weight.grad, atol=1e-5, rtol=1e-4
+    )
+    torch.testing.assert_close(
+        packed.conv.bn.weight.grad, model.bn.weight.grad, atol=1e-5, rtol=1e-4
+    )
+    assert any(isinstance(m, _TrainConvBnWrapper) for m in packed.modules())
+
+
+def test_pack_conv_bn_train_modules_matches_native_block():
+    torch.manual_seed(0)
+    model = _NativeStepBlock().train()
+    packed = functional.pack_conv_bn_train_modules(copy.deepcopy(model))
+    x = torch.randn(2, 3, 16, 16, requires_grad=True)
     x_packed = x.detach().clone().requires_grad_(True)
 
     y_ref = model(x)


### PR DESCRIPTION
## 概述

这个 PR 主要完成了两部分工作：

1. 继续推进 `FlexSN` 的 HOP / lowering 路径探索
2. 进一步优化 `FlexSN(inductor)` 与 activation-based 训练主线的 compile 性能

## 主要改动

### 1. 推进 FlexSN HOP 路径

这一部分主要围绕 `spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py` 展开：

- 为 `FlexSN` 新增显式 `backend="hop"`
- 打通了 `flex_sn_scan` 的 Dynamo 注册
- 支持 `core_fn` 带 tensor closure / lifted freevars
- 在 Linux 上验证了 `torch.compile(fullgraph=True)` 的 HOP 路径
- 新增并验证了基于 `while_loop` 的 `lowerable_while_loop_scan` 原型

当前状态是：

- `backend="hop"` 已可用
- Linux 上 `torch.compile(fullgraph=True)` 已验证通过
- `while_loop` 原型可以在更接近真实网络的 HOP compile 场景里工作

不过这条线目前仍然偏实验性质，尤其在更大卷积场景和完整训练路径里，还没有超过当前 `backend="inductor"` 主线。

### 2. 稳定 FlexSN compile 训练主线

这一部分的目标是让 `FlexSN(inductor)` 在训练里更稳定、更快：

- 稳定了 Triton 训练 kernel 的源码缓存/加载路径
- 收紧了训练 custom-op 的 saved tensor 契约，减少不必要的训练中间量返回
- `store_state_seqs=False` 的训练 final-state 路径继续打通
- 修复了若干 compile / handle / FX 追踪相关的小问题

这些改动让 `FlexSN(inductor) + torch.compile` 的训练路径在服务器上已经能够稳定工作，并持续快于不 compile 的对应路径。

### 3. 训练图边界优化

这次还新增了一个训练期图改写工具：

- `functional.pack_conv_bn_train_modules(model)`

它会把训练模式下相邻的 `Conv* -> BatchNorm*` 打包成单个 compile-friendly wrapper，减少多步路径中的 `flatten/view` 往返和 module 边界开销。

对应测试已补到：

- `test/activation_based/test_fuse_conv_bn.py`

服务器验证通过：

- `3 passed`

## 性能结果

### 1. SpikingVGG + FlexSN(inductor) 训练

服务器长窗口训练 benchmark 表明，当前主线下：

- `eager`: `24.07 ms/step`, `1329.45 samples/s`
- `compile`: `16.922 ms/step`, `1891.01 samples/s`

也就是 compile 相对 eager 大约还有：

- `1.12x ~ 1.14x` 的持续训练提升（在不同阶段的独立对照里略有波动）

### 2. Conv-BN 训练打包

在服务器上，`SpikingVGG + FlexSN(inductor) + torch.compile`：

- 原始路径：`19.781 ms`, `1617.7 samples/s`
- `pack_conv_bn_train_modules` 后：`17.962 ms`, `1781.55 samples/s`

也就是这一项又带来了约 `1.10x` 的训练加速。

### 3. ImageNet 训练速度对比

我还补做了 ImageNet 训练步的对比，路径为：

- 数据集：`/data/zzk/ImageNet2012/train`
- 模型：`spiking_resnet18`
- `T=2`
- `batch_size=8`
- `AMP`
- 统计口径：`5` 个 warmup + `20` 个训练 step

结果如下：

| 版本 / 配置 | 平均 step 时间 | 吞吐 |
|---|---:|---:|
| `0.0.0.0.14`，`torch` 后端 | `30.481 ms` | `262.46 img/s` |
| 当前版本，`torch` 后端，eager | `30.611 ms` | `261.34 img/s` |
| 当前版本，`torch.compile(inductor)` | `18.355 ms` | `435.85 img/s` |

也就是说，在当前最优 ImageNet 训练配置下，相对 `0.0.0.0.14`：

- 吞吐大约提升到 `1.66x`
- 约快 `66%`

### 4. CuPy 补充结果

服务器上已经安装并验证了 `cupy-cuda11x`，并补跑了 `spiking_resnet18 + T=2 + AMP` 的同口径对照：

| 版本 / 后端 | 平均 step 时间 | 吞吐 |
|---|---:|---:|
| 当前版，`torch` 后端，eager | `30.611 ms` | `261.34 img/s` |
| 当前版，`cupy` 后端，eager | `31.604 ms` | `253.13 img/s` |
| `0.0.0.0.14`，`torch` 后端 | `30.481 ms` | `262.46 img/s` |
| `0.0.0.0.14`，`cupy` 后端 | `33.996 ms` | `235.32 img/s` |

在这台服务器和这组配置下，`cupy` 并没有比 `torch` 后端更快，因此当前推荐的最快 ImageNet 训练配置仍然是：

- `torch` 后端
- `AMP`
- `torch.compile(inductor)`

## 说明

- HOP / while-loop 路径这次已经推进到“可显式使用、可 compile、可做 lowering 实验”的阶段，但仍不建议替代当前 `inductor` 主线。
- 训练主线这次真正保留下来的收益，主要来自：
  - `FlexSN` 训练 custom-op 路径稳定化
  - saved tensor 精简
  - `Conv-BN` 训练打包
- 一些探索过但没有稳定正收益的方案（例如更激进的 final-state-only 训练 kernel、Dropout-Linear 打包等）没有保留进主线。

## 后续建议

后续更值得继续做的方向有两条：

1. 继续深挖训练 backward 里 `FlexSN` 周围的边界成本
2. 继续推进 HOP / lowering，让 `FlexSN` 从实验路径逐步演进成更原生的 compiler-visible 路径

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Eval-time convolution+batchnorm fusion and train-time conv+BN packing for multi-step models
  * New multi-step backend and explicit inference/training final-state entry points

* **Improvements**
  * Robust handling for empty-time (T==0) sequences and final-state-only execution across backends
  * Deterministic on-disk kernel caching and safer example-input/device handling
  * Generalized cross-process reduction behavior

* **Tests**
  * Expanded coverage for multi-step backends, final-state behavior, compilation parity, and conv+BN

* **Chores**
  * Removed automatic temporary-file cleanup mechanism
<!-- end of auto-generated comment: release notes by coderabbit.ai -->