### PR TITLE
[memopt] Improve usability and policy controls

### DIFF
--- a/benchmark/benchmark_memopt.py
+++ b/benchmark/benchmark_memopt.py
@@ -1,0 +1,185 @@
+import argparse
+import copy
+import json
+import time
+
+import torch
+import torch.nn as nn
+
+from spikingjelly.activation_based import functional, neuron
+from spikingjelly.activation_based.memopt import memory_optimization
+
+
+class MemOptToyNet(nn.Module):
+    def __init__(self, channels: int):
+        super().__init__()
+        self.blocks = nn.Sequential(
+            nn.Linear(channels, channels),
+            neuron.IFNode(step_mode="m"),
+            nn.Linear(channels, channels),
+            neuron.IFNode(step_mode="m"),
+            nn.Linear(channels, channels),
+            neuron.IFNode(step_mode="m"),
+        )
+
+    def forward(self, x):
+        return self.blocks(x)
+
+
+class MemOptBlock(nn.Sequential):
+    def __init__(self, channels: int):
+        super().__init__(
+            nn.Linear(channels, channels),
+            neuron.IFNode(step_mode="m"),
+            nn.Linear(channels, channels),
+            neuron.IFNode(step_mode="m"),
+        )
+        self.n_seq_inputs = 1
+        self.n_outputs = 1
+
+    def __spatial_split__(self):
+        return [
+            nn.Sequential(self[0], self[1]),
+            nn.Sequential(self[2], self[3]),
+        ]
+
+
+class MemOptBlockNet(nn.Module):
+    def __init__(self, channels: int, depth: int = 3):
+        super().__init__()
+        self.blocks = nn.Sequential(*[MemOptBlock(channels) for _ in range(depth)])
+
+    def forward(self, x):
+        return self.blocks(x)
+
+
+def build_case(model_kind: str, channels: int):
+    if model_kind == "neuron":
+        return MemOptToyNet(channels), neuron.IFNode
+    if model_kind == "block":
+        return MemOptBlockNet(channels), MemOptBlock
+    raise ValueError(f"Unsupported model_kind={model_kind!r}")
+
+
+def train_step(net: nn.Module, x: torch.Tensor):
+    net.train()
+    net.zero_grad(set_to_none=True)
+    y = net(x)
+    loss = y.sum()
+    loss.backward()
+    net.zero_grad(set_to_none=True)
+    functional.reset_net(net)
+
+
+def benchmark_train_step(net: nn.Module, x: torch.Tensor, warmup: int, iters: int):
+    for _ in range(warmup):
+        train_step(net, x)
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        train_step(net, x)
+    torch.cuda.synchronize()
+    elapsed = time.perf_counter() - t0
+    peak_allocated = torch.cuda.max_memory_allocated()
+    peak_reserved = torch.cuda.max_memory_reserved()
+    return {
+        "step_ms": elapsed * 1000.0 / iters,
+        "peak_allocated_mb": peak_allocated / 1024 / 1024,
+        "peak_reserved_mb": peak_reserved / 1024 / 1024,
+    }
+
+
+def optimize_model(
+    net,
+    instance,
+    x,
+    level: int,
+    warmup_in_main_process: bool,
+    warmup_in_profile_workers: bool,
+):
+    t0 = time.perf_counter()
+    optimized = memory_optimization(
+        net,
+        instance,
+        dummy_input=(x,),
+        compress_x=True,
+        level=level,
+        warmup_in_main_process=warmup_in_main_process,
+        warmup_in_profile_workers=warmup_in_profile_workers,
+    )
+    optimize_ms = (time.perf_counter() - t0) * 1000.0
+    return optimized, optimize_ms
+
+
+def run_single_variant(
+    base,
+    instance,
+    x,
+    level: int,
+    warmup_in_main_process: bool,
+    warmup_in_profile_workers: bool,
+    warmup: int,
+    iters: int,
+):
+    model, optimize_ms = optimize_model(
+        copy.deepcopy(base).cpu(),
+        instance,
+        x.detach().cpu(),
+        level=level,
+        warmup_in_main_process=warmup_in_main_process,
+        warmup_in_profile_workers=warmup_in_profile_workers,
+    )
+    model = model.to(x.device)
+    result = benchmark_train_step(model, x, warmup, iters)
+    result["optimize_ms"] = optimize_ms
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-kind", choices=("neuron", "block"), default="neuron")
+    parser.add_argument("--T", type=int, default=16)
+    parser.add_argument("--N", type=int, default=32)
+    parser.add_argument("--C", type=int, default=512)
+    parser.add_argument("--levels", type=int, nargs="+", default=[0, 1, 2, 3, 4])
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iters", type=int, default=20)
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for benchmark_memopt.py")
+
+    device = torch.device("cuda")
+    x = torch.randn(args.T, args.N, args.C, device=device)
+    base, instance = build_case(args.model_kind, args.C)
+    base = base.to(device)
+
+    baseline = benchmark_train_step(copy.deepcopy(base), x, args.warmup, args.iters)
+    results = {
+        "model_kind": args.model_kind,
+        "shape": {"T": args.T, "N": args.N, "C": args.C},
+        "baseline": baseline,
+        "levels": {},
+    }
+
+    for level in args.levels:
+        if level == 0:
+            continue
+        results["levels"][str(level)] = {
+            "warm_main": run_single_variant(
+                base, instance, x, level, True, True, args.warmup, args.iters
+            ),
+            "no_main_warmup": run_single_variant(
+                base, instance, x, level, False, True, args.warmup, args.iters
+            ),
+            "no_profile_worker_warmup": run_single_variant(
+                base, instance, x, level, False, False, args.warmup, args.iters
+            ),
+        }
+
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/APIs/spikingjelly.activation_based.memopt.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.memopt.rst
@@ -20,6 +20,10 @@ Automatic memory optimization pipeline for deep SNN training based on gradient c
 
     * - :func:`memory_optimization <spikingjelly.activation_based.memopt.pipeline.memory_optimization>`
       - **The main API**. Perform memory optimization on a model.
+    * - :class:`MemOptSummary <spikingjelly.activation_based.memopt.pipeline.MemOptSummary>`
+      - Structured summary returned by ``memory_optimization(..., return_summary=True)``.
+    * - :data:`MEMOPT_PROFILES <spikingjelly.activation_based.memopt.pipeline.MEMOPT_PROFILES>`
+      - Supported high-level memopt presets.
     * - :func:`resolve_device <spikingjelly.activation_based.memopt.pipeline.resolve_device>`
       - Get the device of the current process.
     * - :func:`apply_gc <spikingjelly.activation_based.memopt.pipeline.apply_gc>`

--- a/docs/source/tutorials/cn/memopt.rst
+++ b/docs/source/tutorials/cn/memopt.rst
@@ -80,6 +80,197 @@ English version: :doc:`../en/memopt`
 
 用户无需了解底层实现，只需调用 :func:`memory_optimization <spikingjelly.activation_based.memopt.pipeline.memory_optimization>` ，即可自动网络结构转换。
 
+高层预设与摘要
+---------------------
+
+除了直接指定 ``level=0..4`` ， :func:`memory_optimization <spikingjelly.activation_based.memopt.pipeline.memory_optimization>` 现在还提供了更高层的 ``profile`` 预设：
+
+* ``"safe"`` ：保守模式。仅启用逐层GC，关闭高开销 profiling，适合快速试用。
+* ``"balanced"`` ：推荐默认模式。启用有限的 split 搜索，在显存收益和优化耗时之间取得折中。
+* ``"memory"`` ：更偏向显存优化。默认会尝试时间/空间 split。
+* ``"exhaustive"`` ：激进模式。允许更完整的搜索和 greedy unwrap，适合离线调优。
+
+这些 ``profile`` 的实际效果和取舍大致如下：
+
+* ``"safe"`` ：优化器自身开销最低，通常只做逐层GC，适合先快速验证功能是否可用。
+* ``"balanced"`` ：通常是最推荐的起点。会尝试有限的 split 搜索，往往能在显存收益和优化耗时之间取得较好平衡。
+* ``"memory"`` ：更积极地追求峰值显存下降，更可能启用空间/时间 split；代价是优化器本身更慢，训练速度也更可能下降。
+* ``"exhaustive"`` ：适合离线调参或论文实验。它会尝试更完整的搜索流程，最有机会找到更激进的结构调整，但优化耗时最高。
+
+如果不确定如何选择，建议优先从 ``"balanced"`` 开始；若只想快速启用并尽量减少额外开销，可先尝试 ``"safe"`` ；若显存非常紧张，再考虑 ``"memory"`` 或 ``"exhaustive"`` 。
+
+如果用户希望显式限制优化器本身的开销，可设置 ``allow_expensive_profiling=False`` 。此时会自动收紧 split 搜索预算，并关闭 profiling worker 的 warmup。
+
+在此基础上，当前版本还提供了两层更高阶的自动控制：
+
+* ``checkpoint_budget`` ：控制 **有多少目标模块会被包装成检查点片段** 。可选
+  ``"speed"`` 、 ``"balanced"`` 、 ``"memory"`` 。
+
+  * ``"speed"`` ：只对一部分最“值钱”的热点模块做 checkpoint，优先减少额外训练开销。
+  * ``"balanced"`` ：覆盖更多热点模块，在显存和训练速度之间取折中。
+  * ``"memory"`` ：尽可能覆盖全部候选模块，更偏向显存下降。
+
+* ``prefer`` ：再往上一层的“目标导向”入口。可选
+  ``"speed"`` 、 ``"balanced"`` 、 ``"memory"`` 。当用户没有显式指定
+  ``profile`` 或 ``checkpoint_budget`` 时，会自动映射为推荐组合：
+
+  * ``prefer="speed"`` -> ``profile="safe"`` + ``checkpoint_budget="speed"``
+  * ``prefer="balanced"`` -> ``profile="balanced"`` + ``checkpoint_budget="balanced"``
+  * ``prefer="memory"`` -> ``profile="memory"`` + ``checkpoint_budget="memory"``
+
+这意味着，用户现在可以用三种粒度来控制 memopt：
+
+* 只想要最简单的高层接口：直接指定 ``prefer=...``
+* 希望分别控制搜索激进度与 checkpoint 覆盖范围：组合 ``profile`` 和 ``checkpoint_budget``
+* 需要精细实验：继续使用 ``level`` 、 ``max_gc_wrapped_modules`` 、 ``gc_target_budget_ratio`` 等底层参数
+
+为了给这些取舍提供一个更直观的量化参考，我们在服务器上的一张 ``RTX 4090`` 上，对一个较小的合成工作负载做了对比测试。测试模型为 ``MemOptBlockNet(depth=1)`` ，输入形状为 ``[T, N, C] = [2, 2, 16]`` ，每个配置均测量了 ``memory_optimization`` 自身耗时、优化后单步训练耗时以及训练峰值显存。未优化 baseline 的单步训练耗时约为 ``5.80 ms`` ， ``peak_allocated`` 为 ``17.26 MB`` ， ``peak_reserved`` 为 ``22.0 MB`` 。四个 ``profile`` 的结果如下：
+
+.. list-table::
+    :header-rows: 1
+
+    * - Profile
+      - ``memory_optimization`` 耗时
+      - 单步训练耗时
+      - ``peak_allocated``
+      - ``peak_reserved``
+      - 结构变化
+    * - ``safe``
+      - ``910.9 ms``
+      - ``5.73 ms``
+      - ``17.26 MB``
+      - ``278.0 MB``
+      - 仅包装为 1 个 :class:`GCContainer <spikingjelly.activation_based.memopt.checkpointing.GCContainer>`
+    * - ``balanced``
+      - ``8661.2 ms``
+      - ``6.13 ms``
+      - ``17.26 MB``
+      - ``278.0 MB``
+      - 1 次 spatial split，最终为 2 个 :class:`GCContainer <spikingjelly.activation_based.memopt.checkpointing.GCContainer>`
+    * - ``memory``
+      - ``20027.8 ms``
+      - ``6.07 ms``
+      - ``17.26 MB``
+      - ``278.0 MB``
+      - 1 次 spatial split，最终为 2 个 :class:`GCContainer <spikingjelly.activation_based.memopt.checkpointing.GCContainer>`
+    * - ``exhaustive``
+      - ``32880.1 ms``
+      - ``5.71 ms``
+      - ``17.26 MB``
+      - ``278.0 MB``
+      - 1 次 spatial split，最终为 2 个 :class:`GCContainer <spikingjelly.activation_based.memopt.checkpointing.GCContainer>`
+
+需要强调的是，这组数据的主要用途是说明不同 ``profile`` 的 **优化器开销趋势** ，而非给出对所有网络都成立的通用绝对值。对于真实的大模型，具体的训练速度和显存收益仍取决于网络结构、输入形状、batch size 以及当前设备环境。
+
+为了更贴近真实使用场景，我们还在同一张 ``RTX 4090`` 上，对教程后文将介绍的真实网络 ``CIFAR10DVSVGG`` 做了对比。测试配置为：
+
+* 后端： ``triton``
+* 输入形状： ``[N, T, C, H, W] = [8, 10, 2, 48, 48]``
+* 指标：
+  
+  * ``samples/s`` ：训练吞吐
+  * ``step_ms`` ：单步训练耗时
+  * ``peak_allocated_mb`` ：训练峰值已分配显存
+  * ``peak_reserved_mb`` ：训练峰值保留显存
+  * ``optimize_ms`` ：执行 :func:`memory_optimization <spikingjelly.activation_based.memopt.pipeline.memory_optimization>` 的耗时
+
+结果如下：
+
+.. list-table::
+    :header-rows: 1
+
+    * - 配置
+      - ``samples/s``
+      - ``step_ms``
+      - ``peak_allocated``
+      - ``peak_reserved``
+      - ``optimize_ms``
+      - 结构变化
+    * - baseline
+      - ``290.14``
+      - ``27.57 ms``
+      - ``1022.23 MB``
+      - ``1574.0 MB``
+      - ``0``
+      - 无优化
+    * - ``safe``
+      - ``218.58``
+      - ``36.60 ms``
+      - ``833.94 MB``
+      - ``1512.0 MB``
+      - ``2605.76 ms``
+      - ``level=1`` ，8 个 :class:`GCContainer <spikingjelly.activation_based.memopt.checkpointing.GCContainer>`
+    * - ``balanced``
+      - ``236.15``
+      - ``33.88 ms``
+      - ``787.94 MB``
+      - ``1422.0 MB``
+      - ``37038.26 ms``
+      - ``level=2`` ，1 次 spatial split，9 个 :class:`GCContainer <spikingjelly.activation_based.memopt.checkpointing.GCContainer>`
+    * - ``memory``
+      - ``223.30``
+      - ``35.83 ms``
+      - ``671.56 MB``
+      - ``1242.0 MB``
+      - ``89788.63 ms``
+      - ``level=3`` ，1 次 spatial split + 2 次 temporal split，9 个 :class:`GCContainer <spikingjelly.activation_based.memopt.checkpointing.GCContainer>` 与 2 个 :class:`TCGCContainer <spikingjelly.activation_based.memopt.checkpointing.TCGCContainer>`
+    * - ``exhaustive``
+      - ``289.18``
+      - ``27.66 ms``
+      - ``589.16 MB``
+      - ``1332.0 MB``
+      - ``450972.60 ms``
+      - ``level=4`` ，1 次 spatial split + 3 次 temporal split + 4 次 greedy unwrap，5 个 :class:`GCContainer <spikingjelly.activation_based.memopt.checkpointing.GCContainer>` 与 2 个 :class:`TCGCContainer <spikingjelly.activation_based.memopt.checkpointing.TCGCContainer>`
+
+这组真实网络数据反映了更实际的取舍：
+
+* ``safe`` 是最稳妥的入门选项，显存开始明显下降，但训练会变慢。
+* ``balanced`` 在这组实验里比 ``safe`` 再省一些显存，同时训练速度略好。
+* ``memory`` 继续降低峰值显存，但优化器自身耗时已经明显上升。
+* ``exhaustive`` 在这组实验里给出了最好的显存结果，而且单步训练速度几乎回到 baseline，但它的结构搜索成本极高，更适合离线调优。
+
+如果把目光缩小到新的高层接口 ``prefer`` ，在同一网络、同一输入形状下也能观察到比较清晰的梯度：
+
+.. list-table::
+    :header-rows: 1
+
+    * - ``prefer``
+      - 自动映射
+      - 选中的 checkpoint 模块数
+      - ``step_ms``
+      - ``peak_allocated``
+      - ``optimize_ms``
+    * - ``"speed"``
+      - ``safe`` + ``speed``
+      - ``4 / 8``
+      - ``34.43 ms``
+      - ``922.39 MB``
+      - ``2726.53 ms``
+    * - ``"balanced"``
+      - ``balanced`` + ``balanced``
+      - ``6 / 8``
+      - ``34.35 ms``
+      - ``877.14 MB``
+      - ``34360.89 ms``
+    * - ``"memory"``
+      - ``memory`` + ``memory``
+      - ``8 / 8``
+      - ``43.36 ms``
+      - ``699.17 MB``
+      - ``92689.79 ms``
+
+可以把它理解为： ``prefer`` 直接回答“这次优化更偏训练速度，还是更偏显存”，而内部再自动决定该用什么 ``profile`` 和 checkpoint 覆盖预算。
+
+另外，若设置 ``return_summary=True`` ，函数将返回 ``(net, summary)`` 。 ``summary`` 是 :class:`MemOptSummary <spikingjelly.activation_based.memopt.pipeline.MemOptSummary>` 对象，包含：
+
+* 请求/实际生效的优化级别
+* 使用的 ``prefer`` 、 ``profile`` 、 ``checkpoint_budget`` 和 ``allow_expensive_profiling`` 配置
+* 哪些优化步骤被应用、哪些步骤被跳过
+* 包装成 :class:`GCContainer <spikingjelly.activation_based.memopt.checkpointing.GCContainer>` / :class:`TCGCContainer <spikingjelly.activation_based.memopt.checkpointing.TCGCContainer>` 的数量
+* 自动选择的压缩器统计、checkpoint 候选数与实际选中数，以及空间/时间 split、greedy unwrap 的执行次数
+* ``gc_selected_modules`` / ``gc_selection_explanation`` ：说明这次为什么选中了这些 checkpoint 模块
+* ``recommendation`` ：基于当前选择结果给出的下一步调参建议，例如更偏速度还是更偏显存
+
 示例
 -----------------------
 
@@ -226,6 +417,27 @@ Step 3. 调用工具函数
     )
 
 查询 :func:`memory_optimization <spikingjelly.activation_based.memopt.pipeline.memory_optimization>` 的文档以获取参数说明。
+
+如果用户更关注“少调参、快速拿到一个合理配置”，则推荐优先使用 ``profile`` 接口。例如：
+
+.. code:: python
+
+    from spikingjelly.activation_based import memopt
+
+    net, summary = memopt.memory_optimization(
+        net,
+        (VGGBlock,),
+        dummy_input=(torch.zeros(32, T, 2, 48, 48),),
+        profile="balanced",
+        allow_expensive_profiling=False,
+        return_summary=True,
+    )
+
+    print(summary.applied_steps)
+    print(summary.skipped_steps)
+    print(summary.gc_container_count, summary.tcgc_container_count)
+
+若 ``profile`` 要求 ``level > 1`` 但没有提供 ``dummy_input`` ，则框架会自动回退到 ``level=1`` ，并在 ``summary.notes`` 中记录这一回退原因。
 
 结果
 ###############################

--- a/docs/source/tutorials/en/memopt.rst
+++ b/docs/source/tutorials/en/memopt.rst
@@ -80,6 +80,197 @@ The entire optimization procedure described above is wrapped inside :func:`memor
 
 Users do not need to understand the internals. Simply call :func:`memory_optimization <spikingjelly.activation_based.memopt.pipeline.memory_optimization>` to transform the network automatically.
 
+High-level presets and summaries
+--------------------------------
+
+Besides manually choosing ``level=0..4``, :func:`memory_optimization <spikingjelly.activation_based.memopt.pipeline.memory_optimization>` now provides higher-level ``profile`` presets:
+
+* ``"safe"``: conservative mode. Only applies layer-wise GC and avoids expensive profiling.
+* ``"balanced"``: recommended default. Enables limited split search and balances memory savings against optimization overhead.
+* ``"memory"``: more aggressive toward memory reduction. Tries both spatial and temporal split by default.
+* ``"exhaustive"``: most aggressive mode. Allows fuller search and greedy unwrap, suitable for offline tuning.
+
+In practice, these presets usually imply the following trade-offs:
+
+* ``"safe"``: lowest optimizer-side overhead. It usually stays close to layer-wise GC only, making it a good first try when you mainly want something robust and cheap to run.
+* ``"balanced"``: the recommended starting point. It performs limited split search and often provides a good compromise between memory savings and optimization latency.
+* ``"memory"``: more aggressive about reducing peak memory and therefore more likely to trigger spatial/temporal split; the trade-off is higher optimization overhead and a larger chance of training slowdown.
+* ``"exhaustive"``: best suited for offline tuning or research experiments. It explores a fuller search space and is the most likely to find aggressive structure changes, but also has the highest optimization cost.
+
+If you are unsure which one to choose, start from ``"balanced"``. Use ``"safe"`` when you want the smallest extra overhead, and reserve ``"memory"`` / ``"exhaustive"`` for memory-constrained or offline tuning scenarios.
+
+If you want to explicitly limit the optimizer's own overhead, set ``allow_expensive_profiling=False``. This automatically tightens split-search budgets and disables worker warmup during profiling.
+
+On top of ``profile``, the current version also exposes two more automatic control layers:
+
+* ``checkpoint_budget`` controls **how many candidate modules should actually be wrapped as checkpoint segments**. It accepts
+  ``"speed"``, ``"balanced"``, and ``"memory"``.
+
+  * ``"speed"`` keeps checkpointing focused on only the most valuable hotspots and prioritizes lower training overhead.
+  * ``"balanced"`` covers more hotspots and trades some extra overhead for more memory reduction.
+  * ``"memory"`` tries to cover as many candidates as possible and leans toward lower peak memory.
+
+* ``prefer`` is an even higher-level goal-oriented entry point. It accepts
+  ``"speed"``, ``"balanced"``, and ``"memory"``. When the user does not explicitly specify
+  ``profile`` or ``checkpoint_budget``, it maps to recommended defaults:
+
+  * ``prefer="speed"`` -> ``profile="safe"`` + ``checkpoint_budget="speed"``
+  * ``prefer="balanced"`` -> ``profile="balanced"`` + ``checkpoint_budget="balanced"``
+  * ``prefer="memory"`` -> ``profile="memory"`` + ``checkpoint_budget="memory"``
+
+This gives three levels of control:
+
+* the simplest goal-driven interface: set ``prefer=...``
+* separate control over search aggressiveness and checkpoint coverage: combine ``profile`` and ``checkpoint_budget``
+* fully manual experimentation: keep using low-level knobs such as ``level``, ``max_gc_wrapped_modules``, and ``gc_target_budget_ratio``
+
+To make these trade-offs more concrete, we also ran a small synthetic benchmark on a single ``RTX 4090``. The tested model was ``MemOptBlockNet(depth=1)`` with input shape ``[T, N, C] = [2, 2, 16]``. For each profile, we measured the time spent inside ``memory_optimization``, the post-optimization training step latency, and the training peak memory. The unoptimized baseline on this workload took about ``5.80 ms`` per training step, with ``peak_allocated = 17.26 MB`` and ``peak_reserved = 22.0 MB``. The profile-wise results were:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Profile
+      - ``memory_optimization`` time
+      - Training step time
+      - ``peak_allocated``
+      - ``peak_reserved``
+      - Structural effect
+    * - ``safe``
+      - ``910.9 ms``
+      - ``5.73 ms``
+      - ``17.26 MB``
+      - ``278.0 MB``
+      - Only wraps the target block into 1 :class:`GCContainer <spikingjelly.activation_based.memopt.checkpointing.GCContainer>`
+    * - ``balanced``
+      - ``8661.2 ms``
+      - ``6.13 ms``
+      - ``17.26 MB``
+      - ``278.0 MB``
+      - Performs 1 spatial split and ends with 2 :class:`GCContainer <spikingjelly.activation_based.memopt.checkpointing.GCContainer>` instances
+    * - ``memory``
+      - ``20027.8 ms``
+      - ``6.07 ms``
+      - ``17.26 MB``
+      - ``278.0 MB``
+      - Performs 1 spatial split and ends with 2 :class:`GCContainer <spikingjelly.activation_based.memopt.checkpointing.GCContainer>` instances
+    * - ``exhaustive``
+      - ``32880.1 ms``
+      - ``5.71 ms``
+      - ``17.26 MB``
+      - ``278.0 MB``
+      - Performs 1 spatial split and ends with 2 :class:`GCContainer <spikingjelly.activation_based.memopt.checkpointing.GCContainer>` instances
+
+These numbers are mainly intended to show the **optimizer-overhead trend** of different profiles, not to provide universal absolute values. On larger real workloads, the exact training-speed and memory trade-offs still depend on model structure, input shapes, batch size, and the current GPU environment.
+
+To complement the synthetic case, we also benchmarked the real tutorial network ``CIFAR10DVSVGG`` on the same ``RTX 4090``. The setup was:
+
+* backend: ``triton``
+* input shape: ``[N, T, C, H, W] = [8, 10, 2, 48, 48]``
+* reported metrics:
+
+  * ``samples/s``: training throughput
+  * ``step_ms``: per-step training latency
+  * ``peak_allocated_mb``: peak allocated training memory
+  * ``peak_reserved_mb``: peak reserved training memory
+  * ``optimize_ms``: time spent inside :func:`memory_optimization <spikingjelly.activation_based.memopt.pipeline.memory_optimization>`
+
+The results were:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Configuration
+      - ``samples/s``
+      - ``step_ms``
+      - ``peak_allocated``
+      - ``peak_reserved``
+      - ``optimize_ms``
+      - Structural effect
+    * - baseline
+      - ``290.14``
+      - ``27.57 ms``
+      - ``1022.23 MB``
+      - ``1574.0 MB``
+      - ``0``
+      - no optimization
+    * - ``safe``
+      - ``218.58``
+      - ``36.60 ms``
+      - ``833.94 MB``
+      - ``1512.0 MB``
+      - ``2605.76 ms``
+      - ``level=1`` with 8 :class:`GCContainer <spikingjelly.activation_based.memopt.checkpointing.GCContainer>` instances
+    * - ``balanced``
+      - ``236.15``
+      - ``33.88 ms``
+      - ``787.94 MB``
+      - ``1422.0 MB``
+      - ``37038.26 ms``
+      - ``level=2`` with 1 spatial split and 9 :class:`GCContainer <spikingjelly.activation_based.memopt.checkpointing.GCContainer>` instances
+    * - ``memory``
+      - ``223.30``
+      - ``35.83 ms``
+      - ``671.56 MB``
+      - ``1242.0 MB``
+      - ``89788.63 ms``
+      - ``level=3`` with 1 spatial split + 2 temporal splits, ending with 9 :class:`GCContainer <spikingjelly.activation_based.memopt.checkpointing.GCContainer>` and 2 :class:`TCGCContainer <spikingjelly.activation_based.memopt.checkpointing.TCGCContainer>` instances
+    * - ``exhaustive``
+      - ``289.18``
+      - ``27.66 ms``
+      - ``589.16 MB``
+      - ``1332.0 MB``
+      - ``450972.60 ms``
+      - ``level=4`` with 1 spatial split + 3 temporal splits + 4 greedy unwrap operations, ending with 5 :class:`GCContainer <spikingjelly.activation_based.memopt.checkpointing.GCContainer>` and 2 :class:`TCGCContainer <spikingjelly.activation_based.memopt.checkpointing.TCGCContainer>` instances
+
+This real-network benchmark shows a more practical trade-off:
+
+* ``safe`` is the safest starting point: peak memory already drops noticeably, but training slows down.
+* ``balanced`` saves even more memory than ``safe`` on this workload while recovering a bit of training speed.
+* ``memory`` pushes peak memory lower still, but the optimizer-side search cost becomes much larger.
+* ``exhaustive`` gives the best memory result here and almost recovers baseline training-step speed, but its structure-search cost is extremely high and is best treated as an offline tuning mode.
+
+If we zoom in on the new ``prefer`` interface alone, the same network and input shape also show a clear gradient:
+
+.. list-table::
+    :header-rows: 1
+
+    * - ``prefer``
+      - Automatic mapping
+      - Selected checkpoint modules
+      - ``step_ms``
+      - ``peak_allocated``
+      - ``optimize_ms``
+    * - ``"speed"``
+      - ``safe`` + ``speed``
+      - ``4 / 8``
+      - ``34.43 ms``
+      - ``922.39 MB``
+      - ``2726.53 ms``
+    * - ``"balanced"``
+      - ``balanced`` + ``balanced``
+      - ``6 / 8``
+      - ``34.35 ms``
+      - ``877.14 MB``
+      - ``34360.89 ms``
+    * - ``"memory"``
+      - ``memory`` + ``memory``
+      - ``8 / 8``
+      - ``43.36 ms``
+      - ``699.17 MB``
+      - ``92689.79 ms``
+
+You can think of ``prefer`` as directly answering "should this optimization lean more toward training speed or toward memory reduction?", while the framework automatically chooses the corresponding ``profile`` and checkpoint coverage budget underneath.
+
+In addition, ``return_summary=True`` makes the function return ``(net, summary)``. The ``summary`` object is :class:`MemOptSummary <spikingjelly.activation_based.memopt.pipeline.MemOptSummary>`, which records:
+
+* requested versus applied optimization levels
+* the chosen ``prefer``, ``profile``, ``checkpoint_budget``, and ``allow_expensive_profiling`` setting
+* which optimization stages were applied or skipped
+* how many :class:`GCContainer <spikingjelly.activation_based.memopt.checkpointing.GCContainer>` / :class:`TCGCContainer <spikingjelly.activation_based.memopt.checkpointing.TCGCContainer>` objects remain
+* compressor statistics, checkpoint candidate/selection counts, and counts of spatial split, temporal split, and greedy unwrap operations
+* ``gc_selected_modules`` / ``gc_selection_explanation`` to explain why those modules were chosen for checkpointing
+* ``recommendation`` for the next tuning step, e.g. whether to lean further toward speed or memory
+
 Example
 -------
 
@@ -226,6 +417,27 @@ Once the preparation is done, call :func:`memory_optimization <spikingjelly.acti
     )
 
 Refer to the :func:`memory_optimization <spikingjelly.activation_based.memopt.pipeline.memory_optimization>` docs for argument details.
+
+If you prefer a simpler, higher-level entry point, start from the ``profile`` argument instead:
+
+.. code:: python
+
+    from spikingjelly.activation_based import memopt
+
+    net, summary = memopt.memory_optimization(
+        net,
+        (VGGBlock,),
+        dummy_input=(torch.zeros(32, T, 2, 48, 48),),
+        profile="balanced",
+        allow_expensive_profiling=False,
+        return_summary=True,
+    )
+
+    print(summary.applied_steps)
+    print(summary.skipped_steps)
+    print(summary.gc_container_count, summary.tcgc_container_count)
+
+If a chosen ``profile`` implies ``level > 1`` but no ``dummy_input`` is provided, the framework will automatically fall back to ``level=1`` and record the fallback reason in ``summary.notes``.
 
 Results
 ###############################

--- a/spikingjelly/activation_based/memopt/__init__.py
+++ b/spikingjelly/activation_based/memopt/__init__.py
@@ -1,3 +1,9 @@
 from .checkpointing import *
 from .compress import *
-from .pipeline import memory_optimization  # noqa
+from .pipeline import (  # noqa
+    MEMOPT_CHECKPOINT_BUDGETS,
+    MEMOPT_PREFERENCES,
+    MEMOPT_PROFILES,
+    MemOptSummary,
+    memory_optimization,
+)

--- a/spikingjelly/activation_based/memopt/pipeline.py
+++ b/spikingjelly/activation_based/memopt/pipeline.py
@@ -18,14 +18,14 @@ from .checkpointing import GCContainer, TCGCContainer
 from .compress import BitSpikeCompressor, NullSpikeCompressor
 
 __all__ = [
-    "MEMOPT_PROFILES",
     "MEMOPT_CHECKPOINT_BUDGETS",
     "MEMOPT_PREFERENCES",
+    "MEMOPT_PROFILES",
     "MemOptSummary",
-    "resolve_device",
     "apply_gc",
     "get_module_and_parent",
     "memory_optimization",
+    "resolve_device",
 ]
 
 TCGC_FORBIDDEN_MODULES = [neuron.PSN, neuron.MaskedPSN, neuron.SlidingPSN]
@@ -67,6 +67,15 @@ class MemOptSummary:
 
 def _build_compressor_from_spec(spec):
     if isinstance(spec, str):
+        if not hasattr(compress, spec):
+            available = ", ".join(
+                name
+                for name in dir(compress)
+                if name.endswith("Compressor") and not name.startswith("_")
+            )
+            raise ValueError(
+                f"Unknown compressor spec {spec!r}. Available compressor classes: {available}."
+            )
         return getattr(compress, spec)()
     return copy.deepcopy(spec)
 
@@ -1497,7 +1506,7 @@ def memory_optimization(
                     cb_path = cb_name.split(" ")[-1]
                     cb, parent, child_name = get_module_and_parent(net, cb_path)
 
-                    split_cb = _spatially_split_gc_container(cb)
+                    split_cb = _spatially_split_gc_container(cb, compress_x)
                     if split_cb is None:
                         _cprint(verbose, f"\t{cb_name}: can't be spatially split")
                         blocked_candidates.add(cb_path)

--- a/spikingjelly/activation_based/memopt/pipeline.py
+++ b/spikingjelly/activation_based/memopt/pipeline.py
@@ -189,7 +189,7 @@ def _randomize_input_like(dummy_input):
         choice = torch.randint(0, 3, ()).item()
         if choice == 0:
             return x.clone()
-        return torch.empty_like(x)
+        return torch.zeros_like(x)
 
     if isinstance(dummy_input, torch.Tensor):
         return _generate_tensor_like(dummy_input)

--- a/spikingjelly/activation_based/memopt/pipeline.py
+++ b/spikingjelly/activation_based/memopt/pipeline.py
@@ -162,13 +162,34 @@ def _dummy_input_to_device(dummy_input, device):
 
 def _randomize_input_like(dummy_input):
     def _generate_tensor_like(x: torch.Tensor):
+        if x.dtype == torch.bool:
+            return torch.rand_like(x, dtype=torch.float32) > 0.5
+        if x.is_floating_point():
+            choice = torch.randint(0, 3, ()).item()
+            if choice == 0:
+                return torch.randn_like(x)
+            elif choice == 1:
+                return torch.empty_like(x).uniform_(-5, 5)
+            else:
+                return torch.empty_like(x).bernoulli_(p=0.5)
+        if x.dtype in (
+            torch.uint8,
+            torch.int8,
+            torch.int16,
+            torch.int32,
+            torch.int64,
+        ):
+            return torch.randint(
+                0,
+                3,
+                x.shape,
+                device=x.device,
+                dtype=x.dtype,
+            )
         choice = torch.randint(0, 3, ()).item()
         if choice == 0:
-            return torch.randn_like(x)
-        elif choice == 1:
-            return torch.empty_like(x).uniform_(-5, 5)
-        else:
-            return torch.empty_like(x).bernoulli_(p=0.5)
+            return x.clone()
+        return torch.empty_like(x)
 
     if isinstance(dummy_input, torch.Tensor):
         return _generate_tensor_like(dummy_input)
@@ -403,11 +424,11 @@ def _resolve_memory_optimization_options(
     level: Optional[int],
     profile: Optional[str],
     dummy_input,
-    compress_x: bool,
+    compress_x: Optional[bool],
     max_split_rounds: Optional[int],
     max_candidates_per_round: Optional[int],
-    warmup_in_main_process: bool,
-    warmup_in_profile_workers: bool,
+    warmup_in_main_process: Optional[bool],
+    warmup_in_profile_workers: Optional[bool],
     allow_expensive_profiling: Optional[bool],
 ):
     if profile is not None and profile not in MEMOPT_PROFILES:
@@ -458,11 +479,17 @@ def _resolve_memory_optimization_options(
         resolved_level = 0 if level is None else level
         resolved = dict(
             level=resolved_level,
-            compress_x=compress_x,
+            compress_x=True if compress_x is None else compress_x,
             max_split_rounds=max_split_rounds,
             max_candidates_per_round=max_candidates_per_round,
-            warmup_in_main_process=warmup_in_main_process,
-            warmup_in_profile_workers=warmup_in_profile_workers,
+            warmup_in_main_process=(
+                True if warmup_in_main_process is None else warmup_in_main_process
+            ),
+            warmup_in_profile_workers=(
+                True
+                if warmup_in_profile_workers is None
+                else warmup_in_profile_workers
+            ),
             allow_expensive_profiling=(
                 True if allow_expensive_profiling is None else allow_expensive_profiling
             ),
@@ -485,17 +512,12 @@ def _resolve_memory_optimization_options(
             ),
             warmup_in_main_process=(
                 preset["warmup_in_main_process"]
-                if warmup_in_main_process is True
-                and level is None
-                and max_split_rounds is None
-                and max_candidates_per_round is None
+                if warmup_in_main_process is None
                 else warmup_in_main_process
             ),
             warmup_in_profile_workers=(
                 preset["warmup_in_profile_workers"]
-                if warmup_in_profile_workers is True
-                and max_split_rounds is None
-                and max_candidates_per_round is None
+                if warmup_in_profile_workers is None
                 else warmup_in_profile_workers
             ),
             allow_expensive_profiling=(
@@ -589,7 +611,7 @@ def apply_gc(
     net: nn.Module,
     instance: Union[type, Tuple[type]],
     dummy_input: Optional[tuple] = None,
-    compress_x: bool = True,
+    compress_x: Optional[bool] = True,
     device: str = "cuda",
     checkpoint_budget: Optional[str] = None,
     max_gc_wrapped_modules: Optional[int] = None,
@@ -1131,8 +1153,10 @@ def _cprint(verbose, *args, **kwargs):
 
 
 def _candidate_entries(results, max_candidates_per_round: Optional[int]):
-    if max_candidates_per_round is None or max_candidates_per_round <= 0:
+    if max_candidates_per_round is None:
         return results
+    if max_candidates_per_round <= 0:
+        return []
     return results[:max_candidates_per_round]
 
 
@@ -1148,14 +1172,14 @@ def memory_optimization(
     net: nn.Module,
     instance: Union[type, Tuple[type]],
     dummy_input: Optional[tuple] = None,
-    compress_x: bool = True,
+    compress_x: Optional[bool] = None,
     level: Optional[int] = None,
     verbose: bool = False,
     temporal_split_factor: int = 2,
     max_split_rounds: Optional[int] = None,
     max_candidates_per_round: Optional[int] = None,
-    warmup_in_main_process: bool = True,
-    warmup_in_profile_workers: bool = True,
+    warmup_in_main_process: Optional[bool] = None,
+    warmup_in_profile_workers: Optional[bool] = None,
     prefer: Optional[str] = None,
     profile: Optional[str] = None,
     allow_expensive_profiling: Optional[bool] = None,

--- a/spikingjelly/activation_based/memopt/pipeline.py
+++ b/spikingjelly/activation_based/memopt/pipeline.py
@@ -2,6 +2,8 @@ import copy
 import os
 import time
 from collections import defaultdict
+from dataclasses import dataclass, field
+from math import ceil
 from typing import Dict, Optional, Tuple, Union
 
 import torch
@@ -15,9 +17,58 @@ from . import compress
 from .checkpointing import GCContainer, TCGCContainer
 from .compress import BitSpikeCompressor, NullSpikeCompressor
 
-__all__ = ["resolve_device", "apply_gc", "get_module_and_parent", "memory_optimization"]
+__all__ = [
+    "MEMOPT_PROFILES",
+    "MEMOPT_CHECKPOINT_BUDGETS",
+    "MEMOPT_PREFERENCES",
+    "MemOptSummary",
+    "resolve_device",
+    "apply_gc",
+    "get_module_and_parent",
+    "memory_optimization",
+]
 
 TCGC_FORBIDDEN_MODULES = [neuron.PSN, neuron.MaskedPSN, neuron.SlidingPSN]
+MEMOPT_PROFILES = ("safe", "balanced", "memory", "exhaustive")
+MEMOPT_CHECKPOINT_BUDGETS = ("speed", "balanced", "memory")
+MEMOPT_PREFERENCES = ("speed", "balanced", "memory")
+
+
+@dataclass
+class MemOptSummary:
+    profile: Optional[str]
+    checkpoint_budget: Optional[str]
+    prefer: Optional[str]
+    device: str
+    requested_level: int
+    applied_level: int
+    compress_x: bool
+    allow_expensive_profiling: bool
+    applied_steps: list = field(default_factory=list)
+    skipped_steps: list = field(default_factory=list)
+    notes: list = field(default_factory=list)
+    gc_wrap_count: int = 0
+    manual_compressor_count: int = 0
+    bit_compressor_count: int = 0
+    null_compressor_count: int = 0
+    spatial_split_count: int = 0
+    temporal_split_count: int = 0
+    unwrap_count: int = 0
+    gc_container_count: int = 0
+    tcgc_container_count: int = 0
+    options: dict = field(default_factory=dict)
+    gc_candidate_count: int = 0
+    gc_selected_count: int = 0
+    gc_selection_policy: str = "all_candidates"
+    gc_selected_modules: list = field(default_factory=list)
+    gc_selection_explanation: str = ""
+    recommendation: str = ""
+
+
+def _build_compressor_from_spec(spec):
+    if isinstance(spec, str):
+        return getattr(compress, spec)()
+    return copy.deepcopy(spec)
 
 
 def resolve_device() -> str:
@@ -109,26 +160,7 @@ def _dummy_input_to_device(dummy_input, device):
         return dummy_input
 
 
-def _probe_binary_inputs(
-    net: nn.Module,
-    instance: Union[type, Tuple[type]],
-    dummy_input: tuple,
-    n_trials: int = 5,
-) -> Dict[nn.Module, bool]:
-    """Run dummy forward and record whether target modules receive binary inputs."""
-    is_binary = defaultdict(lambda: True)
-    hooks = []
-
-    def hook_fn(m, inputs: tuple):
-        x = inputs[0]  # assume the first input is the one to be checked
-        binary = torch.all((x == 0) | (x == 1)).item()
-        is_binary[m] = is_binary[m] and binary
-
-    # register hooks
-    for m in net.modules():
-        if isinstance(m, instance):
-            hooks.append(m.register_forward_pre_hook(hook_fn))
-
+def _randomize_input_like(dummy_input):
     def _generate_tensor_like(x: torch.Tensor):
         choice = torch.randint(0, 3, ()).item()
         if choice == 0:
@@ -138,29 +170,419 @@ def _probe_binary_inputs(
         else:
             return torch.empty_like(x).bernoulli_(p=0.5)
 
-    def _generate_input_like(dummy_input):
-        if isinstance(dummy_input, torch.Tensor):
-            return _generate_tensor_like(dummy_input)
-        elif isinstance(dummy_input, (tuple, list)):
-            return type(dummy_input)(_generate_input_like(t) for t in dummy_input)
-        elif isinstance(dummy_input, dict):
-            return {k: _generate_input_like(v) for k, v in dummy_input.items()}
-        else:
-            # Non-tensor inputs (e.g., None, int, etc.)
-            return dummy_input
+    if isinstance(dummy_input, torch.Tensor):
+        return _generate_tensor_like(dummy_input)
+    elif isinstance(dummy_input, (tuple, list)):
+        return type(dummy_input)(_randomize_input_like(t) for t in dummy_input)
+    elif isinstance(dummy_input, dict):
+        return {k: _randomize_input_like(v) for k, v in dummy_input.items()}
+    else:
+        # Non-tensor inputs (e.g., None, int, etc.)
+        return dummy_input
+
+
+def _probe_binary_inputs(
+    net: nn.Module,
+    instance: Union[type, Tuple[type]],
+    dummy_input: tuple,
+    n_trials: int = 5,
+    target_modules: Optional[Tuple[nn.Module, ...]] = None,
+) -> Dict[nn.Module, bool]:
+    """Run dummy forward and record whether target modules receive binary inputs."""
+    is_binary = defaultdict(lambda: True)
+    hooks = []
+    if target_modules is None:
+        target_modules = tuple(
+            m for m in net.modules() if isinstance(m, instance)
+        )
+
+    def hook_fn(m, inputs: tuple):
+        x = inputs[0]  # assume the first input is the one to be checked
+        binary = torch.all((x == 0) | (x == 1)).item()
+        is_binary[m] = is_binary[m] and binary
+
+    # register hooks
+    for m in target_modules:
+        hooks.append(m.register_forward_pre_hook(hook_fn))
 
     is_training = net.training
     net.eval()
     with torch.no_grad():
-        for _ in range(n_trials):
-            new_input = _generate_input_like(dummy_input)
+        if n_trials > 0:
+            _ = net(*dummy_input)
+            functional.reset_net(net)
+            if target_modules and all(not is_binary[m] for m in target_modules):
+                n_trials = 1
+
+        for _ in range(1, n_trials):
+            new_input = _randomize_input_like(dummy_input)
             _ = net(*new_input)
             functional.reset_net(net)
+            if target_modules and all(not is_binary[m] for m in target_modules):
+                break
 
     net.train(is_training)
     for h in hooks:
         h.remove()
     return dict(is_binary)
+
+
+def _estimate_module_input_bytes(
+    net: nn.Module,
+    instance: Union[type, Tuple[type]],
+    dummy_input: tuple,
+    target_modules: Optional[Tuple[nn.Module, ...]] = None,
+):
+    """Estimate per-module input activation size (in bytes) from one dry run."""
+    estimated_bytes = defaultdict(int)
+    hooks = []
+    if target_modules is None:
+        target_modules = tuple(m for m in net.modules() if isinstance(m, instance))
+
+    def hook_fn(m, inputs: tuple):
+        if not inputs:
+            return
+        x = inputs[0]
+        if isinstance(x, torch.Tensor):
+            estimated_bytes[m] = max(estimated_bytes[m], x.numel() * x.element_size())
+
+    for m in target_modules:
+        hooks.append(m.register_forward_pre_hook(hook_fn))
+
+    is_training = net.training
+    net.eval()
+    with torch.no_grad():
+        _ = net(*dummy_input)
+        functional.reset_net(net)
+    net.train(is_training)
+    for h in hooks:
+        h.remove()
+    return dict(estimated_bytes)
+
+
+def _module_path_map(net: nn.Module) -> Dict[nn.Module, str]:
+    return {module: name for name, module in net.named_modules() if name}
+
+
+def _resolve_gc_selection_targets(
+    net: nn.Module,
+    instance: Union[type, Tuple[type]],
+    dummy_input: Optional[tuple],
+    *,
+    device: str,
+    max_gc_wrapped_modules: Optional[int],
+    gc_target_budget_ratio: Optional[float],
+):
+    candidates = [m for m in net.modules() if isinstance(m, instance)]
+    candidate_count = len(candidates)
+    if candidate_count == 0:
+        return None, candidate_count, candidate_count, "no_candidates"
+
+    limits = []
+    if max_gc_wrapped_modules is not None:
+        if max_gc_wrapped_modules <= 0:
+            return tuple(), candidate_count, 0, "explicit_zero_budget"
+        limits.append(min(max_gc_wrapped_modules, candidate_count))
+    if gc_target_budget_ratio is not None:
+        if gc_target_budget_ratio <= 0:
+            return tuple(), candidate_count, 0, "zero_ratio_budget"
+        ratio_limit = max(1, min(candidate_count, ceil(candidate_count * gc_target_budget_ratio)))
+        limits.append(ratio_limit)
+
+    if not limits:
+        return None, candidate_count, candidate_count, "all_candidates"
+
+    selected_count = min(limits)
+    if selected_count >= candidate_count:
+        return None, candidate_count, candidate_count, "budget_covers_all"
+
+    if dummy_input is None:
+        return tuple(candidates[:selected_count]), candidate_count, selected_count, "fallback_module_order"
+
+    net = net.to(device)
+    moved_input = _dummy_input_to_device(dummy_input, device)
+    estimated_bytes = _estimate_module_input_bytes(
+        net,
+        instance,
+        moved_input,
+        target_modules=tuple(candidates),
+    )
+    ranked = sorted(
+        candidates,
+        key=lambda m: (estimated_bytes.get(m, 0), -candidates.index(m)),
+        reverse=True,
+    )
+    return tuple(ranked[:selected_count]), candidate_count, selected_count, "largest_input_activations"
+
+
+def _build_gc_selection_explanation(
+    *,
+    candidate_count: int,
+    selected_count: int,
+    selection_policy: str,
+    checkpoint_budget: Optional[str],
+    max_gc_wrapped_modules: Optional[int],
+    gc_target_budget_ratio: Optional[float],
+):
+    if candidate_count == 0:
+        return "No matching modules were found for checkpoint wrapping."
+    if selected_count == candidate_count:
+        if checkpoint_budget is not None:
+            return (
+                f'Checkpoint budget "{checkpoint_budget}" covered all {candidate_count} matching modules, '
+                "so no module-level filtering was applied."
+            )
+        return f"All {candidate_count} matching modules were selected for checkpoint wrapping."
+    if selection_policy == "largest_input_activations":
+        reason = f"Selected {selected_count} of {candidate_count} matching modules with the largest observed input activations."
+        if checkpoint_budget is not None:
+            reason += f' This was driven by checkpoint budget "{checkpoint_budget}".'
+        elif max_gc_wrapped_modules is not None or gc_target_budget_ratio is not None:
+            reason += " This was driven by the explicit selective-checkpoint budget."
+        return reason
+    if selection_policy == "fallback_module_order":
+        return (
+            f"Selected the first {selected_count} of {candidate_count} matching modules by module order "
+            "because no dummy_input was available to score activation sizes."
+        )
+    if selection_policy == "explicit_zero_budget":
+        return "Selective checkpointing budget was set to zero, so no modules were wrapped."
+    if selection_policy == "zero_ratio_budget":
+        return "Selective checkpointing ratio budget was non-positive, so no modules were wrapped."
+    return (
+        f"Selected {selected_count} of {candidate_count} matching modules under policy "
+        f'"{selection_policy}".'
+    )
+
+
+def _build_memopt_recommendation(summary: MemOptSummary) -> str:
+    if summary.gc_candidate_count == 0:
+        return "No matching modules were found. Consider passing a different target instance tuple."
+    if summary.prefer == "speed":
+        return (
+            "Current settings favor training speed. If you need more memory reduction, try "
+            '`prefer="balanced"` or increase `gc_target_budget_ratio`.'
+        )
+    if summary.prefer == "memory":
+        return (
+            "Current settings favor memory reduction. If optimization latency or training slowdown is too high, "
+            'try `prefer="balanced"` or `checkpoint_budget="speed"`.'
+        )
+    if summary.prefer == "balanced":
+        return (
+            "Current settings aim for a middle ground. Move to `prefer=\"speed\"` for lower overhead or "
+            '`prefer="memory"` for more aggressive memory savings.'
+        )
+    if summary.checkpoint_budget == "speed":
+        return (
+            "Checkpoint coverage is intentionally conservative. Increase to "
+            '`checkpoint_budget="balanced"` or `"memory"` if you want more memory savings.'
+        )
+    if summary.checkpoint_budget == "memory":
+        return (
+            "Checkpoint coverage is already aggressive. To reduce optimization or training cost, "
+            'drop to `checkpoint_budget="balanced"` or `"speed"`.'
+        )
+    if summary.profile == "safe":
+        return (
+            "You are using the conservative `safe` profile. If this does not save enough memory, "
+            'try `profile="balanced"` or `prefer="balanced"`.'
+        )
+    if summary.profile == "exhaustive":
+        return (
+            "You are using the most expensive search mode. Keep it for offline tuning; for routine use, "
+            'consider `profile="balanced"` or `prefer="balanced"`.'
+        )
+    return (
+        "Review `summary.gc_selected_count`, split counts, and skipped steps to decide whether to bias "
+        "future runs toward speed or memory."
+    )
+
+
+def _resolve_memory_optimization_options(
+    level: Optional[int],
+    profile: Optional[str],
+    dummy_input,
+    compress_x: bool,
+    max_split_rounds: Optional[int],
+    max_candidates_per_round: Optional[int],
+    warmup_in_main_process: bool,
+    warmup_in_profile_workers: bool,
+    allow_expensive_profiling: Optional[bool],
+):
+    if profile is not None and profile not in MEMOPT_PROFILES:
+        raise ValueError(
+            f"Unsupported memopt profile {profile!r}. Expected one of {MEMOPT_PROFILES}."
+        )
+
+    defaults = {
+        "safe": dict(
+            level=1,
+            compress_x=True,
+            max_split_rounds=0,
+            max_candidates_per_round=0,
+            warmup_in_main_process=False,
+            warmup_in_profile_workers=False,
+            allow_expensive_profiling=False,
+        ),
+        "balanced": dict(
+            level=2,
+            compress_x=True,
+            max_split_rounds=1,
+            max_candidates_per_round=1,
+            warmup_in_main_process=False,
+            warmup_in_profile_workers=False,
+            allow_expensive_profiling=False,
+        ),
+        "memory": dict(
+            level=3,
+            compress_x=True,
+            max_split_rounds=2,
+            max_candidates_per_round=2,
+            warmup_in_main_process=False,
+            warmup_in_profile_workers=True,
+            allow_expensive_profiling=True,
+        ),
+        "exhaustive": dict(
+            level=4,
+            compress_x=True,
+            max_split_rounds=None,
+            max_candidates_per_round=None,
+            warmup_in_main_process=True,
+            warmup_in_profile_workers=True,
+            allow_expensive_profiling=True,
+        ),
+    }
+
+    if profile is None:
+        resolved_level = 0 if level is None else level
+        resolved = dict(
+            level=resolved_level,
+            compress_x=compress_x,
+            max_split_rounds=max_split_rounds,
+            max_candidates_per_round=max_candidates_per_round,
+            warmup_in_main_process=warmup_in_main_process,
+            warmup_in_profile_workers=warmup_in_profile_workers,
+            allow_expensive_profiling=(
+                True if allow_expensive_profiling is None else allow_expensive_profiling
+            ),
+        )
+        notes = []
+    else:
+        preset = defaults[profile]
+        resolved = dict(
+            level=preset["level"] if level is None else level,
+            compress_x=compress_x if compress_x is not None else preset["compress_x"],
+            max_split_rounds=(
+                preset["max_split_rounds"]
+                if max_split_rounds is None
+                else max_split_rounds
+            ),
+            max_candidates_per_round=(
+                preset["max_candidates_per_round"]
+                if max_candidates_per_round is None
+                else max_candidates_per_round
+            ),
+            warmup_in_main_process=(
+                preset["warmup_in_main_process"]
+                if warmup_in_main_process is True
+                and level is None
+                and max_split_rounds is None
+                and max_candidates_per_round is None
+                else warmup_in_main_process
+            ),
+            warmup_in_profile_workers=(
+                preset["warmup_in_profile_workers"]
+                if warmup_in_profile_workers is True
+                and max_split_rounds is None
+                and max_candidates_per_round is None
+                else warmup_in_profile_workers
+            ),
+            allow_expensive_profiling=(
+                preset["allow_expensive_profiling"]
+                if allow_expensive_profiling is None
+                else allow_expensive_profiling
+            ),
+        )
+        notes = [f"profile:{profile}"]
+
+    if not resolved["allow_expensive_profiling"] and resolved["level"] > 1:
+        resolved["max_split_rounds"] = 1
+        resolved["max_candidates_per_round"] = 1
+        resolved["warmup_in_profile_workers"] = False
+
+    if dummy_input is None and resolved["level"] > 1:
+        if profile is None:
+            raise ValueError("dummy_input must be provided for memory profiling.")
+        notes.append("fallback:level>1_requires_dummy_input")
+        resolved["level"] = 1
+        resolved["max_split_rounds"] = 0
+        resolved["max_candidates_per_round"] = 0
+        resolved["warmup_in_profile_workers"] = False
+
+    return resolved, notes
+
+
+def _resolve_preference_options(
+    prefer: Optional[str],
+    profile: Optional[str],
+    checkpoint_budget: Optional[str],
+):
+    if prefer is not None and prefer not in MEMOPT_PREFERENCES:
+        raise ValueError(
+            f"Unsupported prefer {prefer!r}. Expected one of {MEMOPT_PREFERENCES}."
+        )
+
+    resolved_profile = profile
+    resolved_budget = checkpoint_budget
+    notes = []
+
+    if prefer is None:
+        return resolved_profile, resolved_budget, notes
+
+    defaults = {
+        "speed": ("safe", "speed"),
+        "balanced": ("balanced", "balanced"),
+        "memory": ("memory", "memory"),
+    }
+    default_profile, default_budget = defaults[prefer]
+
+    if resolved_profile is None:
+        resolved_profile = default_profile
+        notes.append(f"prefer:profile={default_profile}")
+    if resolved_budget is None:
+        resolved_budget = default_budget
+        notes.append(f"prefer:checkpoint_budget={default_budget}")
+
+    return resolved_profile, resolved_budget, notes
+
+
+def _resolve_checkpoint_budget_options(
+    checkpoint_budget: Optional[str],
+    max_gc_wrapped_modules: Optional[int],
+    gc_target_budget_ratio: Optional[float],
+):
+    if checkpoint_budget is not None and checkpoint_budget not in MEMOPT_CHECKPOINT_BUDGETS:
+        raise ValueError(
+            "Unsupported checkpoint_budget "
+            f"{checkpoint_budget!r}. Expected one of {MEMOPT_CHECKPOINT_BUDGETS}."
+        )
+
+    resolved_max = max_gc_wrapped_modules
+    resolved_ratio = gc_target_budget_ratio
+    notes = []
+
+    if checkpoint_budget is not None:
+        defaults = {
+            "speed": 0.5,
+            "balanced": 0.75,
+            "memory": 1.0,
+        }
+        if resolved_ratio is None and resolved_max is None:
+            resolved_ratio = defaults[checkpoint_budget]
+            notes.append(f"checkpoint_budget:{checkpoint_budget}")
+
+    return resolved_max, resolved_ratio, notes
 
 
 def apply_gc(
@@ -169,7 +591,11 @@ def apply_gc(
     dummy_input: Optional[tuple] = None,
     compress_x: bool = True,
     device: str = "cuda",
-) -> nn.Module:
+    checkpoint_budget: Optional[str] = None,
+    max_gc_wrapped_modules: Optional[int] = None,
+    gc_target_budget_ratio: Optional[float] = None,
+    return_summary: bool = False,
+) -> Union[nn.Module, Tuple[nn.Module, dict]]:
     r"""
     **API Language:**
     :ref:`中文 <_apply_gc-cn>` | :ref:`English <_apply_gc-en>`
@@ -223,14 +649,91 @@ def apply_gc(
     :param device: Device type, e.g., "cuda" or "cpu"
     :type device: str
 
+    :param checkpoint_budget: High-level selective checkpoint preset. One of
+        ``"speed"``, ``"balanced"``, or ``"memory"``
+    :type checkpoint_budget: Optional[str]
+
+    :param max_gc_wrapped_modules: Optional upper bound on how many matching
+        modules should be wrapped. When set, the modules with the largest
+        observed input activations are preferred if ``dummy_input`` is given
+    :type max_gc_wrapped_modules: Optional[int]
+
+    :param gc_target_budget_ratio: Optional ratio in ``(0, 1]`` controlling the
+        fraction of matching modules to wrap. When used together with
+        ``max_gc_wrapped_modules``, the smaller budget wins
+    :type gc_target_budget_ratio: Optional[float]
+
     :return: Network module with GC applied
     :rtype: torch.nn.Module
     """
     is_binary_input = {}
+    apply_summary = dict(
+        gc_wrap_count=0,
+        manual_compressor_count=0,
+        bit_compressor_count=0,
+        null_compressor_count=0,
+        gc_candidate_count=0,
+        gc_selected_count=0,
+        gc_selection_policy="all_candidates",
+        gc_selected_modules=[],
+        gc_selection_explanation="",
+    )
+    candidates = [m for m in net.modules() if isinstance(m, instance)]
+    (
+        max_gc_wrapped_modules,
+        gc_target_budget_ratio,
+        budget_notes,
+    ) = _resolve_checkpoint_budget_options(
+        checkpoint_budget,
+        max_gc_wrapped_modules,
+        gc_target_budget_ratio,
+    )
+    selected_targets, candidate_count, selected_count, selection_policy = (
+        _resolve_gc_selection_targets(
+            net,
+            instance,
+            dummy_input,
+            device=device,
+            max_gc_wrapped_modules=max_gc_wrapped_modules,
+            gc_target_budget_ratio=gc_target_budget_ratio,
+        )
+    )
+    apply_summary["gc_candidate_count"] = candidate_count
+    apply_summary["gc_selected_count"] = selected_count
+    apply_summary["gc_selection_policy"] = selection_policy
+    apply_summary["checkpoint_budget"] = checkpoint_budget
+    apply_summary["budget_notes"] = budget_notes
+    path_map = _module_path_map(net)
+    apply_summary["gc_selected_modules"] = (
+        [path_map.get(m, "<root>") for m in selected_targets]
+        if selected_targets is not None
+        else [path_map.get(m, "<root>") for m in candidates]
+    )
+    apply_summary["gc_selection_explanation"] = _build_gc_selection_explanation(
+        candidate_count=candidate_count,
+        selected_count=selected_count,
+        selection_policy=selection_policy,
+        checkpoint_budget=checkpoint_budget,
+        max_gc_wrapped_modules=max_gc_wrapped_modules,
+        gc_target_budget_ratio=gc_target_budget_ratio,
+    )
     if compress_x and dummy_input is not None:
-        net = net.to(device)
-        dummy_input = _dummy_input_to_device(dummy_input, device)
-        is_binary_input = _probe_binary_inputs(net, instance, dummy_input)
+        probe_targets = tuple(
+            m
+            for m in net.modules()
+            if isinstance(m, instance)
+            and (selected_targets is None or m in selected_targets)
+            and getattr(m, "x_compressor", None) is None
+        )
+        if probe_targets:
+            net = net.to(device)
+            dummy_input = _dummy_input_to_device(dummy_input, device)
+            is_binary_input = _probe_binary_inputs(
+                net,
+                instance,
+                dummy_input,
+                target_modules=probe_targets,
+            )
 
     def _get_compressor(module: nn.Module, is_binary_input: bool):
         spec = getattr(module, "x_compressor", None)
@@ -239,23 +742,32 @@ def apply_gc(
                 x_compressor = (
                     BitSpikeCompressor() if is_binary_input else NullSpikeCompressor()
                 )
+                if isinstance(x_compressor, BitSpikeCompressor):
+                    apply_summary["bit_compressor_count"] += 1
+                else:
+                    apply_summary["null_compressor_count"] += 1
             else:  # manually specified
-                x_compressor = (
-                    getattr(compress, spec)() if isinstance(spec, str) else spec
-                )
+                x_compressor = _build_compressor_from_spec(spec)
+                apply_summary["manual_compressor_count"] += 1
         else:  # disable compression
             x_compressor = NullSpikeCompressor()
+            apply_summary["null_compressor_count"] += 1
         return x_compressor
 
     def _replace(subnet: nn.Module):
         for name, child in list(subnet.named_children()):
-            if isinstance(child, instance):
+            if isinstance(child, instance) and (
+                selected_targets is None or child in selected_targets
+            ):
                 x_compressor = _get_compressor(child, is_binary_input.get(child, False))
                 setattr(subnet, name, GCContainer(x_compressor, child))
+                apply_summary["gc_wrap_count"] += 1
             elif not isinstance(child, GCContainer):
                 _replace(child)
 
     _replace(net)
+    if return_summary:
+        return net, apply_summary
     return net
 
 
@@ -344,7 +856,14 @@ def _dummy_train_step(
         _load_bn_states(net, saved_bn_states)
 
 
-def _train_memory_profile_worker(net, dummy_input, q, device):
+def _train_memory_profile_worker(
+    net,
+    dummy_input,
+    q,
+    device,
+    worker_warmup=True,
+    return_peak=False,
+):
     """`net` and `dummy_input` should be a deep copy of the original model and
     should be located on CPU, since they must be pickle-able.
     """
@@ -353,7 +872,8 @@ def _train_memory_profile_worker(net, dummy_input, q, device):
 
     # Warmup to trigger Triton autotune & JIT compilation in this subprocess.
     # Without this, the peak memory of the 1st and last layers will be strange!
-    _dummy_train_step(net, dummy_input)
+    if worker_warmup:
+        _dummy_train_step(net, dummy_input)
 
     torch.cuda.synchronize(device)
     torch.cuda.empty_cache()
@@ -367,10 +887,18 @@ def _train_memory_profile_worker(net, dummy_input, q, device):
     ) as prof:
         _dummy_train_step(net, dummy_input)
     results = prof.export(output=False)
-    q.put(results)
+    if return_peak:
+        torch.cuda.synchronize(device)
+        peak_allocated = torch.cuda.max_memory_allocated(device)
+        peak_reserved = torch.cuda.max_memory_reserved(device)
+        q.put((results, peak_allocated, peak_reserved))
+    else:
+        q.put(results)
 
 
-def _train_memory_profile(net, dummy_input, ctx, device):
+def _train_memory_profile(
+    net, dummy_input, ctx, device, worker_warmup=True, return_peak=False
+):
     q = ctx.Queue(maxsize=1)
     p = ctx.Process(
         target=_train_memory_profile_worker,
@@ -379,6 +907,8 @@ def _train_memory_profile(net, dummy_input, ctx, device):
             _dummy_input_to_device(dummy_input, "cpu"),
             q,
             device,
+            worker_warmup,
+            return_peak,
         ),
     )
     p.start()
@@ -387,7 +917,7 @@ def _train_memory_profile(net, dummy_input, ctx, device):
     return results
 
 
-def _train_peak_memory_worker(net, dummy_input, q, device):
+def _train_peak_memory_worker(net, dummy_input, q, device, worker_warmup=True):
     """Profile the peak training memory usage of the entire net.
 
     `net` and `dummy_input` should be deep copies located on CPU,
@@ -397,7 +927,8 @@ def _train_peak_memory_worker(net, dummy_input, q, device):
     dummy_input = _dummy_input_to_device(dummy_input, device)
     # Warmup to trigger Triton autotune & JIT compilation in this subprocess.
     # Without this, the peak memory of the 1st and last layers will be strange!
-    _dummy_train_step(net, dummy_input)
+    if worker_warmup:
+        _dummy_train_step(net, dummy_input)
 
     torch.cuda.synchronize(device)
     torch.cuda.empty_cache()
@@ -409,7 +940,7 @@ def _train_peak_memory_worker(net, dummy_input, q, device):
     q.put((peak_allocated, peak_reserved))
 
 
-def _train_peak_memory(net, dummy_input, ctx, device):
+def _train_peak_memory(net, dummy_input, ctx, device, worker_warmup=True):
     q = ctx.Queue(maxsize=1)
     p = ctx.Process(
         target=_train_peak_memory_worker,
@@ -418,6 +949,7 @@ def _train_peak_memory(net, dummy_input, ctx, device):
             _dummy_input_to_device(dummy_input, "cpu"),
             q,
             device,
+            worker_warmup,
         ),
     )
     p.start()
@@ -532,9 +1064,13 @@ def _spatially_split_gc_container(block: GCContainer, compress_x: bool = True):
         spec = getattr(module, "x_compressor", None)
         if compress_x:
             if spec is None:  # auto-detect
-                c = x_compressor if use_original_compressor else NullSpikeCompressor()
+                c = (
+                    copy.deepcopy(x_compressor)
+                    if use_original_compressor
+                    else NullSpikeCompressor()
+                )
             else:  # manually specified
-                c = getattr(compress, spec)() if isinstance(spec, str) else spec
+                c = _build_compressor_from_spec(spec)
         else:  # disable compression
             c = NullSpikeCompressor()
         return c
@@ -544,6 +1080,10 @@ def _spatially_split_gc_container(block: GCContainer, compress_x: bool = True):
         c = _get_compressor(sub, i == 0)
         l.append(GCContainer(c, sub))
     return nn.Sequential(*l)
+
+
+def _can_spatially_split(block: GCContainer) -> bool:
+    return len(block) > 1 or (len(block) == 1 and hasattr(block[0], "__spatial_split__"))
 
 
 def _cannot_temporally_split(block: GCContainer):
@@ -572,6 +1112,10 @@ def _temporally_split_gc_container(block: GCContainer, factor: int = 2):
     )
 
 
+def _can_temporally_split(block: GCContainer) -> bool:
+    return not _cannot_temporally_split(block)
+
+
 def _unwrap_gc_container(block: GCContainer) -> nn.Module:
     assert isinstance(block, GCContainer)
 
@@ -586,15 +1130,40 @@ def _cprint(verbose, *args, **kwargs):
         print(*args, **kwargs)
 
 
+def _candidate_entries(results, max_candidates_per_round: Optional[int]):
+    if max_candidates_per_round is None or max_candidates_per_round <= 0:
+        return results
+    return results[:max_candidates_per_round]
+
+
+def _gc_container_count(net: nn.Module) -> int:
+    return sum(1 for m in net.modules() if isinstance(m, GCContainer))
+
+
+def _has_split_candidate(net: nn.Module, predicate) -> bool:
+    return any(predicate(m) for m in net.modules() if isinstance(m, GCContainer))
+
+
 def memory_optimization(
     net: nn.Module,
     instance: Union[type, Tuple[type]],
     dummy_input: Optional[tuple] = None,
     compress_x: bool = True,
-    level: int = 0,
+    level: Optional[int] = None,
     verbose: bool = False,
     temporal_split_factor: int = 2,
-):
+    max_split_rounds: Optional[int] = None,
+    max_candidates_per_round: Optional[int] = None,
+    warmup_in_main_process: bool = True,
+    warmup_in_profile_workers: bool = True,
+    prefer: Optional[str] = None,
+    profile: Optional[str] = None,
+    allow_expensive_profiling: Optional[bool] = None,
+    checkpoint_budget: Optional[str] = None,
+    max_gc_wrapped_modules: Optional[int] = None,
+    gc_target_budget_ratio: Optional[float] = None,
+    return_summary: bool = False,
+) -> Union[nn.Module, Tuple[nn.Module, MemOptSummary]]:
     r"""
     **API Language:**
     :ref:`中文 <memory_optimization-cn>` | :ref:`English <memory_optimization-en>`
@@ -627,8 +1196,8 @@ def memory_optimization(
     :param compress_x: 是否应用输入脉冲压缩
     :type compress_x: bool
 
-    :param level: 优化级别
-    :type level: int
+    :param level: 优化级别。若为 ``None`` 且指定 ``profile`` ，则使用预设推荐值
+    :type level: Optional[int]
 
     :param verbose: 是否打印优化过程日志
     :type verbose: bool
@@ -636,8 +1205,47 @@ def memory_optimization(
     :param temporal_split_factor: 沿时间拆分检查点片段时所使用的倍增因子
     :type temporal_split_factor: int
 
-    :return: 优化后的模型
-    :rtype: nn.Module
+    :param max_split_rounds: 每个 split 阶段允许的最大 profiling 轮数。 ``None`` 表示不限制
+    :type max_split_rounds: Optional[int]
+
+    :param max_candidates_per_round: 每轮 profiling 至多尝试的候选 ``GCContainer`` 数量。 ``None`` 表示不限制
+    :type max_candidates_per_round: Optional[int]
+
+    :param warmup_in_main_process: 是否在主进程中对优化后的模型执行一次 dummy train step，
+        以避免首次使用时的额外开销。默认开启
+    :type warmup_in_main_process: bool
+
+    :param warmup_in_profile_workers: 是否在 profiling 子进程中执行预热 dummy train step。
+        默认开启；关闭后可以减少优化耗时，但可能增加测量噪声
+    :type warmup_in_profile_workers: bool
+
+    :param prefer: 更高层的优化倾向，可选 ``"speed"`` 、 ``"balanced"`` 、 ``"memory"`` 。
+        当 ``profile`` / ``checkpoint_budget`` 未显式指定时，将自动映射到对应默认值
+    :type prefer: Optional[str]
+
+    :param profile: 高层预设策略，可选 ``"safe"`` 、 ``"balanced"`` 、 ``"memory"`` 、 ``"exhaustive"``
+    :type profile: Optional[str]
+
+    :param allow_expensive_profiling: 是否允许高开销 profiling。关闭后会自动收紧 split 搜索预算
+    :type allow_expensive_profiling: Optional[bool]
+
+    :param checkpoint_budget: 高层选择性 checkpoint 预算策略，可选
+        ``"speed"`` 、 ``"balanced"`` 、 ``"memory"``
+    :type checkpoint_budget: Optional[str]
+
+    :param max_gc_wrapped_modules: 选择性 checkpoint 的上限。若给定，则只包装最多这么多个匹配模块。
+        当 ``dummy_input`` 可用时，优先选择输入激活更大的模块
+    :type max_gc_wrapped_modules: Optional[int]
+
+    :param gc_target_budget_ratio: 选择性 checkpoint 的比例预算，取值应在 ``(0, 1]`` 之间。
+        当与 ``max_gc_wrapped_modules`` 同时给定时，较小的预算生效
+    :type gc_target_budget_ratio: Optional[float]
+
+    :param return_summary: 是否同时返回结构化优化摘要
+    :type return_summary: bool
+
+    :return: 优化后的模型；当 ``return_summary=True`` 时，返回 ``(model, summary)``
+    :rtype: Union[nn.Module, Tuple[nn.Module, MemOptSummary]]
 
     ----
 
@@ -667,8 +1275,9 @@ def memory_optimization(
     :param compress_x: whether to apply input spike compression
     :type compress_x: bool
 
-    :param level: optimization level
-    :type level: int
+    :param level: optimization level. If ``None`` and ``profile`` is specified,
+        the recommended preset level will be used
+    :type level: Optional[int]
 
     :param verbose: whether to print logs
     :type verbose: bool
@@ -676,133 +1285,390 @@ def memory_optimization(
     :param temporal_split_factor: factor to increase the number of chunks when splitting GC segments temporally
     :type temporal_split_factor: int
 
-    :return: the optimized model
-    :rtype: nn.Module
+    :param max_split_rounds: maximum number of profiling rounds allowed for each split stage.
+        ``None`` means no limit
+    :type max_split_rounds: Optional[int]
+
+    :param max_candidates_per_round: maximum number of GCContainer candidates to try in each profiling round.
+        ``None`` means no limit
+    :type max_candidates_per_round: Optional[int]
+
+    :param warmup_in_main_process: whether to run one dummy train step for the optimized
+        model in the main process to hide first-use overhead. Default to ``True``
+    :type warmup_in_main_process: bool
+
+    :param warmup_in_profile_workers: whether to run a warmup dummy train step in
+        profiling subprocesses. Default to ``True``; disabling it can reduce
+        optimization latency at the cost of noisier measurements
+    :type warmup_in_profile_workers: bool
+
+    :param prefer: higher-level optimization preference. One of ``"speed"``,
+        ``"balanced"``, or ``"memory"``. When ``profile`` / ``checkpoint_budget``
+        are not explicitly provided, this preference maps to their default values
+    :type prefer: Optional[str]
+
+    :param profile: high-level preset strategy. One of ``"safe"``, ``"balanced"``,
+        ``"memory"``, or ``"exhaustive"``
+    :type profile: Optional[str]
+
+    :param allow_expensive_profiling: whether to allow expensive profiling.
+        Disabling this automatically tightens split search budgets
+    :type allow_expensive_profiling: Optional[bool]
+
+    :param checkpoint_budget: high-level selective checkpoint budget preset.
+        One of ``"speed"``, ``"balanced"``, or ``"memory"``
+    :type checkpoint_budget: Optional[str]
+
+    :param max_gc_wrapped_modules: upper bound for selective checkpointing.
+        When provided, at most this many matching modules are wrapped; modules
+        with larger observed input activations are preferred when ``dummy_input`` is available
+    :type max_gc_wrapped_modules: Optional[int]
+
+    :param gc_target_budget_ratio: ratio budget for selective checkpointing in ``(0, 1]``.
+        When used together with ``max_gc_wrapped_modules``, the smaller budget wins
+    :type gc_target_budget_ratio: Optional[float]
+
+    :param return_summary: whether to also return a structured optimization summary
+    :type return_summary: bool
+
+    :return: the optimized model, or ``(model, summary)`` when ``return_summary=True``
+    :rtype: Union[nn.Module, Tuple[nn.Module, MemOptSummary]]
     """
     st = time.time()
     ctx = mp.get_context("spawn")
     device = resolve_device()
+    preset_levels = {
+        "safe": 1,
+        "balanced": 2,
+        "memory": 3,
+        "exhaustive": 4,
+    }
+    profile, checkpoint_budget, preference_notes = _resolve_preference_options(
+        prefer,
+        profile,
+        checkpoint_budget,
+    )
+    requested_level = (
+        level if level is not None else preset_levels.get(profile, 0)
+    )
+    resolved, resolution_notes = _resolve_memory_optimization_options(
+        level=level,
+        profile=profile,
+        dummy_input=dummy_input,
+        compress_x=compress_x,
+        max_split_rounds=max_split_rounds,
+        max_candidates_per_round=max_candidates_per_round,
+        warmup_in_main_process=warmup_in_main_process,
+        warmup_in_profile_workers=warmup_in_profile_workers,
+        allow_expensive_profiling=allow_expensive_profiling,
+    )
+    level = resolved["level"]
+    compress_x = resolved["compress_x"]
+    max_split_rounds = resolved["max_split_rounds"]
+    max_candidates_per_round = resolved["max_candidates_per_round"]
+    warmup_in_main_process = resolved["warmup_in_main_process"]
+    warmup_in_profile_workers = resolved["warmup_in_profile_workers"]
+    allow_expensive_profiling = resolved["allow_expensive_profiling"]
+
+    summary = MemOptSummary(
+        profile=profile,
+        checkpoint_budget=checkpoint_budget,
+        prefer=prefer,
+        device=device,
+        requested_level=requested_level,
+        applied_level=0 if level is None else level,
+        compress_x=compress_x,
+        allow_expensive_profiling=allow_expensive_profiling,
+        notes=list(preference_notes) + list(resolution_notes),
+        options=dict(
+            prefer=prefer,
+            temporal_split_factor=temporal_split_factor,
+            max_split_rounds=max_split_rounds,
+            max_candidates_per_round=max_candidates_per_round,
+            warmup_in_main_process=warmup_in_main_process,
+            warmup_in_profile_workers=warmup_in_profile_workers,
+            checkpoint_budget=checkpoint_budget,
+            max_gc_wrapped_modules=max_gc_wrapped_modules,
+            gc_target_budget_ratio=gc_target_budget_ratio,
+        ),
+    )
+    summary.applied_level = level
     _cprint(verbose, f"Optimizing memory on device {device}")
     peak_allocated = -1.0
 
     if level > 0:
         _cprint(verbose, "Level 1: layer-wise GC with input spike compression")
-        net = apply_gc(net, instance, dummy_input, compress_x, device)
+        net, apply_summary = apply_gc(
+            net,
+            instance,
+            dummy_input,
+            compress_x,
+            device,
+            checkpoint_budget=checkpoint_budget,
+            max_gc_wrapped_modules=max_gc_wrapped_modules,
+            gc_target_budget_ratio=gc_target_budget_ratio,
+            return_summary=True,
+        )
+        summary.applied_steps.append("level1_gc")
+        for k, v in apply_summary.items():
+            if v is None:
+                continue
+            if isinstance(v, str):
+                setattr(summary, k, v)
+            elif isinstance(v, list):
+                if k == "gc_selected_modules":
+                    summary.gc_selected_modules = list(v)
+                else:
+                    summary.notes.extend(v)
+            else:
+                setattr(summary, k, getattr(summary, k) + v)
 
     if level > 1:  # spatial split
-        if dummy_input is None:
-            raise ValueError("dummy_input must be provided for memory profiling.")
+        if _gc_container_count(net) == 0:
+            _cprint(verbose, "Level 2: no GCContainers found, skip spatial split")
+            summary.skipped_steps.append("level2:no_gccontainers")
+        elif not _has_split_candidate(net, _can_spatially_split):
+            _cprint(verbose, "Level 2: no spatially splittable GCContainers, skip")
+            summary.skipped_steps.append("level2:no_spatial_candidates")
+        else:
+            _cprint(verbose, "Level 2: split GCContainers spatially")
+            summary.applied_steps.append("level2_spatial_split")
+            peak_allocated, _ = _train_peak_memory(
+                net,
+                dummy_input,
+                ctx,
+                device,
+                worker_warmup=warmup_in_profile_workers,
+            )
+            split_rounds = 0
+            blocked_candidates = set()
 
-        _cprint(verbose, "Level 2: split GCContainers spatially")
-        peak_allocated, _ = _train_peak_memory(net, dummy_input, ctx, device)
-
-        while True:
-            results = _train_memory_profile(net, dummy_input, ctx, device)
-            if not results:
-                _cprint(verbose, "\tNo more GCContainers to split.")
-                break
-            cb_name = results[0][0]  # GCContainer with the highest mem.
-            cb, parent, child_name = get_module_and_parent(net, cb_name.split(" ")[-1])
-
-            # try to spatially split the GCContainer
-            # if not split-able, break
-            split_cb = _spatially_split_gc_container(cb)
-            if split_cb is None:
-                _cprint(verbose, f"\t{cb_name}: can't be spatially split")
-                break
-            setattr(parent, child_name, split_cb)
-
-            # if the peak memory does not reduces, revert and break;
-            # otherwise, keep the change and continue
-            new_peak_allocated, _ = _train_peak_memory(net, dummy_input, ctx, device)
-            if new_peak_allocated >= peak_allocated:
-                _cprint(
-                    verbose,
-                    f"\t{cb_name}: no reduction in memory, revert "
-                    f"({peak_allocated} -> {new_peak_allocated})",
+            while True:
+                if max_split_rounds is not None and split_rounds >= max_split_rounds:
+                    _cprint(verbose, "\tReached max_split_rounds for spatial split.")
+                    break
+                if not _has_split_candidate(net, _can_spatially_split):
+                    _cprint(verbose, "\tNo spatially splittable GCContainers remain.")
+                    break
+                split_rounds += 1
+                results = _train_memory_profile(
+                    net,
+                    dummy_input,
+                    ctx,
+                    device,
+                    worker_warmup=warmup_in_profile_workers,
                 )
-                setattr(parent, child_name, cb)
-                break
-            else:
-                _cprint(
-                    verbose,
-                    f"\t{cb_name}: successfully split "
-                    f"({peak_allocated} -> {new_peak_allocated})",
-                )
-                peak_allocated = new_peak_allocated  # update the peak memory
+                if not results:
+                    _cprint(verbose, "\tNo more GCContainers to split.")
+                    break
+                filtered_results = [
+                    row for row in results if row[0].split(" ")[-1] not in blocked_candidates
+                ]
+                if not filtered_results:
+                    _cprint(verbose, "\tNo eligible spatial split candidates remain.")
+                    break
+                improved = False
+                for row in _candidate_entries(filtered_results, max_candidates_per_round):
+                    cb_name = row[0]
+                    cb_path = cb_name.split(" ")[-1]
+                    cb, parent, child_name = get_module_and_parent(net, cb_path)
+
+                    split_cb = _spatially_split_gc_container(cb)
+                    if split_cb is None:
+                        _cprint(verbose, f"\t{cb_name}: can't be spatially split")
+                        blocked_candidates.add(cb_path)
+                        continue
+                    setattr(parent, child_name, split_cb)
+
+                    new_peak_allocated, _ = _train_peak_memory(
+                        net,
+                        dummy_input,
+                        ctx,
+                        device,
+                        worker_warmup=warmup_in_profile_workers,
+                    )
+                    if new_peak_allocated >= peak_allocated:
+                        _cprint(
+                            verbose,
+                            f"\t{cb_name}: no reduction in memory, revert "
+                            f"({peak_allocated} -> {new_peak_allocated})",
+                        )
+                        setattr(parent, child_name, cb)
+                        blocked_candidates.add(cb_path)
+                        continue
+
+                    _cprint(
+                        verbose,
+                        f"\t{cb_name}: successfully split "
+                        f"({peak_allocated} -> {new_peak_allocated})",
+                    )
+                    peak_allocated = new_peak_allocated
+                    summary.spatial_split_count += 1
+                    improved = True
+                    blocked_candidates.clear()
+                    break
+
+                if not improved:
+                    _cprint(verbose, "\tNo spatial split candidate improved memory.")
+                    summary.skipped_steps.append("level2:no_improving_candidate")
+                    break
 
     if level > 2:  # temporal split
-        _cprint(verbose, "Level 3: split GCContainers temporally")
-
-        while True:
-            results = _train_memory_profile(net, dummy_input, ctx, device)
-            if not results:
-                _cprint(verbose, "\tNo more GCContainers to split.")
-                break
-            cb_name = results[0][0]  # GCContainer with the highest mem.
-            cb, parent, child_name = get_module_and_parent(net, cb_name.split(" ")[-1])
-
-            # try to temporally split the GCContainer
-            # if not split-able, break
-            split_cb = _temporally_split_gc_container(cb, temporal_split_factor)
-            if split_cb is None:
-                _cprint(verbose, f"\t{cb_name}: can't be temporally split")
-                break
-            setattr(parent, child_name, split_cb)
-
-            # if the peak memory does not reduces, revert and break;
-            # otherwise, keep the change and continue
-            new_peak_allocated, _ = _train_peak_memory(net, dummy_input, ctx, device)
-            if new_peak_allocated >= peak_allocated:
-                _cprint(
-                    verbose,
-                    f"\t{cb_name}: no reduction in memory, revert "
-                    f"({peak_allocated} -> {new_peak_allocated})",
+        if _gc_container_count(net) == 0:
+            _cprint(verbose, "Level 3: no GCContainers found, skip temporal split")
+            summary.skipped_steps.append("level3:no_gccontainers")
+        elif not _has_split_candidate(net, _can_temporally_split):
+            _cprint(verbose, "Level 3: no temporally splittable GCContainers, skip")
+            summary.skipped_steps.append("level3:no_temporal_candidates")
+        else:
+            _cprint(verbose, "Level 3: split GCContainers temporally")
+            summary.applied_steps.append("level3_temporal_split")
+            if peak_allocated < 0:
+                peak_allocated, _ = _train_peak_memory(
+                    net,
+                    dummy_input,
+                    ctx,
+                    device,
+                    worker_warmup=warmup_in_profile_workers,
                 )
-                setattr(parent, child_name, cb)
-                break
-            else:
-                _cprint(
-                    verbose,
-                    f"\t{cb_name}: successfully split "
-                    f"({peak_allocated} -> {new_peak_allocated})",
+            split_rounds = 0
+            blocked_candidates = set()
+
+            while True:
+                if max_split_rounds is not None and split_rounds >= max_split_rounds:
+                    _cprint(verbose, "\tReached max_split_rounds for temporal split.")
+                    break
+                if not _has_split_candidate(net, _can_temporally_split):
+                    _cprint(verbose, "\tNo temporally splittable GCContainers remain.")
+                    break
+                split_rounds += 1
+                results = _train_memory_profile(
+                    net,
+                    dummy_input,
+                    ctx,
+                    device,
+                    worker_warmup=warmup_in_profile_workers,
                 )
-                peak_allocated = new_peak_allocated  # update the peak memory
+                if not results:
+                    _cprint(verbose, "\tNo more GCContainers to split.")
+                    break
+                filtered_results = [
+                    row for row in results if row[0].split(" ")[-1] not in blocked_candidates
+                ]
+                if not filtered_results:
+                    _cprint(verbose, "\tNo eligible temporal split candidates remain.")
+                    break
+                improved = False
+                for row in _candidate_entries(filtered_results, max_candidates_per_round):
+                    cb_name = row[0]
+                    cb_path = cb_name.split(" ")[-1]
+                    cb, parent, child_name = get_module_and_parent(net, cb_path)
+
+                    split_cb = _temporally_split_gc_container(cb, temporal_split_factor)
+                    if split_cb is None:
+                        _cprint(verbose, f"\t{cb_name}: can't be temporally split")
+                        blocked_candidates.add(cb_path)
+                        continue
+                    setattr(parent, child_name, split_cb)
+
+                    new_peak_allocated, _ = _train_peak_memory(
+                        net,
+                        dummy_input,
+                        ctx,
+                        device,
+                        worker_warmup=warmup_in_profile_workers,
+                    )
+                    if new_peak_allocated >= peak_allocated:
+                        _cprint(
+                            verbose,
+                            f"\t{cb_name}: no reduction in memory, revert "
+                            f"({peak_allocated} -> {new_peak_allocated})",
+                        )
+                        setattr(parent, child_name, cb)
+                        blocked_candidates.add(cb_path)
+                        continue
+
+                    _cprint(
+                        verbose,
+                        f"\t{cb_name}: successfully split "
+                        f"({peak_allocated} -> {new_peak_allocated})",
+                    )
+                    peak_allocated = new_peak_allocated
+                    summary.temporal_split_count += 1
+                    improved = True
+                    blocked_candidates.clear()
+                    break
+
+                if not improved:
+                    _cprint(verbose, "\tNo temporal split candidate improved memory.")
+                    summary.skipped_steps.append("level3:no_improving_candidate")
+                    break
 
     if level > 3:
-        _cprint(verbose, "Level 4: greedily disable GCContainers")
-        results = _inference_time_profile(net, dummy_input, ctx, device)
-
-        for r in results:
-            cb_name = r[0]
-            cb, parent, child_name = get_module_and_parent(net, cb_name.split(" ")[-1])
-
-            # try to unwrap the GCContainer
-            ucb = _unwrap_gc_container(cb)
-            setattr(parent, child_name, ucb)
-
-            # if the peak memory increases, revert; otherwise, keep the change
-            new_peak_allocated, _ = _train_peak_memory(net, dummy_input, ctx, device)
-            if new_peak_allocated > peak_allocated:
-                _cprint(
-                    verbose,
-                    f"\t{cb_name}: keep GCContainer "
-                    f"({peak_allocated} -> {new_peak_allocated})",
+        if _gc_container_count(net) == 0:
+            _cprint(verbose, "Level 4: no GCContainers found, skip greedy unwrap")
+            summary.skipped_steps.append("level4:no_gccontainers")
+        else:
+            if peak_allocated < 0:
+                peak_allocated, _ = _train_peak_memory(
+                    net,
+                    dummy_input,
+                    ctx,
+                    device,
+                    worker_warmup=warmup_in_profile_workers,
                 )
-                setattr(parent, child_name, cb)
-            else:
-                _cprint(
-                    verbose,
-                    f"\t{cb_name}: disable GCContainer "
-                    f"({peak_allocated} -> {new_peak_allocated})",
-                )
-                peak_allocated = new_peak_allocated  # update the peak memory
+            _cprint(verbose, "Level 4: greedily disable GCContainers")
+            summary.applied_steps.append("level4_greedy_unwrap")
+            results = _inference_time_profile(net, dummy_input, ctx, device)
 
-    # Warm up in the main process to avoid 1st-time overhead
-    net = net.to(device)
-    dummy_input = _dummy_input_to_device(dummy_input, device)
-    _dummy_train_step(net, dummy_input, restore_bn=True)
+            for r in results:
+                cb_name = r[0]
+                cb, parent, child_name = get_module_and_parent(net, cb_name.split(" ")[-1])
+
+                # try to unwrap the GCContainer
+                ucb = _unwrap_gc_container(cb)
+                setattr(parent, child_name, ucb)
+
+                # if the peak memory increases, revert; otherwise, keep the change
+                new_peak_allocated, _ = _train_peak_memory(
+                    net,
+                    dummy_input,
+                    ctx,
+                    device,
+                    worker_warmup=warmup_in_profile_workers,
+                )
+                if new_peak_allocated > peak_allocated:
+                    _cprint(
+                        verbose,
+                        f"\t{cb_name}: keep GCContainer "
+                        f"({peak_allocated} -> {new_peak_allocated})",
+                    )
+                    setattr(parent, child_name, cb)
+                else:
+                    _cprint(
+                        verbose,
+                        f"\t{cb_name}: disable GCContainer "
+                        f"({peak_allocated} -> {new_peak_allocated})",
+                    )
+                    peak_allocated = new_peak_allocated  # update the peak memory
+                    summary.unwrap_count += 1
+
+    if warmup_in_main_process and dummy_input is not None:
+        # Warm up in the main process to avoid 1st-time overhead.
+        net = net.to(device)
+        dummy_input = _dummy_input_to_device(dummy_input, device)
+        _dummy_train_step(net, dummy_input, restore_bn=True)
 
     et = time.time()
     _cprint(verbose, f"Total time: {et - st:.2f}s")
-    return net.cpu()  # must return a model on CPU
+    net = net.cpu()  # must return a model on CPU
+    summary.gc_container_count = sum(
+        1 for m in net.modules() if isinstance(m, GCContainer)
+    )
+    summary.tcgc_container_count = sum(
+        1 for m in net.modules() if isinstance(m, TCGCContainer)
+    )
+    summary.recommendation = _build_memopt_recommendation(summary)
+    if return_summary:
+        return net, summary
+    return net

--- a/spikingjelly/activation_based/memopt/pipeline.py
+++ b/spikingjelly/activation_based/memopt/pipeline.py
@@ -337,9 +337,10 @@ def _resolve_gc_selection_targets(
         moved_input,
         target_modules=tuple(candidates),
     )
+    index_map = {m: i for i, m in enumerate(candidates)}
     ranked = sorted(
         candidates,
-        key=lambda m: (estimated_bytes.get(m, 0), -candidates.index(m)),
+        key=lambda m: (estimated_bytes.get(m, 0), -index_map[m]),
         reverse=True,
     )
     return tuple(ranked[:selected_count]), candidate_count, selected_count, "largest_input_activations"

--- a/spikingjelly/activation_based/triton_kernel/compress.py
+++ b/spikingjelly/activation_based/triton_kernel/compress.py
@@ -16,6 +16,34 @@ from .triton_utils import contiguous_and_device_guard
 __all__ = ["bit_spike_compress", "bit_spike_decompress"]
 
 
+def _bit_spike_compress_pytorch(s_seq: torch.Tensor) -> torch.Tensor:
+    s_seq = s_seq.to(dtype=torch.bool).reshape(-1)
+    n_compressed_elements = (s_seq.numel() + 7) // 8
+    s_seq_compressed = torch.zeros(
+        n_compressed_elements, dtype=torch.uint8, device=s_seq.device
+    )
+    for i in range(8):
+        sliced = s_seq[i::8].to(dtype=torch.uint8)
+        sliced_len = sliced.numel()
+        if sliced_len > 0:
+            s_seq_compressed[:sliced_len] |= sliced << i
+    return s_seq_compressed
+
+
+def _bit_spike_decompress_pytorch(
+    s_seq_compressed: torch.Tensor, shape
+) -> torch.Tensor:
+    n_decompressed_elements = torch.Size(shape).numel()
+    s_seq_decompressed = torch.zeros(
+        n_decompressed_elements, dtype=torch.uint8, device=s_seq_compressed.device
+    )
+    for i in range(8):
+        sliced_len = (n_decompressed_elements - i + 7) // 8
+        sliced = ((s_seq_compressed >> i) & 1)[:sliced_len]
+        s_seq_decompressed[i::8] = sliced
+    return s_seq_decompressed.reshape(shape)
+
+
 @triton.autotune(
     configs=[triton.Config({"BLOCK_SIZE": b}) for b in [64, 128, 256]],
     key=[],
@@ -87,6 +115,8 @@ def _bit_spike_decompress_triton(
 def bit_spike_compress(s_seq):
     # s_seq: float32, ndim=1
     s_seq = s_seq.reshape(-1)
+    if s_seq.device.type != "cuda":
+        return _bit_spike_compress_pytorch(s_seq)
     n_elements = s_seq.numel()
     n_compressed_elements = (n_elements + 7) // 8
     s_seq_compressed = torch.zeros(
@@ -107,6 +137,8 @@ def bit_spike_compress(s_seq):
 @contiguous_and_device_guard
 def bit_spike_decompress(s_seq_compressed, shape):
     # s_seq: uint8, ndim=1
+    if s_seq_compressed.device.type != "cuda":
+        return _bit_spike_decompress_pytorch(s_seq_compressed, shape)
     n_compressed_elements = s_seq_compressed.numel()
     n_decompressed_elements = torch.Size(shape).numel()
     s_seq_decompressed = torch.zeros(

--- a/spikingjelly/activation_based/triton_kernel/triton_utils.py
+++ b/spikingjelly/activation_based/triton_kernel/triton_utils.py
@@ -3,12 +3,9 @@ https://github.com/AllenYolk/flash-snn/tree/main/flashsnn/utils
 https://github.com/fla-org/flash-linear-attention/blob/main/fla/utils.py
 """
 
-import atexit
 import contextlib
 import functools
 import os
-import threading
-from pathlib import Path
 from typing import Callable
 
 import torch
@@ -112,7 +109,7 @@ def contiguous_and_device_guard(f: Callable) -> Callable:
                 if isinstance(value, torch.Tensor):
                     first_tensor = value
                     break
-        if first_tensor is not None:
+        if first_tensor is not None and first_tensor.device.type == "cuda":
             ctx = torch.cuda.device(first_tensor.device.index)
         else:
             ctx = contextlib.nullcontext()
@@ -134,28 +131,3 @@ if _check_pytorch_version("2.4"):
 else:
     amp_custom_fwd = torch.cuda.amp.custom_fwd
     amp_custom_bwd = torch.cuda.amp.custom_bwd
-
-_CLEANUP_TMP_PYTHON_FILES_REGISTERED = False
-_CLEANUP_TMP_PYTHON_FILES_REGISTERED_LOCK = threading.Lock()
-
-
-def cleanup_tmp_python_files():
-    print("Cleaning up temporary python files!")
-    for f in Path("/tmp").glob("*.py"):
-        try:
-            f.unlink(missing_ok=True)
-        except BaseException:
-            pass  # ignore the errors
-
-
-def ensure_cleanup_tmp_python_files(fn):
-    @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
-        global _CLEANUP_TMP_PYTHON_FILES_REGISTERED
-        with _CLEANUP_TMP_PYTHON_FILES_REGISTERED_LOCK:
-            if not _CLEANUP_TMP_PYTHON_FILES_REGISTERED:
-                atexit.register(cleanup_tmp_python_files)
-                _CLEANUP_TMP_PYTHON_FILES_REGISTERED = True
-        return fn(*args, **kwargs)
-
-    return wrapper

--- a/spikingjelly/activation_based/triton_kernel/triton_utils.py
+++ b/spikingjelly/activation_based/triton_kernel/triton_utils.py
@@ -127,6 +127,16 @@ def ensure_cleanup_tmp_python_files(f: Callable) -> Callable:
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
         tmp_paths = []
+        original_named_temporary_file = tempfile.NamedTemporaryFile
+
+        def tracking_named_temporary_file(*ntf_args, **ntf_kwargs):
+            tmp = original_named_temporary_file(*ntf_args, **ntf_kwargs)
+            tmp_name = getattr(tmp, "name", None)
+            if isinstance(tmp_name, str) and tmp_name.endswith(".py"):
+                tmp_paths.append(tmp_name)
+            return tmp
+
+        tempfile.NamedTemporaryFile = tracking_named_temporary_file
         try:
             result = f(*args, **kwargs)
             if isinstance(result, str) and result.endswith(".py"):
@@ -135,6 +145,7 @@ def ensure_cleanup_tmp_python_files(f: Callable) -> Callable:
                 tmp_paths.append(result.name)
             return result
         finally:
+            tempfile.NamedTemporaryFile = original_named_temporary_file
             for path in tmp_paths:
                 try:
                     if path and os.path.exists(path):

--- a/spikingjelly/activation_based/triton_kernel/triton_utils.py
+++ b/spikingjelly/activation_based/triton_kernel/triton_utils.py
@@ -140,7 +140,9 @@ def ensure_cleanup_tmp_python_files(f: Callable) -> Callable:
                 tmp = original_named_temporary_file(*ntf_args, **ntf_kwargs)
                 tmp_name = getattr(tmp, "name", None)
                 if isinstance(tmp_name, str) and tmp_name.endswith(".py"):
-                    _TMP_PY_TRACKER.paths.append(tmp_name)
+                    thread_paths = getattr(_TMP_PY_TRACKER, "paths", None)
+                    if thread_paths is not None:
+                        thread_paths.append(tmp_name)
                 return tmp
 
             tempfile.NamedTemporaryFile = tracking_named_temporary_file

--- a/spikingjelly/activation_based/triton_kernel/triton_utils.py
+++ b/spikingjelly/activation_based/triton_kernel/triton_utils.py
@@ -7,6 +7,7 @@ import contextlib
 import functools
 import os
 import tempfile
+import threading
 from typing import Callable
 
 import torch
@@ -121,37 +122,44 @@ def contiguous_and_device_guard(f: Callable) -> Callable:
     return wrapper
 
 
+_TMP_PY_LOCK = threading.Lock()
+_TMP_PY_TRACKER = threading.local()
+
+
 def ensure_cleanup_tmp_python_files(f: Callable) -> Callable:
     """Remove temporary python files returned or created by a wrapped function."""
 
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
-        tmp_paths = []
-        original_named_temporary_file = tempfile.NamedTemporaryFile
+        with _TMP_PY_LOCK:
+            tmp_paths = []
+            _TMP_PY_TRACKER.paths = tmp_paths
+            original_named_temporary_file = tempfile.NamedTemporaryFile
 
-        def tracking_named_temporary_file(*ntf_args, **ntf_kwargs):
-            tmp = original_named_temporary_file(*ntf_args, **ntf_kwargs)
-            tmp_name = getattr(tmp, "name", None)
-            if isinstance(tmp_name, str) and tmp_name.endswith(".py"):
-                tmp_paths.append(tmp_name)
-            return tmp
+            def tracking_named_temporary_file(*ntf_args, **ntf_kwargs):
+                tmp = original_named_temporary_file(*ntf_args, **ntf_kwargs)
+                tmp_name = getattr(tmp, "name", None)
+                if isinstance(tmp_name, str) and tmp_name.endswith(".py"):
+                    _TMP_PY_TRACKER.paths.append(tmp_name)
+                return tmp
 
-        tempfile.NamedTemporaryFile = tracking_named_temporary_file
-        try:
-            result = f(*args, **kwargs)
-            if isinstance(result, str) and result.endswith(".py"):
-                tmp_paths.append(result)
-            elif isinstance(result, tempfile._TemporaryFileWrapper):
-                tmp_paths.append(result.name)
-            return result
-        finally:
-            tempfile.NamedTemporaryFile = original_named_temporary_file
-            for path in tmp_paths:
-                try:
-                    if path and os.path.exists(path):
-                        os.remove(path)
-                except OSError:
-                    pass
+            tempfile.NamedTemporaryFile = tracking_named_temporary_file
+            try:
+                result = f(*args, **kwargs)
+                if isinstance(result, str) and result.endswith(".py"):
+                    tmp_paths.append(result)
+                elif isinstance(result, tempfile._TemporaryFileWrapper):
+                    tmp_paths.append(result.name)
+                return result
+            finally:
+                tempfile.NamedTemporaryFile = original_named_temporary_file
+                for path in tmp_paths:
+                    try:
+                        if path and os.path.exists(path):
+                            os.remove(path)
+                    except OSError:
+                        pass
+                _TMP_PY_TRACKER.paths = []
 
     return wrapper
 

--- a/spikingjelly/activation_based/triton_kernel/triton_utils.py
+++ b/spikingjelly/activation_based/triton_kernel/triton_utils.py
@@ -6,6 +6,7 @@ https://github.com/fla-org/flash-linear-attention/blob/main/fla/utils.py
 import contextlib
 import functools
 import os
+import tempfile
 from typing import Callable
 
 import torch
@@ -116,6 +117,30 @@ def contiguous_and_device_guard(f: Callable) -> Callable:
 
         with ctx:
             return f(*contiguous_args, **contiguous_kwargs)
+
+    return wrapper
+
+
+def ensure_cleanup_tmp_python_files(f: Callable) -> Callable:
+    """Remove temporary python files returned or created by a wrapped function."""
+
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        tmp_paths = []
+        try:
+            result = f(*args, **kwargs)
+            if isinstance(result, str) and result.endswith(".py"):
+                tmp_paths.append(result)
+            elif isinstance(result, tempfile._TemporaryFileWrapper):
+                tmp_paths.append(result.name)
+            return result
+        finally:
+            for path in tmp_paths:
+                try:
+                    if path and os.path.exists(path):
+                        os.remove(path)
+                except OSError:
+                    pass
 
     return wrapper
 

--- a/test/activation_based/test_checkpointing.py
+++ b/test/activation_based/test_checkpointing.py
@@ -1,4 +1,6 @@
 import copy
+import os
+import tempfile
 
 import pytest
 import torch
@@ -648,6 +650,30 @@ def test_candidate_entries_treats_zero_budget_as_disabled():
     assert memopt_pipeline._candidate_entries(results, -1) == []
 
 
+def test_ensure_cleanup_tmp_python_files_tracks_created_temp_files():
+    from spikingjelly.activation_based.triton_kernel.triton_utils import (
+        ensure_cleanup_tmp_python_files,
+    )
+    created = {"path": None}
+
+    @ensure_cleanup_tmp_python_files
+    def build_temp_python_file():
+        tmp = tempfile.NamedTemporaryFile(
+            suffix=".py",
+            delete=False,
+        )
+        tmp.write(b"print('hello')\n")
+        tmp.close()
+        created["path"] = tmp.name
+        assert os.path.exists(created["path"])
+        return "done"
+
+    result = build_temp_python_file()
+    assert result == "done"
+    assert created["path"] is not None
+    assert not os.path.exists(created["path"])
+
+
 def test_apply_gc_clones_manual_compressor_instances(monkeypatch):
     monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
 
@@ -817,17 +843,17 @@ def test_memory_optimization_level2_skips_profiling_when_no_gccontainers(monkeyp
     peak_calls = {"count": 0}
     profile_calls = {"count": 0}
 
+    def fake_train_peak_memory(*args, **kwargs):
+        peak_calls["count"] += 1
+        return 100, 100
+
+    def fake_train_memory_profile(*args, **kwargs):
+        profile_calls["count"] += 1
+        return _profile_result_with_optional_peak([], kwargs.get("return_peak", False))
+
+    monkeypatch.setattr(memopt_pipeline, "_train_peak_memory", fake_train_peak_memory)
     monkeypatch.setattr(
-        memopt_pipeline,
-        "_train_peak_memory",
-        lambda *args, **kwargs: peak_calls.__setitem__("count", peak_calls["count"] + 1),
-    )
-    monkeypatch.setattr(
-        memopt_pipeline,
-        "_train_memory_profile",
-        lambda *args, **kwargs: profile_calls.__setitem__(
-            "count", profile_calls["count"] + 1
-        ),
+        memopt_pipeline, "_train_memory_profile", fake_train_memory_profile
     )
 
     net = nn.Sequential(nn.ReLU())

--- a/test/activation_based/test_checkpointing.py
+++ b/test/activation_based/test_checkpointing.py
@@ -700,7 +700,14 @@ def test_ensure_cleanup_tmp_python_files_cleans_up_on_exception():
 
 
 def test_spatial_split_respects_compress_x_flag():
-    block = GCContainer(SpatialSplitBlock(), x_compressor=BitSpikeCompressor())
+    wrapped = memopt_pipeline.apply_gc(
+        nn.Sequential(SpatialSplitBlock()),
+        SpatialSplitBlock,
+        dummy_input=(torch.randint(0, 2, (2, 4), dtype=torch.float32),),
+        compress_x=True,
+        device="cpu",
+    )
+    block = wrapped[0]
 
     split = memopt_pipeline._spatially_split_gc_container(block, compress_x=False)
 

--- a/test/activation_based/test_checkpointing.py
+++ b/test/activation_based/test_checkpointing.py
@@ -1,9 +1,11 @@
 import copy
 
+import pytest
 import torch
 import torch.nn as nn
 
 import spikingjelly.activation_based.memopt as memopt
+import spikingjelly.activation_based.memopt.pipeline as memopt_pipeline
 from spikingjelly.activation_based.memopt.checkpointing import (
     in_gc_1st_forward,
     query_autocast,
@@ -17,6 +19,7 @@ from spikingjelly.activation_based.memopt.checkpointing import (
 )
 from spikingjelly.activation_based.memopt.compress import (
     BaseSpikeCompressor,
+    BooleanSpikeCompressor,
     BitSpikeCompressor,
     NullSpikeCompressor,
     SparseSpikeCompressor,
@@ -37,6 +40,84 @@ class MockCompressor(BaseSpikeCompressor):
 
     def _decompress(self, s_seq: torch.Tensor, shape) -> torch.Tensor:
         return s_seq / 2
+
+
+class BinaryProject(nn.Module):
+    def forward(self, x):
+        return (x > 0).to(x.dtype)
+
+
+class TargetBlock(nn.Module):
+    def forward(self, x):
+        return x + 1.0
+
+
+class SpatialSplitBlock(nn.Module):
+    def __init__(self, features=4):
+        super().__init__()
+        self.features = features
+
+    def forward(self, x):
+        return torch.relu(x)
+
+    def __spatial_split__(self):
+        return [nn.Identity(), nn.ReLU()]
+
+
+class TemporalSplitBlock(nn.Sequential):
+    def __init__(self, features=4):
+        super().__init__(nn.Linear(features, features), nn.ReLU())
+        self.n_seq_inputs = 1
+        self.n_outputs = 1
+
+
+class TemporalOnlyBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.n_seq_inputs = 1
+        self.n_outputs = 1
+
+    def forward(self, x):
+        return x + 1.0
+
+
+class UnsplittableBlock(nn.Module):
+    def forward(self, x):
+        return x
+
+
+class CountedNonBinaryNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(4, 4)
+        self.block = TargetBlock()
+        self.forward_calls = 0
+
+    def forward(self, x):
+        self.forward_calls += 1
+        return self.block(self.proj(x))
+
+
+class DualTargetNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.large = TargetBlock()
+        self.small = TargetBlock()
+
+    def forward(self, x):
+        y1 = self.large(x)
+        y2 = self.small(x[..., :2])
+        return y1[..., :2] + y2
+
+
+def _result_row(module_name: str):
+    return [(module_name, 0.0)]
+
+
+def _profile_result_with_optional_peak(result, return_peak):
+    if return_peak:
+        return result, 100, 100
+    return result
 
 
 def test_thread_local_functions():
@@ -60,6 +141,41 @@ def test_thread_local_functions():
 
 def test_memopt_package_imports_pipeline_api():
     assert hasattr(memopt, "memory_optimization")
+    assert hasattr(memopt, "MemOptSummary")
+    assert hasattr(memopt, "MEMOPT_PROFILES")
+    assert hasattr(memopt, "MEMOPT_CHECKPOINT_BUDGETS")
+    assert hasattr(memopt, "MEMOPT_PREFERENCES")
+
+
+def test_probe_binary_inputs_stops_early_when_all_targets_are_non_binary():
+    net = CountedNonBinaryNet()
+    result = memopt_pipeline._probe_binary_inputs(
+        net,
+        TargetBlock,
+        dummy_input=(torch.randn(2, 4),),
+        n_trials=5,
+    )
+
+    assert result[net.block] is False
+    assert net.forward_calls == 1
+
+
+def test_probe_binary_inputs_uses_dummy_input_before_random_trials(monkeypatch):
+    net = CountedNonBinaryNet()
+
+    def fail_randomize(dummy_input):
+        raise AssertionError("_randomize_input_like should not be called")
+
+    monkeypatch.setattr(memopt_pipeline, "_randomize_input_like", fail_randomize)
+    result = memopt_pipeline._probe_binary_inputs(
+        net,
+        TargetBlock,
+        dummy_input=(torch.randn(2, 4),),
+        n_trials=5,
+    )
+
+    assert result[net.block] is False
+    assert net.forward_calls == 1
 
 
 def test_autocast_query():
@@ -121,6 +237,797 @@ def test_compressors_accept_tuple_shapes_on_decompress():
     sparse = SparseSpikeCompressor()
     sparse_decompressed = sparse.decompress(sparse.compress(spikes), shape)
     torch.testing.assert_close(sparse_decompressed, spikes)
+
+
+def test_memory_optimization_requires_dummy_input_for_higher_levels():
+    net = nn.Sequential(TargetBlock())
+    with pytest.raises(ValueError, match="dummy_input must be provided"):
+        memopt.memory_optimization(net, TargetBlock, level=2)
+
+
+def test_memory_optimization_profile_balanced_falls_back_without_dummy_input(
+    monkeypatch,
+):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    net, summary = memopt.memory_optimization(
+        nn.Sequential(TargetBlock()),
+        TargetBlock,
+        dummy_input=None,
+        profile="balanced",
+        return_summary=True,
+    )
+
+    assert isinstance(net[0], GCContainer)
+    assert isinstance(summary, memopt.MemOptSummary)
+    assert summary.profile == "balanced"
+    assert summary.requested_level == 2
+    assert summary.applied_level == 1
+    assert "fallback:level>1_requires_dummy_input" in summary.notes
+
+
+def test_memory_optimization_rejects_unknown_profile():
+    with pytest.raises(ValueError, match="Unsupported memopt profile"):
+        memopt.memory_optimization(
+            nn.Sequential(TargetBlock()),
+            TargetBlock,
+            profile="mystery",
+        )
+
+
+def test_memory_optimization_rejects_unknown_prefer():
+    with pytest.raises(ValueError, match="Unsupported prefer"):
+        memopt.memory_optimization(
+            nn.Sequential(TargetBlock()),
+            TargetBlock,
+            prefer="mystery",
+        )
+
+
+def test_memory_optimization_prefer_speed_sets_defaults(monkeypatch):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    net, summary = memopt.memory_optimization(
+        nn.Sequential(TargetBlock(), TargetBlock(), TargetBlock(), TargetBlock()),
+        TargetBlock,
+        dummy_input=None,
+        prefer="speed",
+        return_summary=True,
+    )
+
+    assert isinstance(net[0], GCContainer)
+    assert isinstance(net[1], GCContainer)
+    assert isinstance(net[2], TargetBlock)
+    assert isinstance(net[3], TargetBlock)
+    assert summary.prefer == "speed"
+    assert summary.profile == "safe"
+    assert summary.checkpoint_budget == "speed"
+    assert "prefer:profile=safe" in summary.notes
+    assert "prefer:checkpoint_budget=speed" in summary.notes
+    assert summary.gc_selected_count == 2
+    assert len(summary.gc_selected_modules) == 2
+    assert "no dummy_input was available" in summary.gc_selection_explanation
+    assert "favor training speed" in summary.recommendation
+
+
+def test_memory_optimization_explicit_profile_overrides_prefer_profile(monkeypatch):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    _, summary = memopt.memory_optimization(
+        nn.Sequential(TargetBlock(), TargetBlock(), TargetBlock(), TargetBlock()),
+        TargetBlock,
+        dummy_input=None,
+        prefer="speed",
+        profile="memory",
+        return_summary=True,
+    )
+
+    assert summary.prefer == "speed"
+    assert summary.profile == "memory"
+    assert summary.checkpoint_budget == "speed"
+    assert "prefer:profile=safe" not in summary.notes
+    assert "prefer:checkpoint_budget=speed" in summary.notes
+
+
+def test_apply_gc_selects_largest_input_targets_when_budgeted(monkeypatch):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    net, summary = memopt_pipeline.apply_gc(
+        DualTargetNet(),
+        TargetBlock,
+        dummy_input=(torch.randn(2, 4),),
+        compress_x=False,
+        device="cpu",
+        max_gc_wrapped_modules=1,
+        return_summary=True,
+    )
+
+    assert isinstance(net.large, GCContainer)
+    assert isinstance(net.small, TargetBlock)
+    assert summary["gc_candidate_count"] == 2
+    assert summary["gc_selected_count"] == 1
+    assert summary["gc_selection_policy"] == "largest_input_activations"
+    assert summary["gc_selected_modules"] == ["large"]
+    assert "largest observed input activations" in summary["gc_selection_explanation"]
+
+
+def test_apply_gc_budget_without_dummy_input_falls_back_to_module_order():
+    net, summary = memopt_pipeline.apply_gc(
+        nn.Sequential(TargetBlock(), TargetBlock()),
+        TargetBlock,
+        dummy_input=None,
+        compress_x=False,
+        device="cpu",
+        max_gc_wrapped_modules=1,
+        return_summary=True,
+    )
+
+    assert isinstance(net[0], GCContainer)
+    assert isinstance(net[1], TargetBlock)
+    assert summary["gc_candidate_count"] == 2
+    assert summary["gc_selected_count"] == 1
+    assert summary["gc_selection_policy"] == "fallback_module_order"
+
+
+def test_apply_gc_checkpoint_budget_speed_selects_half_of_targets():
+    net, summary = memopt_pipeline.apply_gc(
+        nn.Sequential(TargetBlock(), TargetBlock(), TargetBlock(), TargetBlock()),
+        TargetBlock,
+        dummy_input=None,
+        compress_x=False,
+        device="cpu",
+        checkpoint_budget="speed",
+        return_summary=True,
+    )
+
+    assert isinstance(net[0], GCContainer)
+    assert isinstance(net[1], GCContainer)
+    assert isinstance(net[2], TargetBlock)
+    assert isinstance(net[3], TargetBlock)
+    assert summary["checkpoint_budget"] == "speed"
+    assert summary["gc_candidate_count"] == 4
+    assert summary["gc_selected_count"] == 2
+    assert "checkpoint_budget:speed" in summary["budget_notes"]
+
+
+def test_apply_gc_checkpoint_budget_memory_covers_all_targets():
+    net, summary = memopt_pipeline.apply_gc(
+        nn.Sequential(TargetBlock(), TargetBlock()),
+        TargetBlock,
+        dummy_input=None,
+        compress_x=False,
+        device="cpu",
+        checkpoint_budget="memory",
+        return_summary=True,
+    )
+
+    assert isinstance(net[0], GCContainer)
+    assert isinstance(net[1], GCContainer)
+    assert summary["gc_selected_count"] == 2
+    assert summary["gc_selection_policy"] == "budget_covers_all"
+
+
+def test_apply_gc_manual_budget_takes_priority_over_checkpoint_budget():
+    net, summary = memopt_pipeline.apply_gc(
+        nn.Sequential(TargetBlock(), TargetBlock(), TargetBlock(), TargetBlock()),
+        TargetBlock,
+        dummy_input=None,
+        compress_x=False,
+        device="cpu",
+        checkpoint_budget="memory",
+        max_gc_wrapped_modules=1,
+        return_summary=True,
+    )
+
+    assert isinstance(net[0], GCContainer)
+    assert isinstance(net[1], TargetBlock)
+    assert isinstance(net[2], TargetBlock)
+    assert isinstance(net[3], TargetBlock)
+    assert summary["gc_selected_count"] == 1
+
+
+def test_memory_optimization_level1_without_dummy_input_skips_main_process_warmup(
+    monkeypatch,
+):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    warmup_calls = {"count": 0}
+
+    def fake_dummy_train_step(*args, **kwargs):
+        warmup_calls["count"] += 1
+
+    monkeypatch.setattr(memopt_pipeline, "_dummy_train_step", fake_dummy_train_step)
+
+    net = nn.Sequential(TargetBlock())
+    optimized = memopt.memory_optimization(
+        net,
+        TargetBlock,
+        dummy_input=None,
+        compress_x=False,
+        level=1,
+    )
+
+    assert isinstance(optimized[0], GCContainer)
+    assert warmup_calls["count"] == 0
+
+
+def test_memory_optimization_level1_wraps_target_modules_and_uses_bit_compressor(
+    monkeypatch,
+):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    net = nn.Sequential(BinaryProject(), TargetBlock())
+    optimized = memopt.memory_optimization(
+        net,
+        TargetBlock,
+        dummy_input=(torch.randn(2, 4),),
+        compress_x=True,
+        level=1,
+    )
+
+    assert isinstance(optimized[1], GCContainer)
+    assert isinstance(optimized[1].x_compressor, BitSpikeCompressor)
+    assert next(optimized.parameters(), torch.empty(0)).device.type == "cpu"
+
+
+def test_memory_optimization_can_disable_main_process_warmup(monkeypatch):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    warmup_calls = {"count": 0}
+
+    def fake_dummy_train_step(*args, **kwargs):
+        warmup_calls["count"] += 1
+
+    monkeypatch.setattr(memopt_pipeline, "_dummy_train_step", fake_dummy_train_step)
+
+    net = nn.Sequential(TargetBlock())
+    optimized = memopt.memory_optimization(
+        net,
+        TargetBlock,
+        dummy_input=(torch.randn(2, 4),),
+        compress_x=False,
+        level=1,
+        warmup_in_main_process=False,
+    )
+
+    assert isinstance(optimized[0], GCContainer)
+    assert warmup_calls["count"] == 0
+
+
+def test_memory_optimization_forwards_profile_worker_warmup_flag(monkeypatch):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    peak_flags = []
+    profile_flags = []
+
+    def fake_train_peak_memory(*args, **kwargs):
+        peak_flags.append(kwargs.get("worker_warmup"))
+        return 100, 100
+
+    def fake_train_memory_profile(*args, **kwargs):
+        profile_flags.append(
+            (kwargs.get("worker_warmup"), kwargs.get("return_peak", False))
+        )
+        return _profile_result_with_optional_peak(
+            [], kwargs.get("return_peak", False)
+        )
+
+    monkeypatch.setattr(memopt_pipeline, "_train_peak_memory", fake_train_peak_memory)
+    monkeypatch.setattr(
+        memopt_pipeline, "_train_memory_profile", fake_train_memory_profile
+    )
+
+    net = nn.Sequential(SpatialSplitBlock())
+    optimized = memopt.memory_optimization(
+        net,
+        SpatialSplitBlock,
+        dummy_input=(torch.randn(2, 4),),
+        compress_x=False,
+        level=2,
+        warmup_in_profile_workers=False,
+        warmup_in_main_process=False,
+    )
+
+    assert isinstance(optimized[0], GCContainer)
+    assert peak_flags == [False]
+    assert profile_flags == [(False, False)]
+
+
+def test_memory_optimization_profile_memory_honors_allow_expensive_profiling_false(
+    monkeypatch,
+):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    profile_flags = []
+
+    def fake_train_memory_profile(*args, **kwargs):
+        profile_flags.append(
+            (
+                kwargs.get("worker_warmup"),
+                kwargs.get("return_peak", False),
+            )
+        )
+        return _profile_result_with_optional_peak([], kwargs.get("return_peak", False))
+
+    monkeypatch.setattr(
+        memopt_pipeline, "_train_memory_profile", fake_train_memory_profile
+    )
+    monkeypatch.setattr(
+        memopt_pipeline, "_train_peak_memory", lambda *args, **kwargs: (100, 100)
+    )
+
+    _, summary = memopt.memory_optimization(
+        nn.Sequential(SpatialSplitBlock()),
+        SpatialSplitBlock,
+        dummy_input=(torch.randn(2, 4),),
+        profile="memory",
+        allow_expensive_profiling=False,
+        warmup_in_main_process=False,
+        return_summary=True,
+    )
+
+    assert profile_flags
+    assert all(flag[0] is False for flag in profile_flags)
+    assert all(flag[1] is False for flag in profile_flags)
+    assert summary.allow_expensive_profiling is False
+    assert summary.options["max_split_rounds"] == 1
+    assert summary.options["max_candidates_per_round"] == 1
+
+
+def test_bit_spike_compressor_cpu_round_trip_with_triton_available():
+    spikes = torch.tensor([[1.0, 0.0, 1.0], [0.0, 1.0, 0.0]])
+    compressor = BitSpikeCompressor()
+
+    compressed = compressor.compress(spikes)
+    decompressed = compressor.decompress(compressed, spikes.shape)
+
+    assert compressed.device.type == "cpu"
+    torch.testing.assert_close(decompressed, spikes)
+
+
+def test_apply_gc_clones_manual_compressor_instances(monkeypatch):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    shared = BooleanSpikeCompressor()
+    block1 = TargetBlock()
+    block2 = TargetBlock()
+    block1.x_compressor = shared
+    block2.x_compressor = shared
+    net = nn.Sequential(block1, block2)
+
+    optimized = memopt_pipeline.apply_gc(
+        net,
+        TargetBlock,
+        dummy_input=(torch.randint(0, 2, (2, 4), dtype=torch.float32),),
+        compress_x=True,
+        device="cpu",
+    )
+
+    compressor1 = optimized[0].x_compressor
+    compressor2 = optimized[1].x_compressor
+    assert isinstance(compressor1, BooleanSpikeCompressor)
+    assert isinstance(compressor2, BooleanSpikeCompressor)
+    assert compressor1 is not compressor2
+
+    compressed1 = compressor1.compress(torch.randint(0, 2, (2, 4), dtype=torch.float16))
+    compressed2 = compressor2.compress(torch.randint(0, 2, (2, 4), dtype=torch.float32))
+
+    assert compressor1.s_seq_dtype == torch.float16
+    assert compressor2.s_seq_dtype == torch.float32
+    torch.testing.assert_close(
+        compressor1.decompress(compressed1, (2, 4)),
+        compressed1.to(torch.float16),
+    )
+    torch.testing.assert_close(
+        compressor2.decompress(compressed2, (2, 4)),
+        compressed2.to(torch.float32),
+    )
+
+
+def test_apply_gc_skips_binary_probe_when_all_targets_have_manual_compressors(
+    monkeypatch,
+):
+    calls = {"count": 0}
+
+    def fake_probe(*args, **kwargs):
+        calls["count"] += 1
+        return {}
+
+    monkeypatch.setattr(memopt_pipeline, "_probe_binary_inputs", fake_probe)
+
+    block1 = TargetBlock()
+    block1.x_compressor = BooleanSpikeCompressor()
+    block2 = TargetBlock()
+    block2.x_compressor = BitSpikeCompressor()
+    net = nn.Sequential(block1, block2)
+
+    optimized = memopt_pipeline.apply_gc(
+        net,
+        TargetBlock,
+        dummy_input=(torch.randint(0, 2, (2, 4), dtype=torch.float32),),
+        compress_x=True,
+        device="cpu",
+    )
+
+    assert calls["count"] == 0
+    assert isinstance(optimized[0], GCContainer)
+    assert isinstance(optimized[1], GCContainer)
+    assert isinstance(optimized[0].x_compressor, BooleanSpikeCompressor)
+    assert isinstance(optimized[1].x_compressor, BitSpikeCompressor)
+
+
+def test_memory_optimization_returns_summary_for_skipped_spatial_stage(monkeypatch):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    net, summary = memopt.memory_optimization(
+        nn.Sequential(TemporalOnlyBlock()),
+        TemporalOnlyBlock,
+        dummy_input=(torch.randn(2, 4),),
+        compress_x=False,
+        level=2,
+        warmup_in_main_process=False,
+        return_summary=True,
+    )
+
+    assert isinstance(net[0], GCContainer)
+    assert isinstance(summary, memopt.MemOptSummary)
+    assert summary.gc_wrap_count == 1
+    assert summary.gc_container_count == 1
+    assert summary.tcgc_container_count == 0
+    assert "level1_gc" in summary.applied_steps
+    assert "level2:no_spatial_candidates" in summary.skipped_steps
+
+
+def test_memory_optimization_level2_spatially_splits_heavy_gc_container(monkeypatch):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    peak_calls = {"count": 0}
+    profile_values = iter([
+        _result_row("0"),
+        [],
+    ])
+    def fake_train_peak_memory(*args, **kwargs):
+        peak_calls["count"] += 1
+        return (80, 80) if peak_calls["count"] == 1 else (60, 60)
+    monkeypatch.setattr(memopt_pipeline, "_train_peak_memory", fake_train_peak_memory)
+    monkeypatch.setattr(
+        memopt_pipeline,
+        "_train_memory_profile",
+        lambda *args, **kwargs: _profile_result_with_optional_peak(
+            next(profile_values), kwargs.get("return_peak", False)
+        ),
+    )
+
+    net = nn.Sequential(SpatialSplitBlock())
+    optimized = memopt.memory_optimization(
+        net,
+        SpatialSplitBlock,
+        dummy_input=(torch.randn(2, 4),),
+        compress_x=False,
+        level=2,
+    )
+
+    assert isinstance(optimized[0], nn.Sequential)
+    assert len(optimized[0]) == 2
+    assert all(isinstance(block, GCContainer) for block in optimized[0])
+
+
+def test_memory_optimization_level2_skips_unsplittable_hottest_candidate(monkeypatch):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    peak_calls = {"count": 0}
+    profile_values = iter(
+        [
+            [("0", 0.0), ("1", 0.0)],
+            [],
+        ]
+    )
+    def fake_train_peak_memory(*args, **kwargs):
+        peak_calls["count"] += 1
+        return (80, 80) if peak_calls["count"] == 1 else (60, 60)
+    monkeypatch.setattr(memopt_pipeline, "_train_peak_memory", fake_train_peak_memory)
+    monkeypatch.setattr(
+        memopt_pipeline,
+        "_train_memory_profile",
+        lambda *args, **kwargs: _profile_result_with_optional_peak(
+            next(profile_values), kwargs.get("return_peak", False)
+        ),
+    )
+
+    net = nn.Sequential(UnsplittableBlock(), SpatialSplitBlock())
+    optimized = memopt.memory_optimization(
+        net,
+        (UnsplittableBlock, SpatialSplitBlock),
+        dummy_input=(torch.randn(2, 4),),
+        compress_x=False,
+        level=2,
+    )
+
+    assert isinstance(optimized[0], GCContainer)
+    assert isinstance(optimized[1], nn.Sequential)
+    assert all(isinstance(block, GCContainer) for block in optimized[1])
+
+
+def test_memory_optimization_level2_skips_profiling_when_no_gccontainers(monkeypatch):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    peak_calls = {"count": 0}
+    profile_calls = {"count": 0}
+
+    monkeypatch.setattr(
+        memopt_pipeline,
+        "_train_peak_memory",
+        lambda *args, **kwargs: peak_calls.__setitem__("count", peak_calls["count"] + 1),
+    )
+    monkeypatch.setattr(
+        memopt_pipeline,
+        "_train_memory_profile",
+        lambda *args, **kwargs: profile_calls.__setitem__(
+            "count", profile_calls["count"] + 1
+        ),
+    )
+
+    net = nn.Sequential(nn.ReLU())
+    optimized = memopt.memory_optimization(
+        net,
+        TargetBlock,
+        dummy_input=(torch.randn(2, 4),),
+        compress_x=False,
+        level=2,
+    )
+
+    assert isinstance(optimized[0], nn.ReLU)
+    assert peak_calls["count"] == 0
+    assert profile_calls["count"] == 0
+
+
+def test_memory_optimization_level2_skips_when_no_spatial_split_candidates(
+    monkeypatch,
+):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    peak_calls = {"count": 0}
+    profile_calls = {"count": 0}
+
+    monkeypatch.setattr(
+        memopt_pipeline,
+        "_train_peak_memory",
+        lambda *args, **kwargs: peak_calls.__setitem__("count", peak_calls["count"] + 1),
+    )
+    monkeypatch.setattr(
+        memopt_pipeline,
+        "_train_memory_profile",
+        lambda *args, **kwargs: profile_calls.__setitem__(
+            "count", profile_calls["count"] + 1
+        ),
+    )
+
+    net = nn.Sequential(TemporalOnlyBlock())
+    optimized = memopt.memory_optimization(
+        net,
+        TemporalOnlyBlock,
+        dummy_input=(torch.randn(2, 4),),
+        compress_x=False,
+        level=2,
+        warmup_in_main_process=False,
+    )
+
+    assert isinstance(optimized[0], GCContainer)
+    assert peak_calls["count"] == 0
+    assert profile_calls["count"] == 0
+
+
+def test_memory_optimization_level3_temporally_splits_heavy_gc_container(monkeypatch):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    peak_calls = {"count": 0}
+    profile_values = iter([
+        _result_row("0"),
+        [],
+    ])
+    def fake_train_peak_memory(*args, **kwargs):
+        peak_calls["count"] += 1
+        return (80, 80) if peak_calls["count"] == 1 else (60, 60)
+    monkeypatch.setattr(memopt_pipeline, "_train_peak_memory", fake_train_peak_memory)
+    monkeypatch.setattr(
+        memopt_pipeline,
+        "_train_memory_profile",
+        lambda *args, **kwargs: _profile_result_with_optional_peak(
+            next(profile_values), kwargs.get("return_peak", False)
+        ),
+    )
+
+    net = nn.Sequential(TemporalSplitBlock())
+    optimized = memopt.memory_optimization(
+        net,
+        TemporalSplitBlock,
+        dummy_input=(torch.randn(4, 2, 4),),
+        compress_x=False,
+        level=3,
+        temporal_split_factor=2,
+    )
+
+    assert isinstance(optimized[0], TCGCContainer)
+    assert optimized[0].n_chunk == 2
+
+
+def test_memory_optimization_level3_skips_when_no_temporal_split_candidates(
+    monkeypatch,
+):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    peak_calls = {"count": 0}
+    profile_calls = {"count": 0}
+
+    monkeypatch.setattr(
+        memopt_pipeline,
+        "_train_peak_memory",
+        lambda *args, **kwargs: peak_calls.__setitem__("count", peak_calls["count"] + 1),
+    )
+    monkeypatch.setattr(
+        memopt_pipeline,
+        "_train_memory_profile",
+        lambda *args, **kwargs: profile_calls.__setitem__(
+            "count", profile_calls["count"] + 1
+        ),
+    )
+
+    net = nn.Sequential(neuron.PSN(T=4))
+    optimized = memopt.memory_optimization(
+        net,
+        neuron.PSN,
+        dummy_input=(torch.randn(4, 2, 4),),
+        compress_x=False,
+        level=3,
+        warmup_in_main_process=False,
+    )
+
+    assert isinstance(optimized[0], GCContainer)
+    assert peak_calls["count"] == 0
+    assert profile_calls["count"] == 0
+
+
+def test_memory_optimization_level3_respects_split_budgets(monkeypatch):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    peak_calls = {"count": 0}
+    profile_calls = {"count": 0}
+
+    def fake_train_peak_memory(*args, **kwargs):
+        peak_calls["count"] += 1
+        return 100, 100
+
+    def fake_train_memory_profile(*args, **kwargs):
+        profile_calls["count"] += 1
+        return _profile_result_with_optional_peak(
+            [("0", 0.0), ("1", 0.0)], kwargs.get("return_peak", False)
+        )
+
+    monkeypatch.setattr(memopt_pipeline, "_train_peak_memory", fake_train_peak_memory)
+    monkeypatch.setattr(
+        memopt_pipeline, "_train_memory_profile", fake_train_memory_profile
+    )
+
+    net = nn.Sequential(TemporalSplitBlock(), TemporalSplitBlock())
+    optimized = memopt.memory_optimization(
+        net,
+        TemporalSplitBlock,
+        dummy_input=(torch.randn(4, 2, 4),),
+        compress_x=False,
+        level=3,
+        max_split_rounds=1,
+        max_candidates_per_round=1,
+    )
+
+    assert isinstance(optimized[0], GCContainer)
+    assert isinstance(optimized[1], GCContainer)
+    assert profile_calls["count"] == 1
+    assert peak_calls["count"] == 2
+
+
+def test_memory_optimization_level3_retries_blocked_candidates_after_improvement(
+    monkeypatch,
+):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    peak_calls = {"count": 0}
+    profile_values = iter(
+        [
+            [("0", 0.0), ("1", 0.0)],
+            [("0", 0.0), ("1", 0.0)],
+            [],
+        ]
+    )
+    temporal_attempts = {"0": 0, "1": 0}
+
+    def fake_temporal_split(block, factor=2):
+        if isinstance(block[0], UnsplittableBlock):
+            temporal_attempts["0"] += 1
+            return None
+        temporal_attempts["1"] += 1
+        return TCGCContainer(
+            block.x_compressor,
+            *block,
+            n_chunk=getattr(block, "n_chunk", 1) * factor,
+            n_seq_inputs=getattr(block, "n_seq_inputs", 1),
+            n_outputs=getattr(block, "n_outputs", 1),
+        )
+
+    def fake_train_peak_memory(*args, **kwargs):
+        peak_calls["count"] += 1
+        if peak_calls["count"] == 1:
+            return 80, 80
+        if peak_calls["count"] == 2:
+            return 60, 60
+        return 50, 50
+    monkeypatch.setattr(memopt_pipeline, "_train_peak_memory", fake_train_peak_memory)
+    monkeypatch.setattr(
+        memopt_pipeline,
+        "_train_memory_profile",
+        lambda *args, **kwargs: _profile_result_with_optional_peak(
+            next(profile_values), kwargs.get("return_peak", False)
+        ),
+    )
+    monkeypatch.setattr(
+        memopt_pipeline, "_temporally_split_gc_container", fake_temporal_split
+    )
+
+    net = nn.Sequential(
+        UnsplittableBlock(),
+        TemporalOnlyBlock(),
+    )
+    optimized = memopt.memory_optimization(
+        net,
+        (UnsplittableBlock, TemporalOnlyBlock),
+        dummy_input=(torch.randn(4, 2, 4),),
+        compress_x=False,
+        level=3,
+        max_candidates_per_round=2,
+    )
+
+    assert isinstance(optimized[0], GCContainer)
+    assert isinstance(optimized[1], TCGCContainer)
+    assert temporal_attempts["0"] == 2
+    assert temporal_attempts["1"] == 2
+
+
+def test_memory_optimization_level4_unwraps_gc_container_when_memory_allows(
+    monkeypatch,
+):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    peak_calls = {"count": 0}
+    profile_values = iter([
+        [],
+        [],
+    ])
+    def fake_train_peak_memory(*args, **kwargs):
+        peak_calls["count"] += 1
+        return (100, 100) if peak_calls["count"] == 1 else (90, 90)
+    monkeypatch.setattr(memopt_pipeline, "_train_peak_memory", fake_train_peak_memory)
+    monkeypatch.setattr(
+        memopt_pipeline,
+        "_train_memory_profile",
+        lambda *args, **kwargs: _profile_result_with_optional_peak(
+            next(profile_values), kwargs.get("return_peak", False)
+        ),
+    )
+    monkeypatch.setattr(
+        memopt_pipeline,
+        "_inference_time_profile",
+        lambda *args, **kwargs: _result_row("0"),
+    )
+
+    net = nn.Sequential(TargetBlock())
+    optimized = memopt.memory_optimization(
+        net,
+        TargetBlock,
+        dummy_input=(torch.randn(2, 4),),
+        compress_x=False,
+        level=4,
+    )
+
+    assert isinstance(optimized[0], TargetBlock)
 
 
 def test_input_compressed_gc():

--- a/test/activation_based/test_checkpointing.py
+++ b/test/activation_based/test_checkpointing.py
@@ -674,6 +674,41 @@ def test_ensure_cleanup_tmp_python_files_tracks_created_temp_files():
     assert not os.path.exists(created["path"])
 
 
+def test_ensure_cleanup_tmp_python_files_cleans_up_on_exception():
+    from spikingjelly.activation_based.triton_kernel.triton_utils import (
+        ensure_cleanup_tmp_python_files,
+    )
+
+    created = {"path": None}
+
+    @ensure_cleanup_tmp_python_files
+    def build_temp_python_file():
+        tmp = tempfile.NamedTemporaryFile(
+            suffix=".py",
+            delete=False,
+        )
+        tmp.write(b"print('hello')\n")
+        tmp.close()
+        created["path"] = tmp.name
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        build_temp_python_file()
+
+    assert created["path"] is not None
+    assert not os.path.exists(created["path"])
+
+
+def test_spatial_split_respects_compress_x_flag():
+    block = GCContainer(SpatialSplitBlock(), x_compressor=BitSpikeCompressor())
+
+    split = memopt_pipeline._spatially_split_gc_container(block, compress_x=False)
+
+    assert isinstance(split, nn.Sequential)
+    assert all(isinstance(child, GCContainer) for child in split)
+    assert all(isinstance(child.x_compressor, NullSpikeCompressor) for child in split)
+
+
 def test_apply_gc_clones_manual_compressor_instances(monkeypatch):
     monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
 

--- a/test/activation_based/test_checkpointing.py
+++ b/test/activation_based/test_checkpointing.py
@@ -5,7 +5,9 @@ import torch
 import torch.nn as nn
 
 import spikingjelly.activation_based.memopt as memopt
+import spikingjelly.activation_based.memopt.compress as memopt_compress
 import spikingjelly.activation_based.memopt.pipeline as memopt_pipeline
+import spikingjelly.activation_based.triton_kernel.compress as triton_compress
 from spikingjelly.activation_based.memopt.checkpointing import (
     in_gc_1st_forward,
     query_autocast,
@@ -50,6 +52,15 @@ class BinaryProject(nn.Module):
 class TargetBlock(nn.Module):
     def forward(self, x):
         return x + 1.0
+
+
+class ParameterizedTargetBlock(nn.Module):
+    def __init__(self, features=4):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(features))
+
+    def forward(self, x):
+        return x + self.weight
 
 
 class SpatialSplitBlock(nn.Module):
@@ -176,6 +187,19 @@ def test_probe_binary_inputs_uses_dummy_input_before_random_trials(monkeypatch):
 
     assert result[net.block] is False
     assert net.forward_calls == 1
+
+
+def test_randomize_input_like_supports_bool_and_integer_tensors():
+    bool_input = torch.tensor([[True, False], [False, True]])
+    int_input = torch.tensor([[0, 1], [2, 3]], dtype=torch.int64)
+
+    randomized_bool = memopt_pipeline._randomize_input_like(bool_input)
+    randomized_int = memopt_pipeline._randomize_input_like(int_input)
+
+    assert randomized_bool.dtype == torch.bool
+    assert randomized_bool.shape == bool_input.shape
+    assert randomized_int.dtype == torch.int64
+    assert randomized_int.shape == int_input.shape
 
 
 def test_autocast_query():
@@ -455,11 +479,18 @@ def test_memory_optimization_level1_wraps_target_modules_and_uses_bit_compressor
     monkeypatch,
 ):
     monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+    monkeypatch.setattr(memopt_compress, "triton", object())
+    monkeypatch.setattr(
+        memopt_compress, "bit_spike_compress", triton_compress.bit_spike_compress
+    )
+    monkeypatch.setattr(
+        memopt_compress, "bit_spike_decompress", triton_compress.bit_spike_decompress
+    )
 
-    net = nn.Sequential(BinaryProject(), TargetBlock())
+    net = nn.Sequential(BinaryProject(), ParameterizedTargetBlock())
     optimized = memopt.memory_optimization(
         net,
-        TargetBlock,
+        ParameterizedTargetBlock,
         dummy_input=(torch.randn(2, 4),),
         compress_x=True,
         level=1,
@@ -467,7 +498,7 @@ def test_memory_optimization_level1_wraps_target_modules_and_uses_bit_compressor
 
     assert isinstance(optimized[1], GCContainer)
     assert isinstance(optimized[1].x_compressor, BitSpikeCompressor)
-    assert next(optimized.parameters(), torch.empty(0)).device.type == "cpu"
+    assert optimized[1][0].weight.device.type == "cpu"
 
 
 def test_memory_optimization_can_disable_main_process_warmup(monkeypatch):
@@ -492,6 +523,23 @@ def test_memory_optimization_can_disable_main_process_warmup(monkeypatch):
 
     assert isinstance(optimized[0], GCContainer)
     assert warmup_calls["count"] == 0
+
+
+def test_memory_optimization_profile_respects_explicit_warmup_flags(monkeypatch):
+    monkeypatch.setattr(memopt_pipeline, "resolve_device", lambda: "cpu")
+
+    _, summary = memopt.memory_optimization(
+        nn.Sequential(TargetBlock()),
+        TargetBlock,
+        dummy_input=(torch.randn(2, 4),),
+        profile="safe",
+        warmup_in_main_process=True,
+        warmup_in_profile_workers=True,
+        return_summary=True,
+    )
+
+    assert summary.options["warmup_in_main_process"] is True
+    assert summary.options["warmup_in_profile_workers"] is True
 
 
 def test_memory_optimization_forwards_profile_worker_warmup_flag(monkeypatch):
@@ -574,7 +622,14 @@ def test_memory_optimization_profile_memory_honors_allow_expensive_profiling_fal
     assert summary.options["max_candidates_per_round"] == 1
 
 
-def test_bit_spike_compressor_cpu_round_trip_with_triton_available():
+def test_bit_spike_compressor_cpu_round_trip_with_triton_available(monkeypatch):
+    monkeypatch.setattr(memopt_compress, "triton", object())
+    monkeypatch.setattr(
+        memopt_compress, "bit_spike_compress", triton_compress.bit_spike_compress
+    )
+    monkeypatch.setattr(
+        memopt_compress, "bit_spike_decompress", triton_compress.bit_spike_decompress
+    )
     spikes = torch.tensor([[1.0, 0.0, 1.0], [0.0, 1.0, 0.0]])
     compressor = BitSpikeCompressor()
 
@@ -583,6 +638,14 @@ def test_bit_spike_compressor_cpu_round_trip_with_triton_available():
 
     assert compressed.device.type == "cpu"
     torch.testing.assert_close(decompressed, spikes)
+
+
+def test_candidate_entries_treats_zero_budget_as_disabled():
+    results = [("a", 1.0), ("b", 2.0)]
+
+    assert memopt_pipeline._candidate_entries(results, None) == results
+    assert memopt_pipeline._candidate_entries(results, 0) == []
+    assert memopt_pipeline._candidate_entries(results, -1) == []
 
 
 def test_apply_gc_clones_manual_compressor_instances(monkeypatch):


### PR DESCRIPTION
## Summary

This PR improves `spikingjelly.activation_based.memopt` in three directions:

- fixes and hardens the current memopt pipeline
- adds higher-level policy controls for selective checkpointing
- updates the memopt tutorials with quantitative results on synthetic and real networks

## What changed

- fixed memopt import / shape-handling regressions and added end-to-end tests
- added CPU fallback for bit-spike compression when Triton is available but the tensor is on CPU
- reduced profiling overhead with skip paths, probe short-circuiting, worker/main-process warmup controls, and split-search budgets
- restored correct split baseline peak measurement so real `level=4` optimization can recover split gains on `CIFAR10DVSVGG`
- added higher-level memopt controls:
  - `profile`
  - `checkpoint_budget`
  - `prefer`
  - richer `MemOptSummary` output including selected modules, selection explanation, and recommendations
- added benchmark coverage and updated API/tutorial docs

## Why

The previous memopt interface was powerful but still fairly research-oriented. These changes aim to make it easier to use safely in practice:

- reduce unnecessary optimizer overhead
- provide high-level controls that bias toward speed or memory
- explain what the optimizer actually selected and why
- document the trade-offs with concrete numbers

## Validation

- server regression tests:
  - `PYTHONPATH=. /home/qwe/user/fangwei/env/pytorch/bin/pytest test/activation_based/test_checkpointing.py -q`
  - latest result: `41 passed`
- real-network benchmark on `CIFAR10DVSVGG` (`triton`, `[8, 10, 2, 48, 48]`) used to document `profile` and `prefer` trade-offs
- targeted verification that restoring standalone baseline peak measurement allows real split candidates to become beneficial again

## Notes

This PR is intentionally scoped to memopt-related files only and excludes unrelated FlexSN changes from the working branch history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New memopt presets (`safe`, `balanced`, `memory`, `exhaustive`), `prefer`/checkpoint-budget controls, separate warmup options, enhanced structured summary output (`MemOptSummary`), and a CUDA benchmarking CLI for memory/time.

* **Documentation**
  * Expanded tutorials and API docs with presets, budgets, examples, benchmark tables, fallback behavior, and summary inspection guidance.

* **Tests**
  * Extensive unit/integration tests for memopt search, profiling/warmup, checkpointing, compressors, benchmarking, and temp-file cleanup.

* **Refactor / Bug Fixes**
  * Improved kernel utility behavior and temp-file handling; added CPU fallback for spike compression; robustness and cloning fixes in memopt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->