### PR TITLE
[memopt] Fix import and shape handling regressions

### DIFF
--- a/spikingjelly/activation_based/memopt/compress.py
+++ b/spikingjelly/activation_based/memopt/compress.py
@@ -42,8 +42,11 @@ else:
                 s_seq_compressed[:sliced_len] |= sliced << i
         return s_seq_compressed
 
+    def _shape_numel(shape) -> int:
+        return torch.Size(shape).numel()
+
     def bit_spike_decompress(s_seq_compressed: torch.Tensor, shape) -> torch.Tensor:
-        decompressed_len = shape.numel()
+        decompressed_len = _shape_numel(shape)
         s_seq_decompressed = torch.zeros(
             decompressed_len, dtype=torch.bool, device=s_seq_compressed.device
         )
@@ -456,7 +459,7 @@ class SparseSpikeCompressor(BaseSpikeCompressor):
 
     def _decompress(self, s_seq: torch.Tensor, shape) -> torch.Tensor:
         s_seq_decompressed = torch.zeros(
-            shape.numel(), dtype=self.s_seq_dtype, device=s_seq.device
+            torch.Size(shape).numel(), dtype=self.s_seq_dtype, device=s_seq.device
         )
         s_seq_decompressed = s_seq_decompressed.scatter_(
             dim=0,

--- a/spikingjelly/activation_based/memopt/compress.py
+++ b/spikingjelly/activation_based/memopt/compress.py
@@ -42,11 +42,8 @@ else:
                 s_seq_compressed[:sliced_len] |= sliced << i
         return s_seq_compressed
 
-    def _shape_numel(shape) -> int:
-        return torch.Size(shape).numel()
-
     def bit_spike_decompress(s_seq_compressed: torch.Tensor, shape) -> torch.Tensor:
-        decompressed_len = _shape_numel(shape)
+        decompressed_len = torch.Size(shape).numel()
         s_seq_decompressed = torch.zeros(
             decompressed_len, dtype=torch.bool, device=s_seq_compressed.device
         )

--- a/spikingjelly/activation_based/memopt/pipeline.py
+++ b/spikingjelly/activation_based/memopt/pipeline.py
@@ -434,15 +434,12 @@ def _inference_time_profile_worker(net, dummy_input, q, device, N=50):
     dummy_input = _dummy_input_to_device(dummy_input, device)
 
     net.eval()
-    with (
-        torch.no_grad(),
-        LayerWiseFPCUDATimeProfiler(
-            (net,),
-            model_names=("net",),
-            search_mode=("submodules",),
-            instances=(GCContainer,),
-        ) as prof,
-    ):
+    with torch.no_grad(), LayerWiseFPCUDATimeProfiler(
+        (net,),
+        model_names=("net",),
+        search_mode=("submodules",),
+        instances=(GCContainer,),
+    ) as prof:
         for _ in range(N):
             _ = net(*dummy_input)
             functional.reset_net(net)

--- a/spikingjelly/activation_based/triton_kernel/compress.py
+++ b/spikingjelly/activation_based/triton_kernel/compress.py
@@ -108,7 +108,7 @@ def bit_spike_compress(s_seq):
 def bit_spike_decompress(s_seq_compressed, shape):
     # s_seq: uint8, ndim=1
     n_compressed_elements = s_seq_compressed.numel()
-    n_decompressed_elements = shape.numel()
+    n_decompressed_elements = torch.Size(shape).numel()
     s_seq_decompressed = torch.zeros(
         n_decompressed_elements, dtype=torch.uint8, device=s_seq_compressed.device
     )

--- a/test/activation_based/test_checkpointing.py
+++ b/test/activation_based/test_checkpointing.py
@@ -3,6 +3,7 @@ import copy
 import torch
 import torch.nn as nn
 
+import spikingjelly.activation_based.memopt as memopt
 from spikingjelly.activation_based.memopt.checkpointing import (
     in_gc_1st_forward,
     query_autocast,
@@ -16,7 +17,9 @@ from spikingjelly.activation_based.memopt.checkpointing import (
 )
 from spikingjelly.activation_based.memopt.compress import (
     BaseSpikeCompressor,
+    BitSpikeCompressor,
     NullSpikeCompressor,
+    SparseSpikeCompressor,
 )
 from spikingjelly.activation_based import neuron
 
@@ -53,6 +56,10 @@ def test_thread_local_functions():
             assert in_gc_1st_forward()
         assert in_gc_1st_forward()
     assert not in_gc_1st_forward()
+
+
+def test_memopt_package_imports_pipeline_api():
+    assert hasattr(memopt, "memory_optimization")
 
 
 def test_autocast_query():
@@ -97,6 +104,19 @@ def test_argument_separate_combine():
     assert torch.equal(combined[0], tensor1)
     assert combined[1] == "string"
     assert torch.equal(combined[2], tensor2)
+
+
+def test_compressors_accept_tuple_shapes_on_decompress():
+    spikes = torch.tensor([[1.0, 0.0, 1.0], [0.0, 1.0, 0.0]])
+    shape = tuple(spikes.shape)
+
+    bit = BitSpikeCompressor()
+    bit_decompressed = bit.decompress(bit.compress(spikes), shape)
+    torch.testing.assert_close(bit_decompressed, spikes)
+
+    sparse = SparseSpikeCompressor()
+    sparse_decompressed = sparse.decompress(sparse.compress(spikes), shape)
+    torch.testing.assert_close(sparse_decompressed, spikes)
 
 
 def test_input_compressed_gc():

--- a/test/activation_based/test_checkpointing.py
+++ b/test/activation_based/test_checkpointing.py
@@ -107,13 +107,17 @@ def test_argument_separate_combine():
 
 
 def test_compressors_accept_tuple_shapes_on_decompress():
-    spikes = torch.tensor([[1.0, 0.0, 1.0], [0.0, 1.0, 0.0]])
-    shape = tuple(spikes.shape)
+    bit_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    bit_spikes = torch.tensor(
+        [[1.0, 0.0, 1.0], [0.0, 1.0, 0.0]], device=bit_device
+    )
+    shape = tuple(bit_spikes.shape)
 
     bit = BitSpikeCompressor()
-    bit_decompressed = bit.decompress(bit.compress(spikes), shape)
-    torch.testing.assert_close(bit_decompressed, spikes)
+    bit_decompressed = bit.decompress(bit.compress(bit_spikes), shape)
+    torch.testing.assert_close(bit_decompressed, bit_spikes)
 
+    spikes = torch.tensor([[1.0, 0.0, 1.0], [0.0, 1.0, 0.0]])
     sparse = SparseSpikeCompressor()
     sparse_decompressed = sparse.decompress(sparse.compress(spikes), shape)
     torch.testing.assert_close(sparse_decompressed, spikes)


### PR DESCRIPTION
## Summary
This PR fixes two concrete regressions in `spikingjelly.activation_based.memopt` and adds regression coverage.

## What changed
- fix a `SyntaxError` in `memopt.pipeline` that prevented `spikingjelly.activation_based.memopt` from importing at all
- make `memopt` decompression paths accept both `tuple` and `torch.Size` shapes, matching the documented API
- fix the Triton `bit_spike_decompress` path to handle tuple shapes too
- add regression tests for top-level `memopt` import and tuple-shape decompression

## Validation
Validated on the CUDA server:
- `PYTHONPATH=. /home/qwe/user/fangwei/env/pytorch/bin/pytest test/activation_based/test_checkpointing.py -q`
- result: `10 passed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized shape handling in spike decompression so element counts are computed reliably across implementations, preventing incorrect decompression sizing.

* **Tests**
  * Added tests ensuring decompression accepts tuple-based shape arguments and that compressors reproduce original spikes consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->