### PR TITLE
[flexsn] Clean up HOP and compile training improvements

### DIFF
--- a/benchmark/flexsn/benchmark_vgg_inductor.py
+++ b/benchmark/flexsn/benchmark_vgg_inductor.py
@@ -110,9 +110,8 @@ def main() -> None:
          lambda: build_vgg(make_flexsn_factory())),
     ]
 
-    scale_label = "ImageNet-scale" if H >= 224 and W >= 224 else "CIFAR-scale"
-    print(f"Input : T={T}, B={B}, {C}x{H}x{W}  ({scale_label})")
-    print("Model : SpikingVGG-16-BN")
+    print(f"Input : T={T}, B={B}, {C}×{H}×{W}  (ImageNet-scale)")
+    print(f"Model : SpikingVGG-16-BN")
     print()
     print(f"  {'backend':<30}  {'ms/iter':>9}  {'img/s':>9}  {'vs torch':>10}")
     print("-" * 68)
@@ -120,20 +119,13 @@ def main() -> None:
     baseline_ms = None
     for label, build_fn in configs:
         model = build_fn()
-        model.train()
+        model.eval()
 
-        def step(model=model):
-            functional.reset_net(model)
-            model.zero_grad(set_to_none=True)
-            outputs = model(x)
-            outputs = outputs if isinstance(outputs, (tuple, list)) else (outputs,)
-            loss = sum(out.float().sum() for out in outputs)
-            loss.backward()
-
-        # One extra iteration to initialize states and trigger Triton JIT +
-        # autotune before timing begins (avoids measuring compile cost).
-        step()
-        ms = cuda_time_ms(step)
+        with torch.no_grad():
+            # One extra forward to initialise states and trigger Triton JIT +
+            # autotune before timing begins (avoids measuring compile cost).
+            model(x)
+            ms = cuda_time_ms(lambda: (functional.reset_net(model), model(x)))
 
         imgs_per_sec = B * 1000 / ms
         rel = f"{ms / baseline_ms:.2f}×" if baseline_ms is not None else "1.00×"

--- a/benchmark/flexsn/benchmark_vgg_inductor.py
+++ b/benchmark/flexsn/benchmark_vgg_inductor.py
@@ -53,18 +53,24 @@ def make_flexsn_factory():
 # Timing helper
 # ---------------------------------------------------------------------------
 
-def cuda_time_ms(fn, warmup: int = 5, iters: int = 50) -> float:
+def cuda_time_ms(fn, warmup: int = 5, iters: int = 50, reset_hook=None) -> float:
     for _ in range(warmup):
+        if reset_hook is not None:
+            reset_hook()
         fn()
     torch.cuda.synchronize()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
+    elapsed = 0.0
     for _ in range(iters):
+        if reset_hook is not None:
+            reset_hook()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
         fn()
-    end.record()
-    torch.cuda.synchronize()
-    return start.elapsed_time(end) / iters
+        end.record()
+        end.synchronize()
+        elapsed += start.elapsed_time(end)
+    return elapsed / iters
 
 
 # ---------------------------------------------------------------------------
@@ -110,8 +116,9 @@ def main() -> None:
          lambda: build_vgg(make_flexsn_factory())),
     ]
 
-    print(f"Input : T={T}, B={B}, {C}×{H}×{W}  (ImageNet-scale)")
-    print(f"Model : SpikingVGG-16-BN")
+    scale = "ImageNet-scale" if H >= 224 and W >= 224 else "CIFAR-scale"
+    print(f"Input : T={T}, B={B}, {C}x{H}x{W}  ({scale})")
+    print("Model : SpikingVGG-16-BN")
     print()
     print(f"  {'backend':<30}  {'ms/iter':>9}  {'img/s':>9}  {'vs torch':>10}")
     print("-" * 68)
@@ -125,7 +132,7 @@ def main() -> None:
             # One extra forward to initialise states and trigger Triton JIT +
             # autotune before timing begins (avoids measuring compile cost).
             model(x)
-            ms = cuda_time_ms(lambda: (functional.reset_net(model), model(x)))
+            ms = cuda_time_ms(lambda: model(x), reset_hook=lambda: functional.reset_net(model))
 
         imgs_per_sec = B * 1000 / ms
         rel = f"{ms / baseline_ms:.2f}×" if baseline_ms is not None else "1.00×"

--- a/benchmark/flexsn/benchmark_vgg_inductor.py
+++ b/benchmark/flexsn/benchmark_vgg_inductor.py
@@ -14,10 +14,12 @@ Usage (run from repo root):
 import gc
 import os
 import sys
+from collections.abc import Callable
+from copy import deepcopy
+from typing import Any, Optional
 
 import torch
 import torch.nn as nn
-from copy import deepcopy
 
 from spikingjelly.activation_based import neuron, functional
 from spikingjelly.activation_based.model.spiking_vgg import spiking_vgg16_bn
@@ -53,7 +55,12 @@ def make_flexsn_factory():
 # Timing helper
 # ---------------------------------------------------------------------------
 
-def cuda_time_ms(fn, warmup: int = 5, iters: int = 50, reset_hook=None) -> float:
+def cuda_time_ms(
+    fn: Callable[[], Any],
+    warmup: int = 5,
+    iters: int = 50,
+    reset_hook: Optional[Callable[[], Any]] = None,
+) -> float:
     for _ in range(warmup):
         if reset_hook is not None:
             reset_hook()

--- a/benchmark/flexsn/flex_sn_inductor.py
+++ b/benchmark/flexsn/flex_sn_inductor.py
@@ -11,9 +11,12 @@ Usage (run from repo root):
 
 import os
 import sys
+from collections.abc import Callable
+from typing import Any, Optional
 
 import torch
 import torch.nn as nn
+from spikingjelly.activation_based import functional
 from spikingjelly.activation_based.neuron.flexsn import FlexSN
 
 # ---------------------------------------------------------------------------
@@ -44,7 +47,12 @@ def make_flexsn(backend: str) -> FlexSN:
 # ---------------------------------------------------------------------------
 
 
-def cuda_time_ms(fn, warmup: int = 10, iters: int = 200, reset_hook=None) -> float:
+def cuda_time_ms(
+    fn: Callable[[], Any],
+    warmup: int = 10,
+    iters: int = 200,
+    reset_hook: Optional[Callable[[], Any]] = None,
+) -> float:
     for _ in range(warmup):
         if reset_hook is not None:
             reset_hook()
@@ -158,7 +166,6 @@ def bench_linear_flexsn_linear():
         m_ind = SeqModelFused(N, "inductor").cuda()
         c_ind = torch.compile(m_ind, fullgraph=True)
 
-        from spikingjelly.activation_based import functional
         with torch.no_grad():
             ms_tri = cuda_time_ms(lambda: m_tri(x),
                                   reset_hook=lambda: functional.reset_net(m_tri))

--- a/benchmark/flexsn/flex_sn_inductor.py
+++ b/benchmark/flexsn/flex_sn_inductor.py
@@ -44,14 +44,19 @@ def make_flexsn(backend: str) -> FlexSN:
 # ---------------------------------------------------------------------------
 
 
-def cuda_time_ms(fn, warmup: int = 10, iters: int = 200) -> float:
+def cuda_time_ms(fn, warmup: int = 10, iters: int = 200,
+                 reset_hook=None) -> float:
     for _ in range(warmup):
+        if reset_hook is not None:
+            reset_hook()
         fn()
     torch.cuda.synchronize()
     start = torch.cuda.Event(enable_timing=True)
     end = torch.cuda.Event(enable_timing=True)
     start.record()
     for _ in range(iters):
+        if reset_hook is not None:
+            reset_hook()
         fn()
     end.record()
     torch.cuda.synchronize()
@@ -86,8 +91,8 @@ def bench_single_layer():
         c_ind = torch.compile(n_ind, fullgraph=True)
 
         with torch.no_grad():
-            ms_tri = cuda_time_ms(lambda: n_tri(x))
-            ms_ind = cuda_time_ms(lambda: c_ind(x))
+            ms_tri = cuda_time_ms(lambda: n_tri(x), reset_hook=n_tri.reset)
+            ms_ind = cuda_time_ms(lambda: c_ind(x), reset_hook=n_ind.reset)
 
         r = ms_ind / ms_tri
         print(
@@ -152,9 +157,12 @@ def bench_linear_flexsn_linear():
         m_ind = SeqModelFused(N, "inductor").cuda()
         c_ind = torch.compile(m_ind, fullgraph=True)
 
+        from spikingjelly.activation_based import functional
         with torch.no_grad():
-            ms_tri = cuda_time_ms(lambda: m_tri(x))
-            ms_ind = cuda_time_ms(lambda: c_ind(x))
+            ms_tri = cuda_time_ms(lambda: m_tri(x),
+                                  reset_hook=lambda: functional.reset_net(m_tri))
+            ms_ind = cuda_time_ms(lambda: c_ind(x),
+                                  reset_hook=lambda: functional.reset_net(m_ind))
 
         r = ms_ind / ms_tri
         print(
@@ -173,11 +181,12 @@ def main() -> None:
         sys.exit(1)
     if os.environ.get("PYTORCH_JIT", "1") != "0":
         print(
-            "Warning: PYTORCH_JIT != 0. "
+            "Error: PYTORCH_JIT != 0. "
             "The triton backend requires PYTORCH_JIT=0.\n"
-            "Run with:  PYTORCH_JIT=0 python flex_sn_inductor.py",
+            "Run with:  PYTORCH_JIT=0 PYTHONPATH=$(pwd) python benchmark/flexsn/flex_sn_inductor.py",
             file=sys.stderr,
         )
+        sys.exit(1)
 
     print(f"GPU    : {torch.cuda.get_device_name(0)}")
     print(f"PyTorch: {torch.__version__}")

--- a/benchmark/flexsn/flex_sn_inductor.py
+++ b/benchmark/flexsn/flex_sn_inductor.py
@@ -44,23 +44,24 @@ def make_flexsn(backend: str) -> FlexSN:
 # ---------------------------------------------------------------------------
 
 
-def cuda_time_ms(fn, warmup: int = 10, iters: int = 200,
-                 reset_hook=None) -> float:
+def cuda_time_ms(fn, warmup: int = 10, iters: int = 200, reset_hook=None) -> float:
     for _ in range(warmup):
         if reset_hook is not None:
             reset_hook()
         fn()
     torch.cuda.synchronize()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
+    elapsed = 0.0
     for _ in range(iters):
         if reset_hook is not None:
             reset_hook()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
         fn()
-    end.record()
-    torch.cuda.synchronize()
-    return start.elapsed_time(end) / iters
+        end.record()
+        end.synchronize()
+        elapsed += start.elapsed_time(end)
+    return elapsed / iters
 
 
 def ratio_flag(r: float) -> str:

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -228,6 +228,12 @@ def fuse_conv_bn_eval_modules(net: nn.Module) -> fx.GraphModule:
 
     The input model must be in ``eval()`` mode. The returned value is a fused
     ``fx.GraphModule``.
+
+    :param net: EN: Evaluation-mode module to transform. 中文：待变换的评估模式模型，必须已经调用 ``eval()``。
+    :type net: torch.nn.Module
+    :return: EN: Fused FX graph module. 中文：融合后的 FX 图模块。
+    :rtype: torch.fx.GraphModule
+    :raises ValueError: EN: Raised when ``net`` is still in training mode. 中文：当 ``net`` 仍处于训练模式时抛出。
     """
 
     if net.training:
@@ -300,6 +306,12 @@ def pack_conv_bn_train_modules(net: nn.Module) -> fx.GraphModule:
 
     The input model must be in ``train()`` mode. The returned value is the packed
     ``fx.GraphModule``.
+
+    :param net: EN: Training-mode module to transform. 中文：待变换的训练模式模型，必须已经调用 ``train()``。
+    :type net: torch.nn.Module
+    :return: EN: Packed FX graph module. 中文：打包后的 FX 图模块。
+    :rtype: torch.fx.GraphModule
+    :raises ValueError: EN: Raised when ``net`` is not in training mode. 中文：当 ``net`` 不处于训练模式时抛出。
     """
     if not net.training:
         raise ValueError("pack_conv_bn_train_modules only supports train() models.")

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -1,10 +1,11 @@
+import math
+from contextlib import contextmanager
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch import Tensor
-import math
-from contextlib import contextmanager
 from torch import fx
+from torch import Tensor
 from torch.nn.utils.fusion import fuse_conv_bn_eval
 
 from .. import base, layer, neuron
@@ -229,11 +230,11 @@ def fuse_conv_bn_eval_modules(net: nn.Module) -> fx.GraphModule:
     The input model must be in ``eval()`` mode. The returned value is a fused
     ``fx.GraphModule``.
 
-    :param net: EN: Evaluation-mode module to transform. 中文：待变换的评估模式模型，必须已经调用 ``eval()``。
+    :param net: EN: Evaluation-mode module to transform. Chinese: 待变换的评估模式模型, 必须已经调用 ``eval()``。
     :type net: torch.nn.Module
-    :return: EN: Fused FX graph module. 中文：融合后的 FX 图模块。
+    :return: EN: Fused FX graph module. Chinese: 融合后的 FX 图模块。
     :rtype: torch.fx.GraphModule
-    :raises ValueError: EN: Raised when ``net`` is still in training mode. 中文：当 ``net`` 仍处于训练模式时抛出。
+    :raises ValueError: EN: Raised when ``net`` is still in training mode, or when a matched BatchNorm module does not track running statistics or lacks valid running mean/variance. Chinese: 当 ``net`` 仍处于训练模式时, 或者匹配到的 BatchNorm 模块未跟踪运行统计量、缺少有效的运行均值/方差时抛出。
     """
 
     if net.training:
@@ -307,11 +308,11 @@ def pack_conv_bn_train_modules(net: nn.Module) -> fx.GraphModule:
     The input model must be in ``train()`` mode. The returned value is the packed
     ``fx.GraphModule``.
 
-    :param net: EN: Training-mode module to transform. 中文：待变换的训练模式模型，必须已经调用 ``train()``。
+    :param net: EN: Training-mode module to transform. Chinese: 待变换的训练模式模型, 必须已经调用 ``train()``。
     :type net: torch.nn.Module
-    :return: EN: Packed FX graph module. 中文：打包后的 FX 图模块。
+    :return: EN: Packed FX graph module. Chinese: 打包后的 FX 图模块。
     :rtype: torch.fx.GraphModule
-    :raises ValueError: EN: Raised when ``net`` is not in training mode. 中文：当 ``net`` 不处于训练模式时抛出。
+    :raises ValueError: EN: Raised when ``net`` is not in training mode. Chinese: 当 ``net`` 不处于训练模式时抛出。
     """
     if not net.training:
         raise ValueError("pack_conv_bn_train_modules only supports train() models.")

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -3,8 +3,11 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 import math
+from contextlib import contextmanager
+from torch import fx
+from torch.nn.utils.fusion import fuse_conv_bn_eval
 
-from .. import neuron
+from .. import base, layer, neuron
 
 
 __all__ = [
@@ -13,7 +16,324 @@ __all__ = [
     "first_spike_index",
     "kaiming_normal_conv_linear_weight",
     "delay",
+    "fuse_conv_bn_eval_modules",
+    "pack_conv_bn_train_modules",
 ]
+
+
+_TRAIN_PACK_CONV_TYPES = (
+    nn.Conv1d,
+    nn.Conv2d,
+    nn.Conv3d,
+    layer.Conv1d,
+    layer.Conv2d,
+    layer.Conv3d,
+)
+_TRAIN_PACK_BN_TYPES = (
+    nn.BatchNorm1d,
+    nn.BatchNorm2d,
+    nn.BatchNorm3d,
+    layer.BatchNorm1d,
+    layer.BatchNorm2d,
+    layer.BatchNorm3d,
+)
+_CONV_BN_PATTERNS = [
+    (layer.Conv1d, layer.BatchNorm1d),
+    (layer.Conv2d, layer.BatchNorm2d),
+    (layer.Conv3d, layer.BatchNorm3d),
+    (nn.Conv1d, nn.BatchNorm1d),
+    (nn.Conv2d, nn.BatchNorm2d),
+    (nn.Conv3d, nn.BatchNorm3d),
+]
+
+
+def _matches_module_pattern(pattern, node: fx.Node, modules) -> bool:
+    if len(node.args) == 0:
+        return False
+    nodes = (node.args[0], node)
+    if len(pattern) != len(nodes):
+        return False
+    for i in range(len(pattern)):
+        expected_type = pattern[i]
+        current_node = nodes[i]
+        if not isinstance(current_node, fx.Node):
+            return False
+        if current_node.op != "call_module":
+            return False
+        if not isinstance(current_node.target, str):
+            return False
+        if current_node.target not in modules:
+            return False
+        if not isinstance(modules[current_node.target], expected_type):
+            return False
+    return True
+
+
+def _replace_node_module(
+    node: fx.Node, modules, new_module: torch.nn.Module
+) -> None:
+    def parent_name(target: str):
+        *parent, name = target.rsplit(".", 1)
+        return parent[0] if parent else "", name
+
+    assert isinstance(node.target, str)
+    parent, name = parent_name(node.target)
+    modules[node.target] = new_module
+    setattr(modules[parent], name, new_module)
+
+
+def _collect_conv_bn_matches(fx_model: fx.GraphModule, modules, patterns):
+    pair_to_nodes = {}
+    conv_to_bn_targets = {}
+    conv_target_call_counts = {}
+    matched_bn_nodes = set()
+    for node in fx_model.graph.nodes:
+        if node.op == "call_module":
+            conv_target_call_counts[node.target] = (
+                conv_target_call_counts.get(node.target, 0) + 1
+            )
+    for pattern in patterns:
+        for node in list(fx_model.graph.nodes):
+            if node in matched_bn_nodes:
+                continue
+            if not _matches_module_pattern(pattern, node, modules):
+                continue
+            conv_node = node.args[0]
+            assert isinstance(conv_node, fx.Node)
+            if len(conv_node.users) > 1:
+                continue
+            pair = (conv_node.target, node.target)
+            pair_to_nodes.setdefault(pair, []).append(node)
+            conv_to_bn_targets.setdefault(conv_node.target, set()).add(node.target)
+            matched_bn_nodes.add(node)
+
+    ambiguous_conv_targets = {
+        conv_target
+        for conv_target, bn_targets in conv_to_bn_targets.items()
+        if len(bn_targets) > 1
+    }
+    return {
+        pair: matched_nodes
+        for pair, matched_nodes in pair_to_nodes.items()
+        if (
+            pair[0] not in ambiguous_conv_targets
+            and len(matched_nodes) == conv_target_call_counts[pair[0]]
+        )
+    }
+
+
+class _EvalFusionTracer(fx.Tracer):
+    def is_leaf_module(self, m: nn.Module, module_qualified_name: str) -> bool:
+        if isinstance(
+            m,
+            (
+                _TrainConvBnWrapper,
+                layer.Conv1d,
+                layer.Conv2d,
+                layer.Conv3d,
+                layer.BatchNorm1d,
+                layer.BatchNorm2d,
+                layer.BatchNorm3d,
+                base.MemoryModule,
+                neuron.BaseNode,
+            ),
+        ):
+            return True
+        return super().is_leaf_module(m, module_qualified_name)
+
+
+class _TrainPackTracer(_EvalFusionTracer):
+    pass
+
+
+class _TrainConvBnWrapper(nn.Module):
+    def __init__(self, conv: nn.Module, bn: nn.Module):
+        super().__init__()
+        self.conv = conv
+        self.bn = bn
+
+    @contextmanager
+    def _single_step_mode(self, module: nn.Module):
+        if isinstance(module, base.StepModule):
+            old_step_mode = module.step_mode
+            module.step_mode = "s"
+            try:
+                yield
+            finally:
+                module.step_mode = old_step_mode
+        else:
+            yield
+
+    def _packed_forward(self, x: Tensor) -> Tensor:
+        t, n = x.shape[:2]
+        x = x.flatten(0, 1)
+        with self._single_step_mode(self.conv):
+            x = self.conv(x)
+
+        with self._single_step_mode(self.bn):
+            x = self.bn(x)
+        return x.reshape(t, n, *x.shape[1:])
+
+    def _expects_multistep_input(self, x: Tensor) -> bool:
+        if isinstance(self.conv, (nn.Conv1d, layer.Conv1d)):
+            return x.dim() == 4
+        if isinstance(self.conv, (nn.Conv2d, layer.Conv2d)):
+            return x.dim() == 5
+        if isinstance(self.conv, (nn.Conv3d, layer.Conv3d)):
+            return x.dim() == 6
+        return False
+
+    def forward(self, x: Tensor) -> Tensor:
+        if (
+            isinstance(self.conv, _TRAIN_PACK_CONV_TYPES)
+            and isinstance(self.bn, _TRAIN_PACK_BN_TYPES)
+            and getattr(self.conv, "step_mode", "m") == "m"
+            and getattr(self.bn, "step_mode", "m") == "m"
+            and self._expects_multistep_input(x)
+        ):
+            return self._packed_forward(x)
+        return self.bn(self.conv(x))
+
+
+def fuse_conv_bn_eval_modules(net: nn.Module) -> fx.GraphModule:
+    """
+    **API Language:**
+    :ref:`中文 <fuse_conv_bn_eval_modules-cn>` | :ref:`English <fuse_conv_bn_eval_modules-en>`
+
+    ----
+
+    .. _fuse_conv_bn_eval_modules-cn:
+
+    * **中文**
+
+    将评估模式下模型中的相邻 ``Conv*`` 与 ``BatchNorm*`` 模块融合为单个卷积模块.
+    该函数同时支持原生 ``torch.nn`` 模块以及 SpikingJelly 的
+    :class:`spikingjelly.activation_based.layer.Conv1d`,
+    :class:`spikingjelly.activation_based.layer.Conv2d`,
+    :class:`spikingjelly.activation_based.layer.Conv3d`,
+    :class:`spikingjelly.activation_based.layer.BatchNorm1d`,
+    :class:`spikingjelly.activation_based.layer.BatchNorm2d`,
+    :class:`spikingjelly.activation_based.layer.BatchNorm3d`.
+
+    输入模型必须处于 ``eval()`` 模式; 返回值是融合后的 ``fx.GraphModule``.
+
+    .. _fuse_conv_bn_eval_modules-en:
+
+    * **English**
+
+    Fuse adjacent ``Conv*`` and ``BatchNorm*`` modules in an evaluation-mode model
+    into a single convolution module. Both native ``torch.nn`` layers and
+    SpikingJelly activation-based ``layer.Conv*`` / ``layer.BatchNorm*`` wrappers
+    are supported.
+
+    The input model must be in ``eval()`` mode. The returned value is a fused
+    ``fx.GraphModule``.
+    """
+
+    if net.training:
+        raise ValueError("fuse_conv_bn_eval_modules only supports eval() models.")
+
+    tracer = _EvalFusionTracer()
+    graph = tracer.trace(net)
+    fx_model = fx.GraphModule(tracer.root, graph)
+    modules = dict(fx_model.named_modules())
+
+    for (conv_target, bn_target), matched_nodes in _collect_conv_bn_matches(
+        fx_model, modules, _CONV_BN_PATTERNS
+    ).items():
+        conv = modules[conv_target]
+        bn = modules[bn_target]
+        if (
+            getattr(bn, "track_running_stats", True) is False
+            or bn.running_mean is None
+            or bn.running_var is None
+        ):
+            raise ValueError(
+                f"Cannot fuse {bn_target}: BatchNorm must track running stats."
+            )
+        fused_conv = fuse_conv_bn_eval(conv, bn)
+        conv_node = matched_nodes[0].args[0]
+        assert isinstance(conv_node, fx.Node)
+        _replace_node_module(conv_node, modules, fused_conv)
+        for node in matched_nodes:
+            node.replace_all_uses_with(node.args[0])
+            fx_model.graph.erase_node(node)
+
+    fx_model.graph.lint()
+    fx_model.delete_all_unused_submodules()
+    fx_model.recompile()
+    return fx_model
+
+
+def pack_conv_bn_train_modules(net: nn.Module) -> fx.GraphModule:
+    """
+    **API Language:**
+    :ref:`中文 <pack_conv_bn_train_modules-cn>` | :ref:`English <pack_conv_bn_train_modules-en>`
+
+    ----
+
+    .. _pack_conv_bn_train_modules-cn:
+
+    * **中文**
+
+    将训练模式下模型中的相邻 ``Conv*`` 与 ``BatchNorm*`` 模块打包为单个 wrapper,
+    以减少多步 ``Conv -> BatchNorm`` 路径中的 ``view/flatten`` 往返。
+
+    该函数不会像 ``fuse_conv_bn_eval_modules`` 那样融合权重; 它只是将相邻层包装成一个
+    compile-friendly 的训练模块。当前同时支持原生 ``torch.nn`` 的 ``Conv*`` / ``BatchNorm*``
+    模块, 以及 SpikingJelly activation-based ``layer.Conv*`` / ``layer.BatchNorm*`` 模块。
+
+    输入模型必须处于 ``train()`` 模式。返回值是变换后的 ``fx.GraphModule``。
+
+    .. _pack_conv_bn_train_modules-en:
+
+    * **English**
+
+    Pack adjacent ``Conv*`` and ``BatchNorm*`` modules in a training-mode model into
+    a single wrapper to reduce redundant ``view/flatten`` hops along multi-step
+    ``Conv -> BatchNorm`` paths.
+
+    Unlike ``fuse_conv_bn_eval_modules``, this transform does not fuse weights. It
+    only rewrites the module graph into a more compile-friendly training structure.
+    Both native ``torch.nn`` layers and SpikingJelly activation-based
+    ``layer.Conv*`` / ``layer.BatchNorm*`` wrappers are supported.
+
+    The input model must be in ``train()`` mode. The returned value is the packed
+    ``fx.GraphModule``.
+    """
+    if not net.training:
+        raise ValueError("pack_conv_bn_train_modules only supports train() models.")
+
+    tracer = _TrainPackTracer()
+    graph = tracer.trace(net)
+    fx_model = fx.GraphModule(tracer.root, graph)
+    modules = dict(fx_model.named_modules())
+
+    for (conv_target, bn_target), matched_nodes in _collect_conv_bn_matches(
+        fx_model, modules, _CONV_BN_PATTERNS
+    ).items():
+        conv = modules[conv_target]
+        bn = modules[bn_target]
+        if (
+            isinstance(conv, (layer.Conv1d, layer.Conv2d, layer.Conv3d))
+            and isinstance(
+                bn, (layer.BatchNorm1d, layer.BatchNorm2d, layer.BatchNorm3d)
+            )
+            and getattr(conv, "step_mode", None) != getattr(bn, "step_mode", None)
+        ):
+            continue
+        packed = _TrainConvBnWrapper(conv, bn)
+        conv_node = matched_nodes[0].args[0]
+        assert isinstance(conv_node, fx.Node)
+        _replace_node_module(conv_node, modules, packed)
+        for node in matched_nodes:
+            node.replace_all_uses_with(node.args[0])
+            fx_model.graph.erase_node(node)
+
+    fx_model.graph.lint()
+    fx_model.delete_all_unused_submodules()
+    fx_model.recompile()
+    return fx_model
 
 
 def set_threshold_margin(

--- a/spikingjelly/activation_based/model/tv_ref_classify/utils.py
+++ b/spikingjelly/activation_based/model/tv_ref_classify/utils.py
@@ -6,6 +6,8 @@ import os
 import statistics
 import time
 from collections import defaultdict, deque, OrderedDict
+from numbers import Number
+from typing import Optional, Sequence, Union
 
 import torch
 import torch.distributed as dist
@@ -92,7 +94,10 @@ class ThroughputValue:
     def synchronize_between_processes(self):
         """Synchronize cumulative samples/time across ranks.
 
-        Windowed statistics stored in ``deque`` remain local to each rank.
+        ``total_samples`` is reduced with ``SUM`` across all ranks, while
+        ``total_time`` is reduced with ``MAX`` so global throughput is computed
+        as ``sum(samples) / max(elapsed_time)``. Windowed statistics stored in
+        ``deque`` remain local to each rank.
         """
         if not is_dist_avail_and_initialized():
             return
@@ -506,7 +511,23 @@ def store_model_weights(model, checkpoint_path, checkpoint_key="model", strict=T
     return output_path
 
 
-def reduce_across_processes(val, op=dist.ReduceOp.SUM, dtype=None):
+def reduce_across_processes(
+    val: Union[int, float, torch.Tensor, Sequence[Number]],
+    op: dist.ReduceOp = dist.ReduceOp.SUM,
+    dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    """EN: Reduce a scalar, tensor, or number sequence across distributed processes.
+    中文：对标量、张量或数字序列在分布式进程间执行归约。
+
+    :param val: EN: Value to reduce. 中文：待归约的值。
+    :type val: Union[int, float, torch.Tensor, Sequence[Number]]
+    :param op: EN: Reduction operator, defaulting to SUM. 中文：归约操作符，默认为 SUM。
+    :type op: torch.distributed.ReduceOp
+    :param dtype: EN: Optional output tensor dtype. 中文：可选的输出张量数据类型。
+    :type dtype: Optional[torch.dtype]
+    :return: EN: Reduced tensor placed on the backend-appropriate device. 中文：位于当前后端对应设备上的归约结果张量。
+    :rtype: torch.Tensor
+    """
     if not is_dist_avail_and_initialized():
         # nothing to sync, but we still convert to tensor for consistency with the distributed case.
         return torch.tensor(val, dtype=dtype)

--- a/spikingjelly/activation_based/model/tv_ref_classify/utils.py
+++ b/spikingjelly/activation_based/model/tv_ref_classify/utils.py
@@ -97,12 +97,12 @@ class ThroughputValue:
         if not is_dist_avail_and_initialized():
             return
 
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        samples = torch.tensor(self.total_samples, device=device, dtype=torch.float64)
-        elapsed = torch.tensor(self.total_time, device=device, dtype=torch.float64)
-        dist.barrier()
-        dist.all_reduce(samples, op=dist.ReduceOp.SUM)
-        dist.all_reduce(elapsed, op=dist.ReduceOp.MAX)
+        samples = reduce_across_processes(
+            self.total_samples, op=dist.ReduceOp.SUM, dtype=torch.float64
+        )
+        elapsed = reduce_across_processes(
+            self.total_time, op=dist.ReduceOp.MAX, dtype=torch.float64
+        )
         self.total_samples = samples.item()
         self.total_time = elapsed.item()
 
@@ -506,12 +506,19 @@ def store_model_weights(model, checkpoint_path, checkpoint_key="model", strict=T
     return output_path
 
 
-def reduce_across_processes(val):
+def reduce_across_processes(val, op=dist.ReduceOp.SUM, dtype=None):
     if not is_dist_avail_and_initialized():
         # nothing to sync, but we still convert to tensor for consistency with the distributed case.
-        return torch.tensor(val)
+        return torch.tensor(val, dtype=dtype)
 
-    t = torch.tensor(val, device="cuda")
-    dist.barrier()
-    dist.all_reduce(t)
+    backend = dist.get_backend()
+    backend_name = (
+        backend if isinstance(backend, str) else getattr(backend, "value", str(backend))
+    )
+    if "nccl" in backend_name.lower():
+        device = torch.device("cuda", torch.cuda.current_device())
+    else:
+        device = torch.device("cpu")
+    t = torch.tensor(val, device=device, dtype=dtype)
+    dist.all_reduce(t, op=op)
     return t

--- a/spikingjelly/activation_based/model/tv_ref_classify/utils.py
+++ b/spikingjelly/activation_based/model/tv_ref_classify/utils.py
@@ -92,12 +92,28 @@ class ThroughputValue:
         self.total_time += elapsed_time
 
     def synchronize_between_processes(self):
-        """Synchronize cumulative samples/time across ranks.
+        """Synchronize cumulative throughput statistics across ranks.
 
-        ``total_samples`` is reduced with ``SUM`` across all ranks, while
-        ``total_time`` is reduced with ``MAX`` so global throughput is computed
-        as ``sum(samples) / max(elapsed_time)``. Windowed statistics stored in
-        ``deque`` remain local to each rank.
+        Chinese:
+            同步跨进程的累计吞吐统计量。
+
+        English:
+            Synchronize cumulative throughput statistics across distributed ranks.
+
+        :return: EN: ``None``. Chinese: 无返回值。
+        :rtype: None
+
+        .. note::
+
+            English: ``total_samples`` is reduced with ``SUM`` across ranks,
+            while ``total_time`` is reduced with ``MAX`` so global throughput is
+            computed as ``sum(samples) / max(elapsed_time)``. Windowed
+            statistics stored in ``deque`` remain local to each rank.
+
+            Chinese: ``total_samples`` 会在各 rank 间执行 ``SUM`` 归约,
+            ``total_time`` 会执行 ``MAX`` 归约, 因此全局吞吐被定义为
+            ``sum(samples) / max(elapsed_time)``。保存在 ``deque`` 中的窗口统计
+            仍然保持各 rank 本地独立。
         """
         if not is_dist_avail_and_initialized():
             return
@@ -517,15 +533,15 @@ def reduce_across_processes(
     dtype: Optional[torch.dtype] = None,
 ) -> torch.Tensor:
     """EN: Reduce a scalar, tensor, or number sequence across distributed processes.
-    中文：对标量、张量或数字序列在分布式进程间执行归约。
+    Chinese: 对标量、张量或数字序列在分布式进程间执行归约。
 
-    :param val: EN: Value to reduce. 中文：待归约的值。
+    :param val: EN: Value to reduce. Chinese: 待归约的值。
     :type val: Union[int, float, torch.Tensor, Sequence[Number]]
-    :param op: EN: Reduction operator, defaulting to SUM. 中文：归约操作符，默认为 SUM。
+    :param op: EN: Reduction operator, defaulting to SUM. Chinese: 归约操作符, 默认为 SUM。
     :type op: torch.distributed.ReduceOp
-    :param dtype: EN: Optional output tensor dtype. 中文：可选的输出张量数据类型。
+    :param dtype: EN: Optional output tensor dtype. Chinese: 可选的输出张量数据类型。
     :type dtype: Optional[torch.dtype]
-    :return: EN: Reduced tensor placed on the backend-appropriate device. 中文：位于当前后端对应设备上的归约结果张量。
+    :return: EN: Reduced tensor placed on the backend-appropriate device. Chinese: 位于当前后端对应设备上的归约结果张量。
     :rtype: torch.Tensor
     """
     if not is_dist_avail_and_initialized():

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -1149,6 +1149,10 @@ class FlexSN(base.MemoryModule):
             can_elide_zero_states = (
                 self.states is None and _can_elide_zero_state_inputs(self)
             )
+            # The first init_states branch handles the case where zero-state elision
+            # is impossible. _no_grad then determines whether use_implicit_zero_states
+            # can skip explicit state tensors entirely. The second init_states branch
+            # only runs if self.states is still None, so re-initialization cannot occur.
             if self.states is None and not can_elide_zero_states:
                 self.states = self.init_states(self.num_states, self.step_mode, *args)
             _no_grad = not torch.is_grad_enabled() or (

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -316,6 +316,14 @@ def _make_output_template_specs_from_outputs(
     return tuple(specs)
 
 
+def _runtime_output_template_specs(
+    output_template_specs: Optional[Tuple[Tuple, ...]],
+) -> Optional[Tuple[Tuple, ...]]:
+    if output_template_specs is None:
+        return None
+    return tuple((tuple(shape), dtype) for shape, dtype, *_ in output_template_specs)
+
+
 def _validate_scan_backend_output_template_specs(
     output_template_specs: Optional[Tuple[Tuple, ...]],
     example_inputs: Optional[Tuple[torch.Tensor, ...]],
@@ -736,7 +744,9 @@ class FlexSN(base.MemoryModule):
             num_outputs,
             example_outputs,
         )
-        self._output_template_specs = self._explicit_output_template_specs
+        self._output_template_specs = _runtime_output_template_specs(
+            self._explicit_output_template_specs
+        )
 
         if backend in ("triton", "inductor"):
             _validate_scan_backend_output_template_specs(

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -641,9 +641,12 @@ class FlexSN(base.MemoryModule):
             ``state_seqs`` 是个列表，每个元素是形状为 ``[T, ...]`` 的张量。默认 ``False``。
         :type store_state_seqs: bool
 
-        :param example_outputs: ``core`` 的单步输出模板，形式为 ``[*outputs]``。
-            在空序列输入时用于构造输出张量的形状和 dtype，避免为了推断输出而执行 ``core``。
-            默认为 ``None``。
+        :param example_outputs: ``core`` 的单步输出模板，形式为 ``tuple([*outputs])``。
+            当 ``backend="torch"`` 且输入为空序列 ``T == 0`` 时, 需要用它来构造输出张量的
+            形状和 dtype, 从而避免为了推断输出而执行 ``core``。对于 scan 后端
+            (``"triton"``, ``"inductor"``, ``"hop"``), 若提供该参数, 每个模板张量都必须与
+            第一个 ``example_inputs`` 张量的单步形状和 dtype 相匹配。若不需要空序列模板,
+            则可以为 ``None``。默认 ``None``。
         :type example_outputs: Optional[Tuple[torch.Tensor]]
 
         ----
@@ -707,8 +710,12 @@ class FlexSN(base.MemoryModule):
         :type store_state_seqs: bool
 
         :param example_outputs: per-step output templates for ``core`` with the form of
-            ``[*outputs]``. They provide the empty-sequence output shapes and dtypes
-            without executing ``core`` for shape inference. Defaults to ``None``.
+            ``tuple([*outputs])``. When ``backend="torch"`` and the input sequence is
+            empty (``T == 0``), these templates are required to materialize output
+            shapes and dtypes without executing ``core``. For scan backends
+            (``"triton"``, ``"inductor"``, ``"hop"``), each provided template must match
+            the first ``example_inputs`` tensor's per-step shape and dtype. Defaults to
+            ``None`` when empty-sequence output templates are not needed.
         :type example_outputs: Optional[Tuple[torch.Tensor]]
         """
         super().__init__()

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -432,6 +432,23 @@ def _validate_scan_backend_contract(
         device = example_inputs[0].device
         example_inputs = tuple(x.detach().to(device).clone() for x in example_inputs)
 
+    seq_template = example_inputs[0]
+    for i, tensor in enumerate(example_inputs[1:], start=1):
+        if tensor.numel() != seq_template.numel():
+            raise ValueError(
+                "FlexSN triton/inductor scan backends currently require every "
+                "example input and state tensor to have the same number of "
+                f"elements as the first example tensor ({seq_template.numel()}), "
+                f"but example #{i} has {tensor.numel()} elements."
+            )
+        if tensor.dtype != seq_template.dtype:
+            raise ValueError(
+                "FlexSN triton/inductor scan backends currently require every "
+                "example input and state tensor to match the first example "
+                f"tensor's dtype ({seq_template.dtype}), but example #{i} has "
+                f"dtype {tensor.dtype}."
+            )
+
     with torch.no_grad():
         returns = _as_tuple(core(*example_inputs))
 
@@ -442,7 +459,6 @@ def _validate_scan_backend_contract(
             f"{expected} (= num_outputs + num_states)."
         )
 
-    seq_template = example_inputs[0]
     for i, tensor in enumerate(returns):
         if not isinstance(tensor, torch.Tensor):
             raise TypeError(

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -1,4 +1,6 @@
 import copy
+import contextlib
+import functools
 import os
 from typing import Callable, Optional, Tuple, List
 import logging
@@ -9,7 +11,7 @@ from .. import base
 
 try:
     from .. import triton_kernel
-except BaseException as e:
+except (ImportError, AttributeError) as e:
     logging.info(f"spikingjelly.activation_based.neuron: {e}")
     triton_kernel = None
 
@@ -33,9 +35,12 @@ try:
         lowerable_scan_available as _flexsn_lowerable_scan_available,
     )
     from ..triton_kernel.flex_sn_inductor import (
+        dynamo_hop_available as _flexsn_dynamo_hop_available,
+    )
+    from ..triton_kernel.flex_sn_inductor import (
         lowerable_while_loop_available as _flexsn_lowerable_while_loop_available,
     )
-except BaseException as e:
+except (ImportError, AttributeError) as e:
     logging.info(f"spikingjelly.activation_based.neuron.flexsn: {e}")
     _flexsn_eager_scan = None
     _flexsn_eager_scan_final_state = None
@@ -43,6 +48,7 @@ except BaseException as e:
     _flexsn_lowerable_scan = None
     _flexsn_lowerable_scan_final_state = None
     _flexsn_lowerable_scan_available = None
+    _flexsn_dynamo_hop_available = None
     _flexsn_lowerable_while_loop_scan = None
     _flexsn_lowerable_while_loop_scan_final_state = None
     _flexsn_lowerable_while_loop_available = None
@@ -61,12 +67,29 @@ def _warmup_inductor_inference_final_state_kernel(module: "FlexSN") -> None:
     from ..triton_kernel.flexsn.wrapper import flexsn_inference_final_state
 
     info = module._inductor_scan_final_state_info
-    seq_template = torch.zeros((1, 1), device="cuda")
-    state_template = seq_template[0].clone()
-    warm_args = [seq_template.clone() for _ in range(info.num_inputs)]
-    warm_args.extend(state_template.clone() for _ in range(info.num_states))
+    device = getattr(module, "_inductor_scan_final_state_device", None)
+    if device is not None and device.type != "cuda":
+        device = None
+    if isinstance(module.core, torch.nn.Module):
+        if device is None:
+            for tensor in [*module.core.parameters(), *module.core.buffers()]:
+                if tensor.device.type == "cuda":
+                    device = tensor.device
+                    break
+    if device is None:
+        device = torch.device("cuda", torch.cuda.current_device())
+    warm_args = _make_inductor_final_state_warmup_args(
+        info,
+        device,
+        getattr(module, "_inductor_scan_final_state_warmup_specs", None),
+    )
 
-    with torch.no_grad():
+    device_guard = (
+        torch.cuda.device(device)
+        if device.type == "cuda"
+        else contextlib.nullcontext()
+    )
+    with torch.no_grad(), device_guard:
         flexsn_inference_final_state(
             module._inductor_scan_final_state_kernel,
             info,
@@ -74,24 +97,44 @@ def _warmup_inductor_inference_final_state_kernel(module: "FlexSN") -> None:
         )
 
 
-def _warmup_inductor_training_final_state_kernel(module: "FlexSN") -> None:
-    if module._inductor_handle is None or not module._inductor_training_available:
-        return
-
-    from ..triton_kernel.flex_sn_inductor.custom_ops import (
-        flexsn_inductor_training_final_state,
+def _make_inductor_final_state_warmup_specs(
+    example_inputs: Optional[Tuple[torch.Tensor, ...]],
+    expected: int,
+):
+    if example_inputs is None or len(example_inputs) < expected:
+        return None
+    return tuple(
+        (tuple(tensor.shape), tensor.dtype)
+        for tensor in example_inputs[:expected]
     )
 
-    info = module._inductor_train_info
-    seq_template = torch.zeros((1, 1), device="cuda")
-    warm_args = [seq_template.clone() for _ in range(info.num_inputs)]
 
-    with torch.enable_grad():
-        flat_args = [arg.requires_grad_(True) for arg in warm_args]
-        outputs = flexsn_inductor_training_final_state(module._inductor_handle, flat_args)
-        if outputs:
-            loss = sum(output.sum() for output in outputs if isinstance(output, torch.Tensor))
-            loss.backward()
+def _make_inductor_final_state_warmup_args(info, device, warmup_specs):
+    expected = info.num_inputs + info.num_states
+    if warmup_specs is not None and len(warmup_specs) >= expected:
+        warm_args = [
+            torch.zeros((1, *shape), dtype=dtype, device=device)
+            for shape, dtype in warmup_specs[: info.num_inputs]
+        ]
+        warm_args.extend(
+            torch.zeros(shape, dtype=dtype, device=device)
+            for shape, dtype in warmup_specs[info.num_inputs : expected]
+        )
+        return warm_args
+
+    seq_template = torch.zeros((1, 1), device=device)
+    state_template = seq_template[0].clone()
+    warm_args = [seq_template.clone() for _ in range(info.num_inputs)]
+    warm_args.extend(state_template.clone() for _ in range(info.num_states))
+    return warm_args
+
+
+def _first_cuda_device(tensors):
+    if tensors is not None:
+        for tensor in tensors:
+            if isinstance(tensor, torch.Tensor) and tensor.device.type == "cuda":
+                return tensor.device
+    return None
 
 
 def _as_tuple(outputs):
@@ -114,106 +157,6 @@ def _is_compiling() -> bool:
     return False
 
 
-def _get_inductor_segment_steps() -> int:
-    raw = os.environ.get("SJ_FLEXSN_INDUCTOR_SEGMENT_T", "0")
-    try:
-        steps = int(raw)
-    except ValueError:
-        logging.warning(
-            "FlexSN: invalid SJ_FLEXSN_INDUCTOR_SEGMENT_T=%r; segmented scan is disabled.",
-            raw,
-        )
-        return 0
-    return steps if steps > 0 else 0
-
-
-def _concat_segmented_results(segment_results: List[List[torch.Tensor]]) -> List[torch.Tensor]:
-    if not segment_results:
-        return []
-    merged = []
-    for idx in range(len(segment_results[0])):
-        pieces = [segment[idx] for segment in segment_results]
-        merged.append(pieces[0] if len(pieces) == 1 else torch.cat(pieces, dim=0))
-    return merged
-
-
-def _run_inductor_segmented_scan(
-    module: "FlexSN",
-    args: Tuple[torch.Tensor, ...],
-    *,
-    use_implicit_zero_states: bool,
-    no_grad: bool,
-):
-    segment_steps = _get_inductor_segment_steps()
-    if segment_steps <= 0:
-        return None, module.store_state_seqs
-
-    total_steps = args[0].shape[0]
-    if total_steps <= segment_steps:
-        return None, module.store_state_seqs
-
-    from ..triton_kernel.flex_sn_inductor.custom_ops import (
-        flexsn_inductor_inference,
-        flexsn_inductor_inference_final_state,
-        flexsn_inductor_training,
-        flexsn_inductor_training_final_state,
-    )
-
-    segmented_results: List[List[torch.Tensor]] = []
-    current_states = None if use_implicit_zero_states else list(module.states)
-    result_has_state_seqs = module.store_state_seqs
-
-    for start in range(0, total_steps, segment_steps):
-        end = min(start + segment_steps, total_steps)
-        chunk_args = [arg[start:end] for arg in args]
-        flat_args = [*chunk_args]
-        if current_states is not None:
-            flat_args.extend(current_states)
-
-        if no_grad:
-            if not module.store_state_seqs and module._inductor_inference_final_state_available:
-                chunk_result = list(
-                    flexsn_inductor_inference_final_state(module._inductor_handle, flat_args)
-                )
-                segmented_results.append(list(chunk_result[: module.num_outputs]))
-                current_states = list(chunk_result[module.num_outputs :])
-                result_has_state_seqs = False
-                continue
-            if not module._inductor_inference_available:
-                return None, module.store_state_seqs
-            chunk_result = list(flexsn_inductor_inference(module._inductor_handle, flat_args))
-            chunk_result = chunk_result[: module.num_outputs + module.num_states]
-            result_has_state_seqs = True
-        else:
-            if not module._inductor_training_available:
-                return None, module.store_state_seqs
-            if not module.store_state_seqs:
-                chunk_result = list(
-                    flexsn_inductor_training_final_state(module._inductor_handle, flat_args)
-                )
-                segmented_results.append(list(chunk_result[: module.num_outputs]))
-                current_states = list(
-                    chunk_result[module.num_outputs : module.num_outputs + module.num_states]
-                )
-                result_has_state_seqs = False
-                continue
-            chunk_result = list(flexsn_inductor_training(module._inductor_handle, flat_args))
-            chunk_result = chunk_result[: module.num_outputs + module.num_states]
-            result_has_state_seqs = True
-
-        segmented_results.append(chunk_result)
-        chunk_state_seqs = chunk_result[module.num_outputs :]
-        current_states = [state_seq[-1] for state_seq in chunk_state_seqs]
-
-    if not segmented_results:
-        return None, module.store_state_seqs
-
-    merged_results = _concat_segmented_results(segmented_results)
-    if result_has_state_seqs:
-        return merged_results, True
-    return [*merged_results, *(current_states or [])], False
-
-
 def _run_hop_scan(
     core: Callable,
     num_inputs: int,
@@ -221,7 +164,18 @@ def _run_hop_scan(
     num_outputs: int,
     store_state_seqs: bool,
     *flat_args: torch.Tensor,
+    output_template_specs=None,
 ):
+    enable_lowerable_while_loop = (
+        os.environ.get("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP", "0") == "1"
+    )
+    enable_lowerable_scan = (
+        os.environ.get("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_SCAN", "0") == "1"
+    )
+    is_compiling = _is_compiling()
+    # flex_sn_inductor imports HOP helpers as an all-or-none group and sets all
+    # of them to None on failure, so _flexsn_eager_scan is the availability
+    # sentinel for this backend family.
     if _flexsn_eager_scan is None:
         raise RuntimeError(
             "FlexSN HOP backend is unavailable: eager_scan failed to import. "
@@ -229,52 +183,68 @@ def _run_hop_scan(
             "spikingjelly.activation_based.triton_kernel.flex_sn_inductor."
         )
 
+    lowerable_while_loop_impl = (
+        _flexsn_lowerable_while_loop_scan
+        if store_state_seqs
+        else _flexsn_lowerable_while_loop_scan_final_state
+    )
+    lowerable_scan_impl = (
+        _flexsn_lowerable_scan
+        if store_state_seqs
+        else _flexsn_lowerable_scan_final_state
+    )
     use_lowerable_while_loop = (
-        _is_compiling()
-        and _flexsn_lowerable_while_loop_scan is not None
+        is_compiling
+        and lowerable_while_loop_impl is not None
         and callable(_flexsn_lowerable_while_loop_available)
         and _flexsn_lowerable_while_loop_available()
         and (not torch.is_grad_enabled())
-        and os.getenv("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP", "0") == "1"
+        and enable_lowerable_while_loop
     )
     use_lowerable_scan = (
-        _is_compiling()
-        and _flexsn_lowerable_scan is not None
+        is_compiling
+        and lowerable_scan_impl is not None
         and callable(_flexsn_lowerable_scan_available)
         and _flexsn_lowerable_scan_available()
         and (not torch.is_grad_enabled())
-        and os.getenv("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_SCAN", "0") == "1"
+        and enable_lowerable_scan
     )
 
     if use_lowerable_while_loop:
-        scan_impl = (
-            _flexsn_lowerable_while_loop_scan
-            if store_state_seqs
-            else _flexsn_lowerable_while_loop_scan_final_state
-        )
+        scan_impl = lowerable_while_loop_impl
     elif use_lowerable_scan:
-        scan_impl = (
-            _flexsn_lowerable_scan
-            if store_state_seqs
-            else _flexsn_lowerable_scan_final_state
+        scan_impl = lowerable_scan_impl
+    elif (
+        _flexsn_hop_scan is not None
+        and store_state_seqs
+        and (
+            not is_compiling
+            or (
+                callable(_flexsn_dynamo_hop_available)
+                and _flexsn_dynamo_hop_available()
+            )
         )
-    elif _is_compiling() or _flexsn_hop_scan is None:
-        scan_impl = (
-            _flexsn_eager_scan
-            if store_state_seqs
-            else _flexsn_eager_scan_final_state
-        )
+    ):
+        scan_impl = _flexsn_hop_scan
     elif not store_state_seqs:
         scan_impl = _flexsn_eager_scan_final_state
     else:
-        scan_impl = _flexsn_hop_scan
+        scan_impl = _flexsn_eager_scan
+    if scan_impl is None:
+        raise RuntimeError("FlexSN HOP backend has no available scan implementation.")
 
+    template_kwargs = (
+        {}
+        if output_template_specs is None
+        else {"output_template_specs": output_template_specs}
+    )
     return scan_impl(
         core,
         num_inputs,
         num_states,
         num_outputs,
         *flat_args,
+        **template_kwargs,
     )
 
 
@@ -285,6 +255,157 @@ def _can_elide_zero_state_inputs(module: "FlexSN") -> bool:
         and module._memories_rv.get("states") is None
         and module.__class__.init_states is FlexSN.init_states
     )
+
+
+def _last_state_or_current(
+    state_seq: torch.Tensor,
+    current_state: torch.Tensor,
+) -> torch.Tensor:
+    return current_state if state_seq.shape[0] == 0 else state_seq[-1]
+
+
+def _empty_multistep_outputs(
+    args: Tuple[torch.Tensor, ...],
+    states: List[torch.Tensor],
+    num_outputs: int,
+    output_template_specs: Optional[Tuple[Tuple, ...]] = None,
+    *,
+    use_template_device: bool = True,
+) -> List[torch.Tensor]:
+    def _empty_output(i: int) -> torch.Tensor:
+        if output_template_specs is not None and i < len(output_template_specs):
+            spec = output_template_specs[i]
+            if len(spec) == 2:
+                shape, dtype = spec
+                device = args[0].device
+            else:
+                shape, dtype, template_device = spec
+                device = template_device if use_template_device else args[0].device
+            return torch.empty((0, *shape), dtype=dtype, device=device)
+        if args:
+            ref = args[0].new_empty(args[0].shape[1:])
+        elif states:
+            ref = states[-1]
+        else:
+            raise ValueError(
+                "FlexSN empty output fallback requires at least one input or state."
+            )
+        return ref.new_empty((0, *ref.shape))
+
+    return [_empty_output(i) for i in range(num_outputs)]
+
+
+def _make_output_template_specs_from_outputs(
+    num_outputs: int,
+    example_outputs: Optional[Tuple[torch.Tensor, ...]],
+) -> Optional[Tuple[Tuple, ...]]:
+    if example_outputs is None:
+        return None
+    if len(example_outputs) != num_outputs:
+        raise ValueError(
+            f"FlexSN expected {num_outputs} example output tensors, but got "
+            f"{len(example_outputs)}."
+        )
+    specs = []
+    for i, tensor in enumerate(example_outputs):
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(
+                f"FlexSN example output #{i} is {type(tensor)!r}; expected a tensor."
+            )
+        specs.append((tuple(tensor.shape), tensor.dtype, tensor.device))
+    return tuple(specs)
+
+
+def _validate_scan_backend_output_template_specs(
+    output_template_specs: Optional[Tuple[Tuple, ...]],
+    example_inputs: Optional[Tuple[torch.Tensor, ...]],
+) -> None:
+    if output_template_specs is None or example_inputs is None:
+        return
+    seq_template = example_inputs[0]
+    expected_shape = tuple(seq_template.shape)
+    expected_dtype = seq_template.dtype
+    for i, spec in enumerate(output_template_specs):
+        shape, dtype = spec[:2]
+        if tuple(shape) != expected_shape or dtype != expected_dtype:
+            raise ValueError(
+                "FlexSN triton/inductor scan backends require example_outputs "
+                "to match the first example input's per-step shape and dtype "
+                f"({expected_shape}, {expected_dtype}), but example output "
+                f"#{i} is ({tuple(shape)}, {dtype})."
+            )
+
+
+def _core_requires_grad(core: Callable) -> bool:
+    if isinstance(core, functools.partial):
+        return (
+            _core_requires_grad(core.func)
+            or _value_requires_grad(core.args)
+            or _value_requires_grad(core.keywords)
+        )
+
+    bound_self = getattr(core, "__self__", None)
+    if bound_self is not None and _value_requires_grad(bound_self):
+        return True
+    if bound_self is not None:
+        bound_self_dict = getattr(bound_self, "__dict__", None)
+        if bound_self_dict is not None:
+            values = bound_self_dict.values()
+            if isinstance(bound_self, torch.nn.Module):
+                values = (
+                    value
+                    for key, value in bound_self_dict.items()
+                    if key not in {"_parameters", "_buffers", "_modules"}
+                )
+            if any(_value_requires_grad(value) for value in values):
+                return True
+
+    if isinstance(core, torch.nn.Module):
+        for tensor in [*core.parameters(), *core.buffers()]:
+            if tensor.requires_grad:
+                return True
+
+    if callable(core) and not hasattr(core, "__code__"):
+        core_dict = getattr(core, "__dict__", None)
+        if core_dict is not None:
+            for value in core_dict.values():
+                if _value_requires_grad(value):
+                    return True
+
+    closure = getattr(core, "__closure__", None)
+    if closure is None:
+        return False
+    for cell in closure:
+        try:
+            cell_value = cell.cell_contents
+        except ValueError:
+            continue
+        if _value_requires_grad(cell_value):
+            return True
+    return False
+
+
+def _value_requires_grad(value) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, torch.Tensor):
+        return value.requires_grad
+    if isinstance(value, torch.nn.Module):
+        return any(
+            tensor.requires_grad
+            for tensor in [*value.parameters(), *value.buffers()]
+        )
+    if isinstance(value, functools.partial):
+        return (
+            _core_requires_grad(value.func)
+            or _value_requires_grad(value.args)
+            or _value_requires_grad(value.keywords)
+        )
+    if isinstance(value, dict):
+        return any(_value_requires_grad(v) for v in value.values())
+    if isinstance(value, (tuple, list)):
+        return any(_value_requires_grad(v) for v in value)
+    return False
 
 
 def _validate_scan_backend_contract(
@@ -322,21 +443,6 @@ def _validate_scan_backend_contract(
         )
 
     seq_template = example_inputs[0]
-    for i, tensor in enumerate(example_inputs[1:], start=1):
-        if tensor.shape != seq_template.shape:
-            raise ValueError(
-                "FlexSN triton/inductor scan backends currently require every "
-                "example input/state tensor to have the same shape as the "
-                f"first example tensor {tuple(seq_template.shape)}, but input #{i} "
-                f"has shape {tuple(tensor.shape)}."
-            )
-        if tensor.dtype != seq_template.dtype or tensor.device != seq_template.device:
-            raise ValueError(
-                "FlexSN triton/inductor scan backends currently require every "
-                "example input/state tensor to match the first example tensor's "
-                f"dtype/device ({seq_template.dtype}, {seq_template.device}), but "
-                f"input #{i} is ({tensor.dtype}, {tensor.device})."
-            )
     for i, tensor in enumerate(returns):
         if not isinstance(tensor, torch.Tensor):
             raise TypeError(
@@ -468,6 +574,7 @@ class FlexSN(base.MemoryModule):
         step_mode: str = "m",
         backend: str = "triton",
         store_state_seqs: bool = False,
+        example_outputs: Optional[Tuple[torch.Tensor]] = None,
     ):
         """
         **API Language:**
@@ -511,12 +618,17 @@ class FlexSN(base.MemoryModule):
         :type step_mode: str
 
         :param backend: 使用的后端。``"triton"``、``"inductor"`` 和 ``"hop"`` 仅在
-            ``step_mode="m"`` 时可用；``"torch"`` 始终可用。默认 ``"triton"``。
+            ``step_mode="m"`` 时可用; ``"torch"`` 始终可用。默认 ``"triton"``。
         :type backend: str
 
         :param store_state_seqs: 是否保存状态序列。如果为 ``True``，用户可以通过 ``state_seqs`` 属性访问。
             ``state_seqs`` 是个列表，每个元素是形状为 ``[T, ...]`` 的张量。默认 ``False``。
         :type store_state_seqs: bool
+
+        :param example_outputs: ``core`` 的单步输出模板，形式为 ``[*outputs]``。
+            在空序列输入时用于构造输出张量的形状和 dtype，避免为了推断输出而执行 ``core``。
+            默认为 ``None``。
+        :type example_outputs: Optional[Tuple[torch.Tensor]]
 
         ----
 
@@ -577,6 +689,11 @@ class FlexSN(base.MemoryModule):
             ``state_seqs`` is a list of tensors with shape ``[T, ...]``. Defaults
             to ``False``.
         :type store_state_seqs: bool
+
+        :param example_outputs: per-step output templates for ``core`` with the form of
+            ``[*outputs]``. They provide the empty-sequence output shapes and dtypes
+            without executing ``core`` for shape inference. Defaults to ``None``.
+        :type example_outputs: Optional[Tuple[torch.Tensor]]
         """
         super().__init__()
         self.core = core
@@ -586,11 +703,37 @@ class FlexSN(base.MemoryModule):
         self.step_mode = step_mode
         self.backend = backend
         self.store_state_seqs = store_state_seqs
+        self._inductor_scan_final_state_warmup_specs = (
+            _make_inductor_final_state_warmup_specs(
+                example_inputs,
+                num_inputs + num_states,
+            )
+        )
+        self._explicit_output_template_specs = _make_output_template_specs_from_outputs(
+            num_outputs,
+            example_outputs,
+        )
+        self._output_template_specs = self._explicit_output_template_specs
 
-        if backend in ("triton", "inductor", "hop"):
+        if backend in ("triton", "inductor"):
+            _validate_scan_backend_output_template_specs(
+                self._explicit_output_template_specs,
+                example_inputs,
+            )
             _validate_scan_backend_contract(
                 core, num_inputs, num_states, num_outputs, example_inputs
             )
+        elif backend == "hop":
+            if _flexsn_eager_scan is None:
+                raise ImportError(
+                    "FlexSN backend='hop' is unavailable: missing _flexsn_eager_scan."
+                )
+            if num_inputs + num_states == 0:
+                raise ValueError("FlexSN requires at least one input or state tensor.")
+            if num_inputs == 0:
+                raise ValueError(
+                    "FlexSN HOP backend requires at least one input sequence to derive T."
+                )
 
         if backend == "triton":
             self.kernel = FlexSNKernel(
@@ -601,6 +744,9 @@ class FlexSN(base.MemoryModule):
         register_flexsn_kernel_handle = None
 
         if backend == "inductor" and torch.cuda.is_available():
+            self._inductor_scan_final_state_device = _first_cuda_device(
+                example_inputs
+            ) or torch.device("cuda", torch.cuda.current_device())
             try:
                 from ..triton_kernel.flex_sn_inductor.kernel import (
                     build_inference_kernel, build_inference_final_state_kernel, build_training_kernels,
@@ -636,20 +782,18 @@ class FlexSN(base.MemoryModule):
                         build_inference_final_state_kernel(core, num_inputs, num_states, num_outputs, example_inputs=example_inputs)
                     )
                 except Exception as e:
+                    # Triton/CUDA/driver compilation failures surface through
+                    # several exception types; any failure here can safely fall
+                    # back to the already-built regular inference path.
                     logging.warning(
-                        "FlexSN: could not build inductor inference-final-state kernel (%s); "
-                        "store_state_seqs=False inference falls back to the regular inference kernel." % e
+                        "FlexSN: could not build inductor inference-final-state kernel (%s: %s); "
+                        "store_state_seqs=False inference falls back to the regular inference kernel."
+                        % (type(e).__name__, e)
                     )
                     self._inductor_scan_final_state_kernel = None
                     self._inductor_scan_final_state_info = None
                 try:
-                    (
-                        self._inductor_fwd_kernel,
-                        self._inductor_fwd_final_state_kernel,
-                        self._inductor_bwd_kernel,
-                        self._inductor_bwd_final_state_kernel,
-                        self._inductor_train_info,
-                    ) = (
+                    self._inductor_fwd_kernel, self._inductor_bwd_kernel, self._inductor_train_info = (
                         build_training_kernels(core, num_inputs, num_states, num_outputs, example_inputs=example_inputs)
                     )
                 except Exception as e:
@@ -658,9 +802,7 @@ class FlexSN(base.MemoryModule):
                         "training falls back to eager_scan." % e
                     )
                     self._inductor_fwd_kernel = None
-                    self._inductor_fwd_final_state_kernel = None
                     self._inductor_bwd_kernel = None
-                    self._inductor_bwd_final_state_kernel = None
                     self._inductor_train_info = None
             else:
                 self._inductor_scan_kernel = None
@@ -668,19 +810,16 @@ class FlexSN(base.MemoryModule):
                 self._inductor_scan_final_state_kernel = None
                 self._inductor_scan_final_state_info = None
                 self._inductor_fwd_kernel = None
-                self._inductor_fwd_final_state_kernel = None
                 self._inductor_bwd_kernel = None
-                self._inductor_bwd_final_state_kernel = None
                 self._inductor_train_info = None
         else:
             self._inductor_scan_kernel = None
             self._inductor_scan_info = None
             self._inductor_scan_final_state_kernel = None
             self._inductor_scan_final_state_info = None
+            self._inductor_scan_final_state_device = None
             self._inductor_fwd_kernel = None
-            self._inductor_fwd_final_state_kernel = None
             self._inductor_bwd_kernel = None
-            self._inductor_bwd_final_state_kernel = None
             self._inductor_train_info = None
         self._inductor_handle = None
         self._inductor_inference_available = (
@@ -699,25 +838,20 @@ class FlexSN(base.MemoryModule):
         if (
             backend == "inductor"
             and register_flexsn_kernel_handle is not None
-            and (self._inductor_inference_available or self._inductor_training_available)
+            and (
+                self._inductor_inference_available
+                or self._inductor_inference_final_state_available
+                or self._inductor_training_available
+            )
         ):
-            state_template_specs = None
-            if example_inputs is not None:
-                state_template_specs = tuple(
-                    (tuple(t.shape), t.dtype, t.device)
-                    for t in example_inputs[num_inputs : num_inputs + num_states]
-                )
             self._inductor_handle = register_flexsn_kernel_handle(
                 inference_kernel=self._inductor_scan_kernel,
                 inference_info=self._inductor_scan_info,
                 inference_final_state_kernel=self._inductor_scan_final_state_kernel,
                 inference_final_state_info=self._inductor_scan_final_state_info,
                 forward_kernel=self._inductor_fwd_kernel,
-                forward_final_state_kernel=self._inductor_fwd_final_state_kernel,
                 backward_kernel=self._inductor_bwd_kernel,
-                backward_final_state_kernel=self._inductor_bwd_final_state_kernel,
                 training_info=self._inductor_train_info,
-                state_template_specs=state_template_specs,
             )
             self._inductor_handle_finalizer = attach_flexsn_handle_finalizer(
                 self, self._inductor_handle
@@ -727,20 +861,14 @@ class FlexSN(base.MemoryModule):
                     _warmup_inductor_inference_final_state_kernel(self)
                 except Exception as e:
                     logging.warning(
-                        "FlexSN: could not warm up inductor inference-final-state kernel (%s); "
-                        "falling back to the regular inference kernel for store_state_seqs=False." % e
+                        "FlexSN: could not warm up inductor inference-final-state "
+                        "kernel (%s: %s); falling back to the regular inference "
+                        "kernel for store_state_seqs=False."
+                        % (type(e).__name__, e)
                     )
                     self._inductor_scan_final_state_kernel = None
                     self._inductor_scan_final_state_info = None
                     self._inductor_inference_final_state_available = False
-            if self._inductor_training_available:
-                try:
-                    _warmup_inductor_training_final_state_kernel(self)
-                except Exception as e:
-                    logging.warning(
-                        "FlexSN: could not warm up inductor training-final-state kernel (%s); "
-                        "training will compile it lazily on first use." % e
-                    )
         else:
             self._inductor_handle_finalizer = None
 
@@ -852,7 +980,9 @@ class FlexSN(base.MemoryModule):
         if step_mode == "s":
             return [torch.zeros_like(args[0]) for _ in range(num_states)]
         elif step_mode == "m":
-            return [torch.zeros_like(args[0][0]) for _ in range(num_states)]
+            if args[0].shape[0] > 0:
+                return [torch.zeros_like(args[0][0]) for _ in range(num_states)]
+            return [args[0].new_zeros(args[0].shape[1:]) for _ in range(num_states)]
         else:
             raise ValueError(f"Unsupported step mode: {step_mode}")
 
@@ -863,8 +993,61 @@ class FlexSN(base.MemoryModule):
         return results[: self.num_outputs]
 
     def multi_step_forward(self, *args):
+        T = args[0].shape[0]
+        if T == 0:
+            if self.backend not in self.supported_backends:
+                raise ValueError(f"Unsupported backend: {self.backend}")
+            if self.states is None:
+                self.states = self.init_states(self.num_states, self.step_mode, *args)
+            if self.backend == "hop":
+                state_args = [state.contiguous() for state in self.states]
+                result_seqs = _run_hop_scan(
+                    self.core,
+                    self.num_inputs,
+                    self.num_states,
+                    self.num_outputs,
+                    self.store_state_seqs,
+                    *args,
+                    *state_args,
+                    output_template_specs=self._output_template_specs,
+                )
+                output_seqs = list(result_seqs[: self.num_outputs])
+                state_results = list(result_seqs[self.num_outputs :])
+                if self.store_state_seqs:
+                    self.state_seqs = state_results
+                    self.states = [
+                        _last_state_or_current(v, self.states[i])
+                        for i, v in enumerate(state_results)
+                    ]
+                else:
+                    self.states = state_results
+                return output_seqs
+            if (
+                self.backend == "torch"
+                and self.num_outputs > 0
+                and self._output_template_specs is None
+            ):
+                raise ValueError(
+                    f"FlexSN backend='{self.backend}' requires example_outputs "
+                    "for empty multi-step inputs so output shapes and dtypes "
+                    "match core's per-step return contract without executing core."
+                )
+            output_seqs = _empty_multistep_outputs(
+                args,
+                self.states,
+                self.num_outputs,
+                self._output_template_specs,
+                use_template_device=False,
+            )
+            if self.store_state_seqs:
+                self.state_seqs = [
+                    s.new_empty((0, *s.shape)) for s in self.states
+                ]
+            return output_seqs
+
         if self.backend == "torch":
-            T = args[0].shape[0]
+            if self.states is None:
+                self.states = self.init_states(self.num_states, self.step_mode, *args)
             output_seqs = [[] for _ in range(self.num_outputs)]
             if self.store_state_seqs:
                 state_seqs = [[] for _ in range(self.num_states)]
@@ -883,15 +1066,23 @@ class FlexSN(base.MemoryModule):
             return [torch.stack(y, dim=0) for y in output_seqs]
 
         elif self.backend == "triton":
+            if self.states is None:
+                self.states = self.init_states(self.num_states, self.step_mode, *args)
             result_seqs = self.kernel(*args, *self.states)
             output_seqs = result_seqs[: self.num_outputs]
             state_seqs = result_seqs[self.num_outputs :]
-            self.states = [v[-1] for v in state_seqs]
+            self.states = [
+                _last_state_or_current(v, self.states[i])
+                for i, v in enumerate(state_seqs)
+            ]
             if self.store_state_seqs:
                 self.state_seqs = state_seqs
             return output_seqs
 
         elif self.backend == "hop":
+            if self.states is None:
+                self.states = self.init_states(self.num_states, self.step_mode, *args)
+            state_args = [state.contiguous() for state in self.states]
             result_seqs = _run_hop_scan(
                 self.core,
                 self.num_inputs,
@@ -899,13 +1090,17 @@ class FlexSN(base.MemoryModule):
                 self.num_outputs,
                 self.store_state_seqs,
                 *args,
-                *self.states,
+                *state_args,
+                output_template_specs=self._output_template_specs,
             )
             output_seqs = list(result_seqs[: self.num_outputs])
             state_results = list(result_seqs[self.num_outputs :])
             if self.store_state_seqs:
                 state_seqs = state_results
-                self.states = [v[-1] for v in state_seqs]
+                self.states = [
+                    _last_state_or_current(v, self.states[i])
+                    for i, v in enumerate(state_seqs)
+                ]
                 self.state_seqs = state_seqs
             else:
                 self.states = state_results
@@ -913,77 +1108,74 @@ class FlexSN(base.MemoryModule):
 
         elif self.backend == "inductor":
             result_has_state_seqs = self.store_state_seqs
-            _no_grad = not torch.is_grad_enabled() or not any(
-                a.requires_grad for a in (
-                    *args,
-                    *([] if self.states is None else self.states),
-                )
+            can_elide_zero_states = (
+                self.states is None and _can_elide_zero_state_inputs(self)
             )
-            use_implicit_zero_states = (
-                self.states is None and _no_grad and _can_elide_zero_state_inputs(self)
+            if self.states is None and not can_elide_zero_states:
+                self.states = self.init_states(self.num_states, self.step_mode, *args)
+            _no_grad = not torch.is_grad_enabled() or (
+                not _value_requires_grad(args)
+                and not _value_requires_grad(self.states)
+                and not _core_requires_grad(self.core)
             )
+            use_implicit_zero_states = can_elide_zero_states and _no_grad
+            if self.states is None and not use_implicit_zero_states:
+                self.states = self.init_states(self.num_states, self.step_mode, *args)
             state_args = [] if use_implicit_zero_states else list(self.states)
             flat_args = [*args, *state_args]
             all_cuda = len(flat_args) > 0 and all(t.is_cuda for t in flat_args)
             same_device = len({t.device for t in flat_args}) == 1
             if self._inductor_handle is not None and all_cuda and same_device:
-                segmented_result, result_has_state_seqs = _run_inductor_segmented_scan(
-                    self,
-                    args,
-                    use_implicit_zero_states=use_implicit_zero_states,
-                    no_grad=_no_grad,
+                from ..triton_kernel.flex_sn_inductor.custom_ops import (
+                    flexsn_inductor_inference,
+                    flexsn_inductor_inference_final_state,
+                    flexsn_inductor_training,
+                    flexsn_inductor_training_final_state,
                 )
-                if segmented_result is not None:
-                    result_seqs = segmented_result
-                else:
-                    from ..triton_kernel.flex_sn_inductor.custom_ops import (
-                        flexsn_inductor_inference,
-                        flexsn_inductor_inference_final_state,
-                        flexsn_inductor_training,
-                        flexsn_inductor_training_final_state,
-                    )
 
-                    if _no_grad and self._inductor_inference_available:
-                        if (
-                            not self.store_state_seqs
-                            and self._inductor_inference_final_state_available
-                        ):
-                            result_seqs = flexsn_inductor_inference_final_state(
-                                self._inductor_handle, flat_args
-                            )
-                            output_seqs = list(result_seqs[: self.num_outputs])
-                            self.states = list(result_seqs[self.num_outputs :])
-                            return output_seqs
-                        else:
-                            result_seqs = flexsn_inductor_inference(
-                                self._inductor_handle, flat_args
-                            )
-                            result_has_state_seqs = True
-                    elif (not _no_grad) and self._inductor_training_available:
-                        if not self.store_state_seqs:
-                            result_seqs = flexsn_inductor_training_final_state(
-                                self._inductor_handle, flat_args
-                            )
-                            output_seqs = list(result_seqs[: self.num_outputs])
-                            self.states = list(
-                                result_seqs[
-                                    self.num_outputs : self.num_outputs + self.num_states
-                                ]
-                            )
-                            return output_seqs
-                        result_seqs = flexsn_inductor_training(
+                if _no_grad:
+                    if (
+                        not self.store_state_seqs
+                        and self._inductor_inference_final_state_available
+                    ):
+                        result_seqs = flexsn_inductor_inference_final_state(
                             self._inductor_handle, flat_args
                         )
-                        result_seqs = result_seqs[: self.num_outputs + self.num_states]
+                        output_seqs = list(result_seqs[: self.num_outputs])
+                        self.states = list(result_seqs[self.num_outputs :])
+                        return output_seqs
+                    elif self._inductor_inference_available:
+                        result_seqs = flexsn_inductor_inference(
+                            self._inductor_handle, flat_args
+                        )
                         result_has_state_seqs = True
                     else:
                         result_seqs = None
+                elif (not _no_grad) and self._inductor_training_available:
+                    if not self.store_state_seqs:
+                        result_seqs = flexsn_inductor_training_final_state(
+                            self._inductor_handle, flat_args
+                        )
+                        output_seqs = list(result_seqs[: self.num_outputs])
+                        self.states = list(
+                            result_seqs[
+                                self.num_outputs : self.num_outputs + self.num_states
+                            ]
+                        )
+                        return output_seqs
+                    result_seqs = flexsn_inductor_training(
+                        self._inductor_handle, flat_args
+                    )
+                    result_seqs = result_seqs[: self.num_outputs + self.num_states]
+                else:
+                    result_seqs = None
             else:
                 result_seqs = None
 
             if result_seqs is None:
                 if self.states is None:
                     self.states = self.init_states(self.num_states, self.step_mode, *args)
+                state_args = [state.contiguous() for state in self.states]
                 result_seqs = _run_hop_scan(
                     self.core,
                     self.num_inputs,
@@ -991,12 +1183,19 @@ class FlexSN(base.MemoryModule):
                     self.num_outputs,
                     self.store_state_seqs,
                     *args,
-                    *self.states,
+                    *state_args,
+                    output_template_specs=self._output_template_specs,
                 )
+                result_has_state_seqs = self.store_state_seqs
             output_seqs = list(result_seqs[: self.num_outputs])
             state_seqs = list(result_seqs[self.num_outputs :])
             if result_has_state_seqs:
-                self.states = [v[-1] for v in state_seqs]
+                if self.states is None:
+                    self.states = self.init_states(self.num_states, self.step_mode, *args)
+                self.states = [
+                    _last_state_or_current(v, self.states[i])
+                    for i, v in enumerate(state_seqs)
+                ]
                 if self.store_state_seqs:
                     self.state_seqs = state_seqs
             else:
@@ -1007,7 +1206,17 @@ class FlexSN(base.MemoryModule):
             raise ValueError(f"Unsupported backend: {self.backend}")
 
     def forward(self, *args):
-        can_elide = _can_elide_zero_state_inputs(self) and not torch.is_grad_enabled()
+        can_elide = (
+            self.step_mode == "m"
+            and _can_elide_zero_state_inputs(self)
+            and (
+                not torch.is_grad_enabled()
+                or (
+                    not _value_requires_grad(args)
+                    and not _core_requires_grad(self.core)
+                )
+            )
+        )
         if self.states is None and not can_elide:
             self.states = self.init_states(self.num_states, self.step_mode, *args)
         output = super().forward(*args)

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -488,6 +488,7 @@ def _validate_scan_backend_contract(
                 f"{seq_template.device}), but return #{i} is "
                 f"({tensor.dtype}, {tensor.device})."
             )
+    return example_inputs
 
 
 class FlexSNKernel:
@@ -652,9 +653,10 @@ class FlexSN(base.MemoryModule):
         :param example_outputs: ``core`` 的单步输出模板，形式为 ``tuple([*outputs])``。
             当 ``backend="torch"`` 且输入为空序列 ``T == 0`` 时, 需要用它来构造输出张量的
             形状和 dtype, 从而避免为了推断输出而执行 ``core``。对于 scan 后端
-            (``"triton"``, ``"inductor"``, ``"hop"``), 若提供该参数, 每个模板张量都必须与
-            第一个 ``example_inputs`` 张量的单步形状和 dtype 相匹配。若不需要空序列模板,
-            则可以为 ``None``。默认 ``None``。
+            ``"triton"`` 和 ``"inductor"``, 若提供该参数, 每个模板张量都必须与第一个
+            ``example_inputs`` 张量的单步形状和 dtype 相匹配。``"hop"`` 后端会保留任意
+            输出模板, 并在空序列/HOP 路径中按运行时输入设备物化它们, 不执行上述形状/dtype
+            校验。若不需要空序列模板, 则可以为 ``None``。默认 ``None``。
         :type example_outputs: Optional[Tuple[torch.Tensor]]
 
         ----
@@ -721,8 +723,11 @@ class FlexSN(base.MemoryModule):
             ``tuple([*outputs])``. When ``backend="torch"`` and the input sequence is
             empty (``T == 0``), these templates are required to materialize output
             shapes and dtypes without executing ``core``. For scan backends
-            (``"triton"``, ``"inductor"``, ``"hop"``), each provided template must match
-            the first ``example_inputs`` tensor's per-step shape and dtype. Defaults to
+            ``"triton"`` and ``"inductor"``, each provided template must match the
+            first ``example_inputs`` tensor's per-step shape and dtype. The ``"hop"``
+            backend intentionally allows arbitrary output templates and materializes
+            them on the runtime input device for empty-sequence/HOP paths, so it
+            does not enforce that scan-backend shape/dtype check. Defaults to
             ``None`` when empty-sequence output templates are not needed.
         :type example_outputs: Optional[Tuple[torch.Tensor]]
         """
@@ -749,12 +754,12 @@ class FlexSN(base.MemoryModule):
         )
 
         if backend in ("triton", "inductor"):
+            validated_example_inputs = _validate_scan_backend_contract(
+                core, num_inputs, num_states, num_outputs, example_inputs
+            )
             _validate_scan_backend_output_template_specs(
                 self._explicit_output_template_specs,
-                example_inputs,
-            )
-            _validate_scan_backend_contract(
-                core, num_inputs, num_states, num_outputs, example_inputs
+                validated_example_inputs,
             )
         elif backend == "hop":
             if _flexsn_eager_scan is None:

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
@@ -27,3 +27,18 @@ except Exception as e:
     lowerable_while_loop_scan = None
     lowerable_while_loop_scan_final_state = None
     lowerable_while_loop_available = None
+
+
+__all__ = [
+    "flex_sn_scan",
+    "FlexSNScan",
+    "eager_scan",
+    "eager_scan_final_state",
+    "lowerable_scan",
+    "lowerable_scan_final_state",
+    "lowerable_scan_available",
+    "dynamo_hop_available",
+    "lowerable_while_loop_scan",
+    "lowerable_while_loop_scan_final_state",
+    "lowerable_while_loop_available",
+]

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
@@ -30,15 +30,15 @@ except Exception as e:
 
 
 __all__ = [
-    "flex_sn_scan",
-    "FlexSNScan",
+    "dynamo_hop_available",
     "eager_scan",
     "eager_scan_final_state",
+    "flex_sn_scan",
+    "FlexSNScan",
     "lowerable_scan",
-    "lowerable_scan_final_state",
     "lowerable_scan_available",
-    "dynamo_hop_available",
+    "lowerable_scan_final_state",
     "lowerable_while_loop_scan",
-    "lowerable_while_loop_scan_final_state",
     "lowerable_while_loop_available",
+    "lowerable_while_loop_scan_final_state",
 ]

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/__init__.py
@@ -1,15 +1,16 @@
 try:
     from .hop import (
+        flex_sn_scan,
         FlexSNScan,
         eager_scan,
         eager_scan_final_state,
-        flex_sn_scan,
         lowerable_scan,
-        lowerable_scan_available,
         lowerable_scan_final_state,
-        lowerable_while_loop_available,
+        lowerable_scan_available,
+        dynamo_hop_available,
         lowerable_while_loop_scan,
         lowerable_while_loop_scan_final_state,
+        lowerable_while_loop_available,
     )
 except Exception as e:
     import logging
@@ -21,7 +22,8 @@ except Exception as e:
     eager_scan_final_state = None
     lowerable_scan = None
     lowerable_scan_final_state = None
+    lowerable_scan_available = None
+    dynamo_hop_available = None
     lowerable_while_loop_scan = None
     lowerable_while_loop_scan_final_state = None
-    lowerable_scan_available = None
     lowerable_while_loop_available = None

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -17,8 +17,8 @@ from __future__ import annotations
 
 import contextlib
 from dataclasses import dataclass
+from typing import Dict, List, Optional
 from itertools import count
-import os
 from threading import Lock
 import weakref
 
@@ -31,57 +31,38 @@ from ..flexsn.wrapper import (
     flexsn_inference_final_state,
 )
 from ..flexsn.info import FlexSNInfo
-from ..triton_utils import type_dict
 
 
 @dataclass
 class FlexSNKernelHandle:
-    inference_kernel: object | None
-    inference_info: FlexSNInfo | None
-    inference_final_state_kernel: object | None
-    inference_final_state_info: FlexSNInfo | None
-    forward_kernel: object | None
-    forward_final_state_kernel: object | None
-    backward_kernel: object | None
-    backward_final_state_kernel: object | None
-    training_info: FlexSNInfo | None
-    state_template_specs: tuple[tuple[tuple[int, ...], torch.dtype, torch.device], ...] | None = None
+    inference_kernel: Optional[object]
+    inference_info: Optional[FlexSNInfo]
+    inference_final_state_kernel: Optional[object]
+    inference_final_state_info: Optional[FlexSNInfo]
+    forward_kernel: Optional[object]
+    backward_kernel: Optional[object]
+    training_info: Optional[FlexSNInfo]
     owner_refs: int = 1
     active_refs: int = 0
 
 
-_KERNEL_REGISTRY: dict[int, FlexSNKernelHandle] = {}
+_KERNEL_REGISTRY: Dict[int, FlexSNKernelHandle] = {}
 _KERNEL_REGISTRY_LOCK = Lock()
 _KERNEL_ID_GEN = count(1)
-
-
-def _get_env_int(name: str, default: int) -> int:
-    raw = os.environ.get(name)
-    if raw is None or raw == "":
-        return default
-    try:
-        return int(raw)
-    except ValueError:
-        return default
-
-
-_TRAINING_FINAL_STATE_SPECIALIZED_MIN_TOKENS = _get_env_int(
-    "SJ_FLEXSN_INDUCTOR_TRAINING_FINAL_STATE_MIN_TOKENS", 1 << 20
-)
-_BACKWARD_FINAL_STATE_SPECIALIZED_MIN_STEPS = _get_env_int(
-    "SJ_FLEXSN_INDUCTOR_BACKWARD_FINAL_STATE_MIN_STEPS", 24
-)
-_BACKWARD_FINAL_STATE_SPECIALIZED_MIN_TOKENS = _get_env_int(
-    "SJ_FLEXSN_INDUCTOR_BACKWARD_FINAL_STATE_MIN_TOKENS", 1 << 18
-)
 
 
 def _normalize_kernel_handle(handle: int) -> int:
     if isinstance(handle, int):
         return handle
+    if isinstance(handle, torch.Tensor):
+        if handle.numel() != 1:
+            raise TypeError(
+                f"Unsupported FlexSN kernel handle tensor shape: {tuple(handle.shape)}"
+            )
+        return int(handle.item())
     try:
         return int(handle)
-    except Exception as exc:
+    except (TypeError, ValueError) as exc:
         raise TypeError(
             f"Unsupported FlexSN kernel handle type: {type(handle)!r}"
         ) from exc
@@ -94,11 +75,8 @@ def register_flexsn_kernel_handle(
     inference_final_state_kernel,
     inference_final_state_info,
     forward_kernel,
-    forward_final_state_kernel,
     backward_kernel,
-    backward_final_state_kernel,
     training_info,
-    state_template_specs=None,
 ) -> int:
     with _KERNEL_REGISTRY_LOCK:
         handle = next(_KERNEL_ID_GEN)
@@ -108,11 +86,8 @@ def register_flexsn_kernel_handle(
             inference_final_state_kernel=inference_final_state_kernel,
             inference_final_state_info=inference_final_state_info,
             forward_kernel=forward_kernel,
-            forward_final_state_kernel=forward_final_state_kernel,
             backward_kernel=backward_kernel,
-            backward_final_state_kernel=backward_final_state_kernel,
             training_info=training_info,
-            state_template_specs=state_template_specs,
         )
     return handle
 
@@ -130,9 +105,7 @@ def _cleanup_kernel_handle(bundle: FlexSNKernelHandle) -> None:
         bundle.inference_kernel,
         bundle.inference_final_state_kernel,
         bundle.forward_kernel,
-        bundle.forward_final_state_kernel,
         bundle.backward_kernel,
-        bundle.backward_final_state_kernel,
     ):
         closer = getattr(obj, "close", None)
         if callable(closer):
@@ -190,8 +163,8 @@ def release_active_flexsn_kernel_handle(handle: int) -> None:
 
 
 def _make_seq_outputs_like(
-    info: FlexSNInfo, flat_args: list[torch.Tensor], n: int
-) -> list[torch.Tensor]:
+    info: FlexSNInfo, flat_args: List[torch.Tensor], n: int
+) -> List[torch.Tensor]:
     if not flat_args:
         raise ValueError("Expected at least one FlexSN argument tensor.")
     # The underlying FlexSN Triton wrappers allocate all sequence outputs with
@@ -207,47 +180,37 @@ def _template_spec(tensor: torch.Tensor):
 
 def _materialize_template(spec):
     shape, dtype, device = spec
-    return torch.empty(shape, dtype=dtype, device=device)
-
-
-def _materialize_runtime_template_arg(spec):
-    shape, dtype, device = spec
     return torch.empty((), dtype=dtype, device=device).expand(shape)
 
 
-def _resolve_state_template_specs(
-    info: FlexSNInfo,
-    flat_args: list[torch.Tensor],
-    bundle: FlexSNKernelHandle,
-):
-    if info.num_states == 0:
-        return []
-    if len(flat_args) >= info.num_inputs + info.num_states:
-        return [_template_spec(flat_args[info.num_inputs + i]) for i in range(info.num_states)]
-    if bundle.state_template_specs is not None:
-        runtime_device = flat_args[0].device if flat_args else None
-        specs = []
-        for shape, dtype, device in bundle.state_template_specs:
-            specs.append((shape, dtype, runtime_device if runtime_device is not None else device))
-        return specs
-    if not flat_args:
-        raise ValueError("Expected at least one FlexSN argument tensor.")
-    runtime_template = flat_args[0][0]
-    state_template = (tuple(runtime_template.shape), runtime_template.dtype, runtime_template.device)
-    return [state_template for _ in range(info.num_states)]
-
-
-def _materialize_empty_from_spec(spec):
-    shape, dtype, device = spec
-    return torch.empty(shape, dtype=dtype, device=device)
-
-
-def _materialize_zeros_from_spec(spec):
+def _grad_or_zeros(grad_out, index: int, spec):
+    grad = grad_out[index] if index < len(grad_out) else None
+    if grad is not None:
+        return grad
     shape, dtype, device = spec
     return torch.zeros(shape, dtype=dtype, device=device)
 
 
-def _device_guard(tensors: list[torch.Tensor]):
+def _make_state_templates_like(
+    info: FlexSNInfo, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
+    if not flat_args:
+        raise ValueError("Expected at least one input tensor for FlexSN fake op.")
+    explicit_states = flat_args[info.num_inputs: info.num_inputs + info.num_states]
+    if len(explicit_states) == info.num_states:
+        return [state.new_empty(state.shape) for state in explicit_states]
+    seq_template = flat_args[0]
+    if seq_template.dim() == 0:
+        state_shape = ()
+    else:
+        state_shape = tuple(seq_template.shape[1:])
+    return [
+        seq_template.new_empty(state_shape)
+        for _ in range(info.num_states)
+    ]
+
+
+def _device_guard(tensors: List[torch.Tensor]):
     for tensor in tensors:
         if isinstance(tensor, torch.Tensor) and tensor.is_cuda:
             return torch.cuda.device(tensor.device)
@@ -258,50 +221,37 @@ def _visible_fwd_return_count(info: FlexSNInfo) -> int:
     return info.num_outputs + info.num_states
 
 
-def _extra_saved_return_indices(info: FlexSNInfo) -> list[int]:
+def _extra_saved_return_indices(info: FlexSNInfo) -> List[int]:
     visible = _visible_fwd_return_count(info)
     return [idx for idx in info.c2k_return_mapping if idx >= visible]
 
 
-def _saved_non_output_indices(info: FlexSNInfo) -> list[int]:
-    saved = []
-    seen = set()
-    for idx in info.c2k_return_mapping:
-        if idx < info.num_outputs or idx in seen:
-            continue
-        saved.append(idx)
-        seen.add(idx)
-    return saved
-
-
-def _training_final_state_specialized_wins(info: FlexSNInfo) -> bool:
-    specialized_seq_count = info.num_outputs + len(_saved_non_output_indices(info))
-    return specialized_seq_count < info.num_fwd_kernel_returns
+def _final_state_saved_return_indices(info: FlexSNInfo) -> List[int]:
+    return [idx for idx in info.c2k_return_mapping if idx >= info.num_outputs]
 
 
 def _materialize_zero_state_args(
-    bundle: FlexSNKernelHandle,
-    info: FlexSNInfo,
-    flat_args: list[torch.Tensor],
-) -> list[torch.Tensor]:
+    info: FlexSNInfo, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
     if len(flat_args) == info.num_inputs:
         # In the common reset-before-forward path, FlexSN initial states are
-        # materialized inside the opaque custom op so compile graphs do not
-        # need explicit ``zeros_like`` nodes in front of every neuron layer.
+        # zero tensors matching the per-step input shape. Materialize them
+        # inside the opaque custom op so compile graphs do not need explicit
+        # ``zeros_like`` nodes in front of every neuron layer.
         if info.num_inputs == 0:
             raise ValueError("FlexSN custom ops require at least one input sequence.")
+        seq0 = flat_args[0]
         zero_states = [
-            _materialize_zeros_from_spec(spec)
-            for spec in _resolve_state_template_specs(info, flat_args, bundle)
+            seq0.new_zeros(seq0.shape[1:]) for _ in range(info.num_states)
         ]
         return [*flat_args, *zero_states]
     return flat_args
 
 
 def _flexsn_inductor_inference_impl(
-    bundle: FlexSNKernelHandle, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
-    args = _materialize_zero_state_args(bundle, bundle.inference_info, flat_args)
+    bundle: FlexSNKernelHandle, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
+    args = _materialize_zero_state_args(bundle.inference_info, flat_args)
     args = [arg.contiguous() for arg in args]
     with _device_guard(args):
         return list(
@@ -314,9 +264,9 @@ def _flexsn_inductor_inference_impl(
 
 
 def _flexsn_inductor_inference_final_state_impl(
-    bundle: FlexSNKernelHandle, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
-    args = _materialize_zero_state_args(bundle, bundle.inference_final_state_info, flat_args)
+    bundle: FlexSNKernelHandle, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
+    args = _materialize_zero_state_args(bundle.inference_final_state_info, flat_args)
     args = [arg.contiguous() for arg in args]
     with _device_guard(args):
         return list(
@@ -329,9 +279,9 @@ def _flexsn_inductor_inference_final_state_impl(
 
 
 def _flexsn_inductor_training_impl(
-    bundle: FlexSNKernelHandle, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
-    args = _materialize_zero_state_args(bundle, bundle.training_info, flat_args)
+    bundle: FlexSNKernelHandle, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
+    args = _materialize_zero_state_args(bundle.training_info, flat_args)
     args = [arg.contiguous() for arg in args]
     with _device_guard(args):
         return list(
@@ -343,112 +293,38 @@ def _flexsn_inductor_training_impl(
         )
 
 
-def _flexsn_forward_final_state(
-    kernel,
-    info: FlexSNInfo,
-    state_template_specs,
-    *args: torch.Tensor,
-) -> tuple[torch.Tensor, ...]:
-    x_example = args[0]
-    T = x_example.shape[0]
-    NCL = x_example[0].numel()
-    dtype = x_example.dtype
-    output_seqs = [torch.empty_like(x_example) for _ in range(info.num_outputs)]
-    final_states = [_materialize_empty_from_spec(spec) for spec in state_template_specs]
-    saved_tensors = [
-        torch.empty_like(x_example) for _ in _saved_non_output_indices(info)
-    ]
-    grid = lambda meta: ((NCL + meta["BLOCK_NCL"] - 1) // meta["BLOCK_NCL"],)
-
-    kernel[grid](
-        *args,
-        *output_seqs,
-        *final_states,
-        *saved_tensors,
-        T=T,
-        NCL=NCL,
-        dtype=type_dict[dtype],
-    )
-    return tuple([*output_seqs, *final_states, *saved_tensors])
-
-
-def _should_use_training_final_state_kernel(args: list[torch.Tensor]) -> bool:
-    if _TRAINING_FINAL_STATE_SPECIALIZED_MIN_TOKENS <= 0:
-        return True
-    if not args:
-        return False
-    return args[0].numel() >= _TRAINING_FINAL_STATE_SPECIALIZED_MIN_TOKENS
-
-
-def _should_use_backward_final_state_kernel(grad_outputs: list[torch.Tensor]) -> bool:
-    if not grad_outputs:
-        return False
-    grad0 = grad_outputs[0]
-    steps_enabled = _BACKWARD_FINAL_STATE_SPECIALIZED_MIN_STEPS > 0
-    tokens_enabled = _BACKWARD_FINAL_STATE_SPECIALIZED_MIN_TOKENS > 0
-    if steps_enabled and grad0.shape[0] >= _BACKWARD_FINAL_STATE_SPECIALIZED_MIN_STEPS:
-        return True
-    if tokens_enabled and grad0.numel() >= _BACKWARD_FINAL_STATE_SPECIALIZED_MIN_TOKENS:
-        return True
-    return not steps_enabled and not tokens_enabled
-
-
 def _flexsn_inductor_training_final_state_impl(
-    bundle: FlexSNKernelHandle, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
-    args = _materialize_zero_state_args(bundle, bundle.training_info, flat_args)
-    args = [arg.contiguous() for arg in args]
-    if (
-        bundle.forward_final_state_kernel is not None
-        and _training_final_state_specialized_wins(bundle.training_info)
-        and _should_use_training_final_state_kernel(args)
-    ):
-        with _device_guard(args):
-            return list(
-                _flexsn_forward_final_state(
-                    bundle.forward_final_state_kernel,
-                    bundle.training_info,
-                    _resolve_state_template_specs(bundle.training_info, args, bundle),
-                    *args,
-                )
-            )
-
-    full_returns = _flexsn_inductor_training_impl(bundle, flat_args)
+    bundle: FlexSNKernelHandle, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
     info = bundle.training_info
     assert info is not None
+    args = _materialize_zero_state_args(info, flat_args)
+    full_returns = _flexsn_inductor_training_impl(bundle, args)
     visible_outputs = list(full_returns[: info.num_outputs])
-    state_seqs = list(full_returns[info.num_outputs : info.num_outputs + info.num_states])
-    final_states = [state_seq[-1].clone() for state_seq in state_seqs]
-    saved_non_output_tensors = [full_returns[i] for i in _saved_non_output_indices(info)]
-    return [*visible_outputs, *final_states, *saved_non_output_tensors]
+    state_seqs = list(
+        full_returns[info.num_outputs : info.num_outputs + info.num_states]
+    )
+    init_states = list(args[info.num_inputs : info.num_inputs + info.num_states])
+    final_states = [
+        (init_states[i] if state_seq.shape[0] == 0 else state_seq[-1]).clone()
+        for i, state_seq in enumerate(state_seqs)
+    ]
+    extra_saved_tensors = [full_returns[i] for i in _final_state_saved_return_indices(info)]
+    return [*visible_outputs, *final_states, *extra_saved_tensors]
 
 
 def _flexsn_inductor_backward_impl(
     bundle: FlexSNKernelHandle,
-    grad_outputs: list[torch.Tensor],
-    saved_tensors: list[torch.Tensor],
-) -> list[torch.Tensor]:
-    return _flexsn_inductor_backward_with_kernel(
-        bundle.backward_kernel,
-        bundle.training_info,
-        grad_outputs,
-        saved_tensors,
-    )
-
-
-def _flexsn_inductor_backward_with_kernel(
-    kernel,
-    info: FlexSNInfo,
-    grad_outputs: list[torch.Tensor],
-    saved_tensors: list[torch.Tensor],
-) -> list[torch.Tensor]:
+    grad_outputs: List[torch.Tensor],
+    saved_tensors: List[torch.Tensor],
+) -> List[torch.Tensor]:
     grads = [grad.contiguous() for grad in grad_outputs]
     saved = [tensor.contiguous() for tensor in saved_tensors]
     with _device_guard([*grads, *saved]):
         return list(
             flexsn_backward(
-                kernel,
-                info,
+                bundle.backward_kernel,
+                bundle.training_info,
                 *grads,
                 *saved,
             )
@@ -456,7 +332,7 @@ def _flexsn_inductor_backward_with_kernel(
 
 
 @torch.library.custom_op("sj::flexsn_inductor_inference", mutates_args=())
-def flexsn_inductor_inference(handle: int, flat_args: list[torch.Tensor]) -> list[torch.Tensor]:
+def flexsn_inductor_inference(handle: int, flat_args: List[torch.Tensor]) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if bundle.inference_kernel is None or bundle.inference_info is None:
         raise RuntimeError("FlexSN inference kernel is unavailable for this handle.")
@@ -464,7 +340,7 @@ def flexsn_inductor_inference(handle: int, flat_args: list[torch.Tensor]) -> lis
 
 
 @torch.library.custom_op("sj::flexsn_inductor_inference_final_state", mutates_args=())
-def flexsn_inductor_inference_final_state(handle: int, flat_args: list[torch.Tensor]) -> list[torch.Tensor]:
+def flexsn_inductor_inference_final_state(handle: int, flat_args: List[torch.Tensor]) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if (
         bundle.inference_final_state_kernel is None
@@ -476,8 +352,8 @@ def flexsn_inductor_inference_final_state(handle: int, flat_args: list[torch.Ten
 
 @torch.library.register_fake("sj::flexsn_inductor_inference")
 def _flexsn_inductor_inference_fake(
-    handle: int, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
+    handle: int, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if bundle.inference_info is None:
         raise RuntimeError("FlexSN inference metadata is unavailable for this handle.")
@@ -490,8 +366,8 @@ def _flexsn_inductor_inference_fake(
 
 @torch.library.register_fake("sj::flexsn_inductor_inference_final_state")
 def _flexsn_inductor_inference_final_state_fake(
-    handle: int, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
+    handle: int, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if bundle.inference_final_state_info is None:
         raise RuntimeError(
@@ -502,15 +378,14 @@ def _flexsn_inductor_inference_final_state_fake(
         flat_args,
         bundle.inference_final_state_info.num_outputs,
     )
-    state_specs = _resolve_state_template_specs(
-        bundle.inference_final_state_info, flat_args, bundle
+    final_states = _make_state_templates_like(
+        bundle.inference_final_state_info, flat_args
     )
-    final_states = [_materialize_empty_from_spec(spec) for spec in state_specs]
     return [*seq_outputs, *final_states]
 
 
 @torch.library.custom_op("sj::flexsn_inductor_training", mutates_args=())
-def flexsn_inductor_training(handle: int, flat_args: list[torch.Tensor]) -> list[torch.Tensor]:
+def flexsn_inductor_training(handle: int, flat_args: List[torch.Tensor]) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if (
         bundle.forward_kernel is None
@@ -523,8 +398,8 @@ def flexsn_inductor_training(handle: int, flat_args: list[torch.Tensor]) -> list
 
 @torch.library.custom_op("sj::flexsn_inductor_training_final_state", mutates_args=())
 def flexsn_inductor_training_final_state(
-    handle: int, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
+    handle: int, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if (
         bundle.forward_kernel is None
@@ -537,8 +412,8 @@ def flexsn_inductor_training_final_state(
 
 @torch.library.register_fake("sj::flexsn_inductor_training")
 def _flexsn_inductor_training_fake(
-    handle: int, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
+    handle: int, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if bundle.training_info is None:
         raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
@@ -551,8 +426,8 @@ def _flexsn_inductor_training_fake(
 
 @torch.library.register_fake("sj::flexsn_inductor_training_final_state")
 def _flexsn_inductor_training_final_state_fake(
-    handle: int, flat_args: list[torch.Tensor]
-) -> list[torch.Tensor]:
+    handle: int, flat_args: List[torch.Tensor]
+) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if bundle.training_info is None:
         raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
@@ -561,12 +436,11 @@ def _flexsn_inductor_training_final_state_fake(
         flat_args,
         bundle.training_info.num_outputs,
     )
-    state_specs = _resolve_state_template_specs(bundle.training_info, flat_args, bundle)
-    final_states = [_materialize_empty_from_spec(spec) for spec in state_specs]
+    final_states = _make_state_templates_like(bundle.training_info, flat_args)
     extra_saved_tensors = _make_seq_outputs_like(
         bundle.training_info,
         flat_args,
-        len(_saved_non_output_indices(bundle.training_info)),
+        len(_final_state_saved_return_indices(bundle.training_info)),
     )
     return [*seq_outputs, *final_states, *extra_saved_tensors]
 
@@ -574,10 +448,10 @@ def _flexsn_inductor_training_final_state_fake(
 @torch.library.custom_op("sj::flexsn_inductor_backward", mutates_args=())
 def flexsn_inductor_backward(
     handle: int,
-    grad_outputs: list[torch.Tensor],
-    saved_tensors: list[torch.Tensor],
-    input_templates: list[torch.Tensor],
-) -> list[torch.Tensor]:
+    grad_outputs: List[torch.Tensor],
+    saved_tensors: List[torch.Tensor],
+    input_templates: List[torch.Tensor],
+) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if bundle.backward_kernel is None or bundle.training_info is None:
         raise RuntimeError("FlexSN backward kernel is unavailable for this handle.")
@@ -587,22 +461,22 @@ def flexsn_inductor_backward(
 @torch.library.register_fake("sj::flexsn_inductor_backward")
 def _flexsn_inductor_backward_fake(
     handle: int,
-    grad_outputs: list[torch.Tensor],
-    saved_tensors: list[torch.Tensor],
-    input_templates: list[torch.Tensor],
-) -> list[torch.Tensor]:
+    grad_outputs: List[torch.Tensor],
+    saved_tensors: List[torch.Tensor],
+    input_templates: List[torch.Tensor],
+) -> List[torch.Tensor]:
     bundle = _lookup_kernel_handle(handle)
     if bundle.training_info is None:
         raise RuntimeError("FlexSN training metadata is unavailable for this handle.")
-    seq_grads = []
-    for i in range(bundle.training_info.num_inputs):
-        seq_grads.append(input_templates[i].new_empty(input_templates[i].shape))
-    state_specs = _resolve_state_template_specs(
-        bundle.training_info,
-        input_templates,
-        bundle,
-    )
-    state_grads = [_materialize_empty_from_spec(spec) for spec in state_specs]
+    seq_grads = [
+        input_templates[i].new_empty(input_templates[i].shape)
+        for i in range(bundle.training_info.num_inputs)
+    ]
+    state_offset = bundle.training_info.num_inputs
+    state_grads = [
+        input_templates[state_offset + i].new_empty(input_templates[state_offset + i].shape)
+        for i in range(bundle.training_info.num_states)
+    ]
     return [*seq_grads, *state_grads]
 
 
@@ -641,50 +515,39 @@ def _flexsn_training_final_state_setup_context(ctx, inputs, output):
     ]
     if bundle.training_info.num_inputs == 0:
         raise RuntimeError("FlexSN training requires at least one input sequence.")
-    T = ctx.input_template_specs[0][0][0]
-    ctx.final_state_template_specs = [
-        _template_spec(t)
-        for t in output[
-            bundle.training_info.num_outputs : bundle.training_info.num_outputs + bundle.training_info.num_states
-        ]
-    ]
+    seq_len = ctx.input_template_specs[0][0][0]
+    state_start = bundle.training_info.num_outputs
+    state_end = state_start + bundle.training_info.num_states
     ctx.state_seq_template_specs = [
-        ((T, *shape), dtype, device)
-        for shape, dtype, device in ctx.final_state_template_specs
+        ((seq_len, *state_shape), state_dtype, state_device)
+        for state_shape, state_dtype, state_device in (
+            _template_spec(t) for t in output[state_start:state_end]
+        )
     ]
-    extra_saved_offset = bundle.training_info.num_outputs + bundle.training_info.num_states
-    extra_saved = {
-        idx: output[extra_saved_offset + pos]
-        for pos, idx in enumerate(_saved_non_output_indices(bundle.training_info))
-    }
+    visible_outputs = bundle.training_info.num_outputs
+    visible = bundle.training_info.num_outputs + bundle.training_info.num_states
+    extra_saved = list(output[visible:])
+    extra_saved_iter = iter(extra_saved)
     saved = []
     for idx in bundle.training_info.c2k_return_mapping:
-        if idx < bundle.training_info.num_outputs:
+        if idx < visible_outputs:
             saved.append(output[idx])
         else:
-            saved.append(extra_saved[idx])
+            saved.append(next(extra_saved_iter))
     ctx.save_for_backward(*saved)
 
 
-def _flexsn_training_backward(ctx, grad_out: list[torch.Tensor | None]):
+def _flexsn_training_backward(ctx, grad_out: List[Optional[torch.Tensor]]):
     bundle = _lookup_kernel_handle(ctx.handle)
     if bundle.backward_kernel is None or bundle.training_info is None:
         raise RuntimeError("FlexSN backward kernel is unavailable for this handle.")
 
     required_grads = bundle.training_info.num_outputs + bundle.training_info.num_states
     grad_inputs = [
-        grad_out[i]
-        if grad_out[i] is not None
-        else torch.zeros(
-            ctx.output_template_specs[i][0],
-            dtype=ctx.output_template_specs[i][1],
-            device=ctx.output_template_specs[i][2],
-        )
+        _grad_or_zeros(grad_out, i, ctx.output_template_specs[i])
         for i in range(required_grads)
     ]
-    input_templates = [
-        _materialize_runtime_template_arg(spec) for spec in ctx.input_template_specs
-    ]
+    input_templates = [_materialize_template(spec) for spec in ctx.input_template_specs]
     try:
         if ctx._active_ref_finalizer.alive:
             ctx._active_ref_finalizer.detach()
@@ -703,70 +566,65 @@ def _flexsn_training_backward(ctx, grad_out: list[torch.Tensor | None]):
     return None, grads
 
 
-def _flexsn_training_final_state_backward(ctx, grad_out: list[torch.Tensor | None]):
+def _flexsn_training_final_state_backward(ctx, grad_out: List[Optional[torch.Tensor]]):
     bundle = _lookup_kernel_handle(ctx.handle)
     if bundle.backward_kernel is None or bundle.training_info is None:
         raise RuntimeError("FlexSN backward kernel is unavailable for this handle.")
 
     output_grads = []
     for i in range(bundle.training_info.num_outputs):
-        if grad_out[i] is not None:
-            output_grads.append(grad_out[i])
-        else:
-            output_grads.append(
-                torch.zeros(
-                    ctx.output_template_specs[i][0],
-                    dtype=ctx.output_template_specs[i][1],
-                    device=ctx.output_template_specs[i][2],
-                )
-            )
+        output_grads.append(_grad_or_zeros(grad_out, i, ctx.output_template_specs[i]))
 
+    state_grads = []
+    for i in range(bundle.training_info.num_states):
+        state_seq_shape, state_seq_dtype, state_seq_device = (
+            ctx.state_seq_template_specs[i]
+        )
+        final_grad_index = bundle.training_info.num_outputs + i
+        final_grad = (
+            grad_out[final_grad_index]
+            if final_grad_index < len(grad_out)
+            else None
+        )
+        seq_grad = torch.zeros(
+            state_seq_shape,
+            dtype=state_seq_dtype,
+            device=state_seq_device,
+        )
+        if final_grad is not None and state_seq_shape[0] > 0:
+            seq_grad[-1].copy_(final_grad)
+        state_grads.append(seq_grad)
+
+    input_templates = [_materialize_template(spec) for spec in ctx.input_template_specs]
     try:
         if ctx._active_ref_finalizer.alive:
             ctx._active_ref_finalizer.detach()
-        if (
-            bundle.backward_final_state_kernel is not None
-            and _should_use_backward_final_state_kernel(output_grads)
-        ):
-            final_state_grads = []
-            for i, final_state_spec in enumerate(ctx.final_state_template_specs):
-                final_grad = grad_out[bundle.training_info.num_outputs + i]
-                if final_grad is not None:
-                    final_state_grads.append(final_grad)
-                else:
-                    final_state_grads.append(
-                        _materialize_zeros_from_spec(final_state_spec)
-                    )
-            grads = list(
-                _flexsn_inductor_backward_with_kernel(
-                    bundle.backward_final_state_kernel,
-                    bundle.training_info,
-                    [*output_grads, *final_state_grads],
-                    list(ctx.saved_tensors),
-                )
+        grads = list(
+            flexsn_inductor_backward(
+                ctx.handle,
+                [*output_grads, *state_grads],
+                list(ctx.saved_tensors),
+                input_templates,
             )
-        else:
-            input_templates = [
-                _materialize_runtime_template_arg(spec)
-                for spec in ctx.input_template_specs
-            ]
-            state_grads = []
-            for i, state_seq_spec in enumerate(ctx.state_seq_template_specs):
-                final_grad = grad_out[bundle.training_info.num_outputs + i]
-                seq_grad = _materialize_zeros_from_spec(state_seq_spec)
-                if final_grad is not None:
-                    seq_grad[-1].copy_(final_grad)
-                state_grads.append(seq_grad)
-            grads = list(
-                flexsn_inductor_backward(
-                    ctx.handle,
-                    [*output_grads, *state_grads],
-                    list(ctx.saved_tensors),
-                    input_templates,
-                )
-            )
+        )
         if len(grads) != len(ctx.input_template_specs):
             grads = grads[: len(ctx.input_template_specs)]
+        explicit_state_start = bundle.training_info.num_inputs
+        for i in range(bundle.training_info.num_states):
+            final_grad_index = bundle.training_info.num_outputs + i
+            final_grad = (
+                grad_out[final_grad_index]
+                if final_grad_index < len(grad_out)
+                else None
+            )
+            state_seq_shape = ctx.state_seq_template_specs[i][0]
+            grad_index = explicit_state_start + i
+            if (
+                final_grad is not None
+                and state_seq_shape[0] == 0
+                and grad_index < len(grads)
+            ):
+                grads[grad_index] = grads[grad_index] + final_grad
     finally:
         release_active_flexsn_kernel_handle(ctx.handle)
     return None, grads

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -560,7 +560,9 @@ def _flexsn_training_backward(ctx, grad_out: List[Optional[torch.Tensor]]):
         _grad_or_zeros(grad_out, i, ctx.output_template_specs[i])
         for i in range(required_grads)
     ]
-    input_templates = [_materialize_template(spec) for spec in ctx.input_template_specs]
+    # ctx.input_template_specs mirrors the full flat argument list passed into the
+    # training custom op: input sequences first, then any explicit initial states.
+    arg_templates = [_materialize_template(spec) for spec in ctx.input_template_specs]
     try:
         if ctx._active_ref_finalizer.alive:
             ctx._active_ref_finalizer.detach()
@@ -569,7 +571,7 @@ def _flexsn_training_backward(ctx, grad_out: List[Optional[torch.Tensor]]):
                 ctx.handle,
                 grad_inputs,
                 list(ctx.saved_tensors),
-                input_templates,
+                arg_templates,
             )
         )
         if len(grads) != len(ctx.input_template_specs):
@@ -608,7 +610,9 @@ def _flexsn_training_final_state_backward(ctx, grad_out: List[Optional[torch.Ten
             seq_grad[-1].copy_(final_grad)
         state_grads.append(seq_grad)
 
-    input_templates = [_materialize_template(spec) for spec in ctx.input_template_specs]
+    # ctx.input_template_specs already includes both input-sequence and initial-state
+    # templates, and flexsn_inductor_backward splits them back apart internally.
+    arg_templates = [_materialize_template(spec) for spec in ctx.input_template_specs]
     try:
         if ctx._active_ref_finalizer.alive:
             ctx._active_ref_finalizer.detach()
@@ -617,7 +621,7 @@ def _flexsn_training_final_state_backward(ctx, grad_out: List[Optional[torch.Ten
                 ctx.handle,
                 [*output_grads, *state_grads],
                 list(ctx.saved_tensors),
-                input_templates,
+                arg_templates,
             )
         )
         if len(grads) != len(ctx.input_template_specs):

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/custom_ops.py
@@ -317,16 +317,24 @@ def _flexsn_inductor_backward_impl(
     bundle: FlexSNKernelHandle,
     grad_outputs: List[torch.Tensor],
     saved_tensors: List[torch.Tensor],
+    input_templates: List[torch.Tensor],
 ) -> List[torch.Tensor]:
     grads = [grad.contiguous() for grad in grad_outputs]
     saved = [tensor.contiguous() for tensor in saved_tensors]
-    with _device_guard([*grads, *saved]):
+    templates = [tensor.contiguous() for tensor in input_templates]
+    info = bundle.training_info
+    assert info is not None
+    seq_templates = templates[: info.num_inputs]
+    state_templates = templates[info.num_inputs : info.num_inputs + info.num_states]
+    with _device_guard([*grads, *saved, *templates]):
         return list(
             flexsn_backward(
                 bundle.backward_kernel,
-                bundle.training_info,
+                info,
                 *grads,
                 *saved,
+                input_templates=seq_templates,
+                state_templates=state_templates,
             )
         )
 
@@ -455,7 +463,12 @@ def flexsn_inductor_backward(
     bundle = _lookup_kernel_handle(handle)
     if bundle.backward_kernel is None or bundle.training_info is None:
         raise RuntimeError("FlexSN backward kernel is unavailable for this handle.")
-    return _flexsn_inductor_backward_impl(bundle, grad_outputs, saved_tensors)
+    return _flexsn_inductor_backward_impl(
+        bundle,
+        grad_outputs,
+        saved_tensors,
+        input_templates,
+    )
 
 
 @torch.library.register_fake("sj::flexsn_inductor_backward")

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -1272,10 +1272,10 @@ def _register_dynamo_hop() -> None:
                     explicit_output_template_specs = (
                         output_template_specs_arg.as_python_constant()
                     )
-                except Exception:
+                except Exception as e:
                     raise hop_vars.unimplemented(
                         "flex_sn_scan output_template_specs must be a Python constant"
-                    )
+                    ) from e
 
             if len(args) < 4:
                 raise hop_vars.unimplemented(

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -276,7 +276,7 @@ def lowerable_scan_available() -> bool:
         Return whether the current environment exposes PyTorch's built-in
         ``scan`` higher-order operator.
 
-    :returns: EN: ``True`` when ``torch.ops.higher_order.scan`` is available;
+    :return: EN: ``True`` when ``torch.ops.higher_order.scan`` is available;
         otherwise ``False``. Chinese: 若 ``torch.ops.higher_order.scan`` 可用则
         返回 ``True``，否则返回 ``False``。
     :rtype: bool
@@ -294,7 +294,7 @@ def dynamo_hop_available() -> bool:
         Return whether the FlexSN-specific Dynamo HigherOrderOperator
         registration has been installed successfully.
 
-    :returns: EN: ``True`` when the Dynamo compatibility shim for
+    :return: EN: ``True`` when the Dynamo compatibility shim for
         ``flex_sn_scan`` is registered; otherwise ``False``. Chinese:
         当 ``flex_sn_scan`` 的 Dynamo 兼容注册已完成时返回 ``True``，否则返回
         ``False``。
@@ -313,7 +313,7 @@ def lowerable_while_loop_available() -> bool:
         Return whether the current environment exposes PyTorch's built-in
         ``while_loop`` higher-order operator.
 
-    :returns: EN: ``True`` when ``torch.ops.higher_order.while_loop`` is
+    :return: EN: ``True`` when ``torch.ops.higher_order.while_loop`` is
         available; otherwise ``False``. Chinese: 若
         ``torch.ops.higher_order.while_loop`` 可用则返回 ``True``，否则返回
         ``False``。
@@ -330,6 +330,12 @@ def _callable_positional_arg_range(
         signature = inspect.signature(target)
     except (TypeError, ValueError):
         return None
+    for parameter in signature.parameters.values():
+        if (
+            parameter.kind == inspect.Parameter.KEYWORD_ONLY
+            and parameter.default is inspect.Parameter.empty
+        ):
+            return None
     min_required = 0
     positional_capacity = 0
     for parameter in signature.parameters.values():
@@ -348,6 +354,17 @@ def _callable_positional_arg_range(
 def _callable_accepts_positional_args(fn: Callable, n_args: int) -> bool | None:
     arg_range = _callable_positional_arg_range(fn)
     if arg_range is None:
+        target = fn.forward if isinstance(fn, torch.nn.Module) else fn
+        try:
+            signature = inspect.signature(target)
+        except (TypeError, ValueError):
+            return None
+        if any(
+            parameter.kind == inspect.Parameter.KEYWORD_ONLY
+            and parameter.default is inspect.Parameter.empty
+            for parameter in signature.parameters.values()
+        ):
+            return False
         return None
     min_required, capacity = arg_range
     if n_args < min_required:

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -280,7 +280,9 @@ def lowerable_while_loop_available() -> bool:
     return _torch_while_loop is not None
 
 
-def _callable_positional_arg_range(fn: Callable) -> tuple[int, int | None] | None:
+def _callable_positional_arg_range(
+    fn: Callable,
+) -> Optional[Tuple[int, Optional[int]]]:
     target = fn.forward if isinstance(fn, torch.nn.Module) else fn
     try:
         signature = inspect.signature(target)

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -1,24 +1,56 @@
 """FlexSN time-step scan as a HigherOrderOperator.
 
-Current scope (M1 + M2):
+Current progress:
 
+M1:
 * HOP definition with an eager Python time-step loop impl.
 * Eager autograd works via the natural computation graph (``x[t]`` indexing
   and ``torch.stack`` are differentiable, so the per-step ``core_fn`` graph
   is correctly chained through time). Verified with ``gradcheck``.
+
+M2:
 * AOTAutograd tracing (``torch.fx.experimental.proxy_tensor.make_fx`` /
-  ``torch._functorch.aot_autograd.aot_function``) works out of the box by
-  unrolling the scan into T copies of ``core_fn``'s aten ops. This is the
-  input format Inductor expects.
+  ``torch._functorch.aot_autograd.aot_function``) works by unrolling the scan
+  into T copies of ``core_fn``'s aten ops.
 
-Deferred to M3:
+M3:
+* ``FlexSN(backend="hop")`` is available as an explicit backend.
+* Dynamo recognizes ``flex_sn_scan`` via a compatibility registration and can
+  rewrite the call into a HOP node with a traced ``GraphModule`` body.
+* ``torch.compile(fullgraph=True)`` for the HOP backend is verified on the
+  Linux CI/server environment, including tensor lifted freevars/closures.
 
-* A Dynamo ``VariableBuilder`` so ``torch.compile(model, fullgraph=True)``
-  can lift the HOP directly. Today the HOP is unsupported by Dynamo and
-  users must either wrap the scan in ``torch.compiler.disable`` or use
-  the lower-level ``aot_function`` API.
-* An Inductor lowering that preserves the scan as a single node and emits
-  a ``tl.static_range`` time loop (vs. the current unrolled-aten path).
+M4:
+* ``lowerable_scan`` re-expresses the FlexSN step function through PyTorch's
+  built-in ``torch.ops.higher_order.scan`` when that API is available.
+* It is kept as an explicit experimental helper for investigating a
+  single-scan-node forward path instead of fully unrolling the body.
+* ``lowerable_while_loop_scan`` provides an alternative experimental forward
+  path based on ``torch.ops.higher_order.while_loop``. On the Linux validation
+  environment, its ``torch.compile(fullgraph=True) + no_grad`` path is working
+  after switching to fixed-shape queue carries instead of ``x[t]`` indexing.
+* The experimental while-loop path is wired into ``FlexSN(backend="hop")`` via
+  ``SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP=1`` for compile-time forward
+  evaluation, and has been validated on:
+  - a single FlexSN layer,
+  - ``Linear -> FlexSN -> Linear``,
+  - ``SpikingVGG`` forward inference.
+
+Current limitations:
+
+* The custom Dynamo registration in this file is still a compatibility shim,
+  not a true in-tree ``BaseHOP`` integration.
+* ``lowerable_scan`` is currently an experimental helper, not the default
+  compiled path. In the PyTorch versions we validate against, fake/proxy/export
+  handling for this out-of-tree scan shape is not yet stable enough to enable
+  it by default.
+* Training and autograd still use the existing eager/unrolled path.
+* The current while-loop lowering is functionally correct for the validated
+  forward ``no_grad`` cases, but it is not yet faster than the current
+  ``backend="inductor"`` custom-op compile path on the server benchmark.
+* A true first-class Inductor lowering for ``flex_sn_scan`` itself does not
+  exist yet; the current "less unrolled" path relies on PyTorch's built-in
+  scan / while_loop decomposition.
 
 Usage::
 
@@ -29,13 +61,28 @@ Usage::
     # returns: (*output_seqs, *state_seqs) — each with shape [T, ...]
     result = flex_sn_scan(core_fn, num_inputs, num_states, num_outputs,
                          *inputs_seq, *init_states)
+
+Captured tensor freevars from ``core_fn`` are appended after the
+``[*inputs_seq, *init_states]`` segment when Dynamo rewrites the HOP call.
 """
 from __future__ import annotations
-
-from typing import Callable, Tuple
+import inspect
+import warnings
+from typing import Callable, Optional, Tuple, Union
 
 import torch
+import torch.utils._pytree as pytree
 from torch._ops import HigherOrderOperator
+
+try:
+    from torch._higher_order_ops.scan import scan_op as _torch_scan_op
+except (ImportError, AttributeError):
+    _torch_scan_op = None
+
+try:
+    from torch._higher_order_ops.while_loop import while_loop as _torch_while_loop
+except (ImportError, AttributeError):
+    _torch_while_loop = None
 
 
 class FlexSNScan(HigherOrderOperator):
@@ -51,7 +98,8 @@ class FlexSNScan(HigherOrderOperator):
       partition the flat tensor args.
     * ``flat_args``: first ``num_inputs`` tensors are input sequences with
       leading time dim ``T``; the next ``num_states`` tensors are initial
-      states (no time dim).
+      states (no time dim); any remaining tensors are lifted freevars that are
+      passed through to ``core_fn`` unchanged at every time step.
 
     Return: ``num_outputs`` output sequences followed by ``num_states`` state
     sequences, all stacked along the leading time dim.
@@ -67,19 +115,191 @@ class FlexSNScan(HigherOrderOperator):
         num_states: int,
         num_outputs: int,
         *flat_args: torch.Tensor,
+        output_template_specs: Optional[OutputTemplateSpecs] = None,
     ) -> Tuple[torch.Tensor, ...]:
         return super().__call__(
-            core_fn, num_inputs, num_states, num_outputs, *flat_args
+            core_fn,
+            num_inputs,
+            num_states,
+            num_outputs,
+            *flat_args,
+            output_template_specs=output_template_specs,
         )
 
 
 flex_sn_scan = FlexSNScan()
+_DYNAMO_HOP_REGISTERED = False
+OutputTemplateSpec = Union[
+    Tuple[Tuple[int, ...], torch.dtype],
+    Tuple[Tuple[int, ...], torch.dtype, torch.device],
+]
+OutputTemplateSpecs = Tuple[OutputTemplateSpec, ...]
 
 
-def _normalize_scan_results(results):
-    if isinstance(results, torch.Tensor):
-        return (results,)
-    return tuple(results)
+def _as_tuple(outputs):
+    if isinstance(outputs, torch.Tensor):
+        return (outputs,)
+    return tuple(outputs)
+
+
+def _empty_outputs_from_template(
+    input_seqs: Tuple[torch.Tensor, ...],
+    num_outputs: int,
+    output_template_specs: Optional[OutputTemplateSpecs],
+) -> Tuple[torch.Tensor, ...]:
+    if num_outputs == 0:
+        return ()
+    if output_template_specs is None:
+        raise ValueError(
+            "FlexSN HOP empty scans require output_template_specs so output "
+            "shapes and dtypes can be built without executing core_fn."
+        )
+    if len(output_template_specs) != num_outputs:
+        raise ValueError(
+            f"expected {num_outputs} output template specs, got "
+            f"{len(output_template_specs)}"
+        )
+    outputs = []
+    for spec in output_template_specs:
+        if len(spec) == 2:
+            shape, dtype = spec
+            device = input_seqs[0].device
+        else:
+            shape, dtype, device = spec
+        if device == input_seqs[0].device:
+            outputs.append(input_seqs[0].new_empty((0, *shape), dtype=dtype))
+        else:
+            outputs.append(torch.empty((0, *shape), dtype=dtype, device=device))
+    return tuple(outputs)
+
+
+def _flatten_dynamo_body_result(value) -> Tuple[object, ...]:
+    if isinstance(value, torch.Tensor):
+        return (value,)
+    if isinstance(value, (tuple, list)):
+        return tuple(
+            leaf for item in value for leaf in _flatten_dynamo_body_result(item)
+        )
+    variable_items = getattr(value, "items", None)
+    if isinstance(variable_items, (tuple, list)):
+        return tuple(
+            leaf
+            for item in variable_items
+            for leaf in _flatten_dynamo_body_result(item)
+        )
+    return (value,)
+
+
+def _dynamo_leaf_example_value(value):
+    if isinstance(value, torch.Tensor):
+        return value
+    as_proxy = getattr(value, "as_proxy", None)
+    if callable(as_proxy):
+        try:
+            proxy = as_proxy()
+        except Exception:
+            return None
+        node = getattr(proxy, "node", None)
+        meta = getattr(node, "meta", None)
+        if isinstance(meta, dict):
+            return meta.get("example_value")
+    return None
+
+
+def _output_template_specs_from_dynamo_body_result(
+    body_result,
+    num_outputs: int,
+) -> Optional[OutputTemplateSpecs]:
+    leaves = _flatten_dynamo_body_result(body_result)
+    if len(leaves) < num_outputs:
+        return None
+    specs = []
+    for leaf in leaves[:num_outputs]:
+        example_value = _dynamo_leaf_example_value(leaf)
+        if not isinstance(example_value, torch.Tensor):
+            return None
+        specs.append(
+            (tuple(example_value.shape), example_value.dtype, example_value.device)
+        )
+    return tuple(specs)
+
+
+def lowerable_scan_available() -> bool:
+    return _torch_scan_op is not None
+
+
+def dynamo_hop_available() -> bool:
+    return _DYNAMO_HOP_REGISTERED
+
+
+def lowerable_while_loop_available() -> bool:
+    return _torch_while_loop is not None
+
+
+def _callable_positional_arg_capacity(fn: Callable) -> int | None:
+    target = fn.forward if isinstance(fn, torch.nn.Module) else fn
+    try:
+        signature = inspect.signature(target)
+    except (TypeError, ValueError):
+        return None
+    positional = 0
+    for parameter in signature.parameters.values():
+        if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
+            return None
+        if parameter.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            positional += 1
+    return positional
+
+
+def _callable_accepts_positional_args(fn: Callable, n_args: int) -> bool | None:
+    capacity = _callable_positional_arg_capacity(fn)
+    if capacity is None:
+        return None
+    return n_args <= capacity
+
+
+def _reorder_placeholders_to_canonical_args(
+    graph: torch.fx.Graph, canonical_arg_names: Tuple[str, ...]
+) -> Tuple[torch.fx.Node, ...]:
+    placeholders = [node for node in graph.nodes if node.op == "placeholder"]
+    if not placeholders:
+        return ()
+
+    by_name = {node.name: node for node in placeholders}
+    ordered = [by_name[name] for name in canonical_arg_names if name in by_name]
+    ordered.extend(node for node in placeholders if node not in ordered)
+
+    if ordered != placeholders:
+        first_non_placeholder = next(
+            (node for node in graph.nodes if node.op != "placeholder"), None
+        )
+        if first_non_placeholder is not None:
+            for node in ordered:
+                first_non_placeholder.prepend(node)
+
+    return tuple(node for node in graph.nodes if node.op == "placeholder")
+
+
+def _check_lifted_arg_arity(
+    core_fn: Callable,
+    num_inputs: int,
+    num_states: int,
+    lifted_args: Tuple[torch.Tensor, ...],
+) -> None:
+    if not lifted_args:
+        return
+    expected = num_inputs + num_states
+    total = expected + len(lifted_args)
+    accepts = _callable_accepts_positional_args(core_fn, total)
+    if accepts is False:
+        raise ValueError(
+            f"flex_sn_scan expected {expected} tensor args "
+            f"(num_inputs={num_inputs} + num_states={num_states}), "
+            f"got {total}"
+        )
 
 
 def eager_scan(
@@ -88,6 +308,7 @@ def eager_scan(
     num_states: int,
     num_outputs: int,
     *flat_args: torch.Tensor,
+    output_template_specs: Optional[OutputTemplateSpecs] = None,
 ) -> Tuple[torch.Tensor, ...]:
     """Plain-Python scan loop reused by both the HOP eager impl and the
     Dynamo-friendly path in :class:`FlexSN` (see ``backend="inductor"``).
@@ -105,27 +326,38 @@ def eager_scan(
         )
 
     inputs_seq = flat_args[:num_inputs]
-    states = list(flat_args[num_inputs : num_inputs + num_states])
-    lifted_args = flat_args[num_inputs + num_states :]
+    states = list(flat_args[num_inputs:expected])
+    lifted_args = tuple(flat_args[expected:])
+    _check_lifted_arg_arity(core_fn, num_inputs, num_states, lifted_args)
 
     if num_inputs == 0:
         raise ValueError("flex_sn_scan requires at least one input sequence")
 
     T = inputs_seq[0].shape[0]
-    if T == 0:
-        raise ValueError("empty input sequence: T == 0 not supported")
     for i, x in enumerate(inputs_seq):
         if x.shape[0] != T:
             raise ValueError(
                 f"input {i} has leading dim {x.shape[0]}, expected {T}"
             )
 
+    if T == 0:
+        empty_outputs = _empty_outputs_from_template(
+            inputs_seq, num_outputs, output_template_specs
+        )
+        empty_states = tuple(
+            state.new_empty((0, *state.shape))
+            for state in states
+        )
+        return (*empty_outputs, *empty_states)
+
     output_buffers = [[] for _ in range(num_outputs)]
     state_buffers = [[] for _ in range(num_states)]
 
     for t in range(T):
         step_inputs = tuple(x[t] for x in inputs_seq)
-        results = _normalize_scan_results(core_fn(*step_inputs, *states, *lifted_args))
+        results = core_fn(*step_inputs, *states, *lifted_args)
+        if not isinstance(results, (tuple, list)):
+            results = (results,)
         if len(results) != num_outputs + num_states:
             raise ValueError(
                 f"core returned {len(results)} values, "
@@ -144,24 +376,20 @@ def eager_scan(
     return (*output_seqs, *state_seqs)
 
 
-flex_sn_scan.py_impl(torch._C.DispatchKey.CompositeExplicitAutograd)(eager_scan)
-# HOPs route every tensor call through the Autograd dispatch key even when
-# ``requires_grad=False``. Re-entering ``eager_scan`` from Autograd is
-# correct: the inner ``core_fn`` invocations build a standard per-timestep
-# autograd graph which is chained via ``torch.stack``/indexing, giving a
-# full BPTT graph. AOTAutograd (``aot_function`` / ``make_fx``) traces this
-# graph natively by unrolling; see module docstring.
-flex_sn_scan.py_impl(torch._C.DispatchKey.Autograd)(eager_scan)
-
-
 def eager_scan_final_state(
     core_fn: Callable,
     num_inputs: int,
     num_states: int,
     num_outputs: int,
     *flat_args: torch.Tensor,
+    output_template_specs: Optional[OutputTemplateSpecs] = None,
 ) -> Tuple[torch.Tensor, ...]:
-    """Eager scan variant that returns final states instead of full state seqs."""
+    """Variant of :func:`eager_scan` that returns output sequences followed by
+    final states only.
+
+    This is used by :class:`FlexSN` when ``store_state_seqs=False`` so the HOP
+    backend does not materialize full state sequences only to discard them.
+    """
     expected = num_inputs + num_states
     if len(flat_args) < expected:
         raise ValueError(
@@ -171,26 +399,34 @@ def eager_scan_final_state(
         )
 
     inputs_seq = flat_args[:num_inputs]
-    states = list(flat_args[num_inputs : num_inputs + num_states])
-    lifted_args = flat_args[num_inputs + num_states :]
+    states = list(flat_args[num_inputs:expected])
+    lifted_args = tuple(flat_args[expected:])
+    _check_lifted_arg_arity(core_fn, num_inputs, num_states, lifted_args)
 
     if num_inputs == 0:
         raise ValueError("flex_sn_scan requires at least one input sequence")
 
     T = inputs_seq[0].shape[0]
-    if T == 0:
-        raise ValueError("empty input sequence: T == 0 not supported")
     for i, x in enumerate(inputs_seq):
         if x.shape[0] != T:
             raise ValueError(
                 f"input {i} has leading dim {x.shape[0]}, expected {T}"
             )
 
+    if T == 0:
+        empty_outputs = _empty_outputs_from_template(
+            inputs_seq, num_outputs, output_template_specs
+        )
+        final_states = tuple(s.clone() for s in states)
+        return (*empty_outputs, *final_states)
+
     output_buffers = [[] for _ in range(num_outputs)]
 
     for t in range(T):
         step_inputs = tuple(x[t] for x in inputs_seq)
-        results = _normalize_scan_results(core_fn(*step_inputs, *states, *lifted_args))
+        results = core_fn(*step_inputs, *states, *lifted_args)
+        if not isinstance(results, (tuple, list)):
+            results = (results,)
         if len(results) != num_outputs + num_states:
             raise ValueError(
                 f"core returned {len(results)} values, "
@@ -203,18 +439,797 @@ def eager_scan_final_state(
             output_buffers[i].append(y)
 
     output_seqs = tuple(torch.stack(buf, dim=0) for buf in output_buffers)
-    return (*output_seqs, *states)
+    return (*output_seqs, *tuple(states))
 
 
-lowerable_scan = None
-lowerable_scan_final_state = None
-lowerable_while_loop_scan = None
-lowerable_while_loop_scan_final_state = None
+def lowerable_scan(
+    core_fn: Callable,
+    num_inputs: int,
+    num_states: int,
+    num_outputs: int,
+    *flat_args: torch.Tensor,
+    output_template_specs: Optional[OutputTemplateSpecs] = None,
+) -> Tuple[torch.Tensor, ...]:
+    """Run FlexSN scan through PyTorch's built-in ``scan`` HOP.
+
+    This path keeps the scan as a single higher-order op under tracing so
+    downstream compilers can decompose it to a loop instead of unrolling the
+    body T times in the traced graph. It is currently intended as an
+    experimental helper for investigation rather than a production default.
+
+    Notes:
+    * On the PyTorch versions we validate against, fake/proxy/export handling
+      for this out-of-tree scan pattern is still not stable enough to make this
+      the default compiled path.
+    * We pass flattened input/state leaves directly to ``torch.ops.higher_order.scan``
+      and rebuild the structured inputs inside ``wrapped_combine_fn``.
+    """
+    if _torch_scan_op is None:
+        raise RuntimeError("PyTorch scan HOP is unavailable in this environment")
+
+    expected = num_inputs + num_states
+    if len(flat_args) < expected:
+        raise ValueError(
+            f"flex_sn_scan expected at least {expected} tensor args "
+            f"(num_inputs={num_inputs} + num_states={num_states}), "
+            f"got {len(flat_args)}"
+        )
+    if num_inputs == 0:
+        raise ValueError("flex_sn_scan requires at least one input sequence")
+
+    input_seqs = flat_args[:num_inputs]
+    init_states = flat_args[num_inputs:expected]
+    lifted_args = tuple(flat_args[expected:])
+    _check_lifted_arg_arity(core_fn, num_inputs, num_states, lifted_args)
+
+    T = input_seqs[0].shape[0]
+    for i, x in enumerate(input_seqs):
+        if x.shape[0] != T:
+            raise ValueError(
+                f"input {i} has leading dim {x.shape[0]}, expected {T}"
+            )
+
+    if T == 0:
+        empty_outputs = _empty_outputs_from_template(
+            input_seqs, num_outputs, output_template_specs
+        )
+        empty_states = tuple(
+            state.new_empty((0, *state.shape))
+            for state in init_states
+        )
+        return (*empty_outputs, *empty_states)
+
+    def combine_fn(carry, step_inputs, additional_inputs):
+        carry = tuple(carry)
+        step_inputs = tuple(step_inputs)
+        additional_inputs = tuple(additional_inputs)
+        results = core_fn(*step_inputs, *carry, *additional_inputs)
+        results = tuple(results) if not isinstance(results, torch.Tensor) else (results,)
+        if len(results) != num_outputs + num_states:
+            raise ValueError(
+                f"core returned {len(results)} values, "
+                f"expected num_outputs + num_states = {num_outputs + num_states}"
+            )
+
+        outputs = list(results[:num_outputs])
+        next_states = list(results[num_outputs:])
+        output_states = [state.clone() for state in next_states]
+        return next_states, [*outputs, *output_states]
+
+    leaves_init = list(init_states)
+    leaves_xs = list(input_seqs)
+    _, spec_init = pytree.tree_flatten(leaves_init)
+    _, spec_xs = pytree.tree_flatten(leaves_xs)
+
+    def wrapped_combine_fn(*args):
+        expected_args = len(leaves_init) + len(leaves_xs) + len(lifted_args)
+        if len(args) != expected_args:
+            raise ValueError(
+                f"scan combine_fn expected {expected_args} flattened args, got {len(args)}"
+            )
+        carry = pytree.tree_unflatten(args[: len(leaves_init)], spec_init)
+        xs = pytree.tree_unflatten(
+            args[len(leaves_init) : len(leaves_init) + len(leaves_xs)],
+            spec_xs,
+        )
+        additional_inputs = tuple(args[len(leaves_init) + len(leaves_xs) :])
+        return combine_fn(carry, xs, additional_inputs)
+
+    result = _torch_scan_op(
+        wrapped_combine_fn,
+        leaves_init,
+        leaves_xs,
+        additional_inputs=lifted_args,
+    )
+    result = tuple(result)
+    # PyTorch scan returns final carry first, followed by the stacked outputs.
+    return result[num_states:]
 
 
-def lowerable_scan_available() -> bool:
-    return False
+def lowerable_scan_final_state(
+    core_fn: Callable,
+    num_inputs: int,
+    num_states: int,
+    num_outputs: int,
+    *flat_args: torch.Tensor,
+    output_template_specs: Optional[OutputTemplateSpecs] = None,
+) -> Tuple[torch.Tensor, ...]:
+    if _torch_scan_op is None:
+        raise RuntimeError("PyTorch scan HOP is unavailable in this environment")
+
+    expected = num_inputs + num_states
+    if len(flat_args) < expected:
+        raise ValueError(
+            f"flex_sn_scan expected at least {expected} tensor args "
+            f"(num_inputs={num_inputs} + num_states={num_states}), "
+            f"got {len(flat_args)}"
+        )
+    if num_inputs == 0:
+        raise ValueError("flex_sn_scan requires at least one input sequence")
+
+    input_seqs = flat_args[:num_inputs]
+    init_states = flat_args[num_inputs:expected]
+    lifted_args = tuple(flat_args[expected:])
+    _check_lifted_arg_arity(core_fn, num_inputs, num_states, lifted_args)
+
+    T = input_seqs[0].shape[0]
+    for i, x in enumerate(input_seqs):
+        if x.shape[0] != T:
+            raise ValueError(
+                f"input {i} has leading dim {x.shape[0]}, expected {T}"
+            )
+
+    if T == 0:
+        empty_outputs = _empty_outputs_from_template(
+            input_seqs, num_outputs, output_template_specs
+        )
+        final_states = tuple(s.clone() for s in init_states)
+        return (*empty_outputs, *final_states)
+
+    def combine_fn(carry, step_inputs, additional_inputs):
+        carry = tuple(carry)
+        step_inputs = tuple(step_inputs)
+        additional_inputs = tuple(additional_inputs)
+        results = core_fn(*step_inputs, *carry, *additional_inputs)
+        results = tuple(results) if not isinstance(results, torch.Tensor) else (results,)
+        if len(results) != num_outputs + num_states:
+            raise ValueError(
+                f"core returned {len(results)} values, "
+                f"expected num_outputs + num_states = {num_outputs + num_states}"
+            )
+        outputs = list(results[:num_outputs])
+        next_states = list(results[num_outputs:])
+        return next_states, outputs
+
+    leaves_init = list(init_states)
+    leaves_xs = list(input_seqs)
+    _, spec_init = pytree.tree_flatten(leaves_init)
+    _, spec_xs = pytree.tree_flatten(leaves_xs)
+
+    def wrapped_combine_fn(*args):
+        expected_args = len(leaves_init) + len(leaves_xs) + len(lifted_args)
+        if len(args) != expected_args:
+            raise ValueError(
+                f"scan combine_fn expected {expected_args} flattened args, got {len(args)}"
+            )
+        carry = pytree.tree_unflatten(args[: len(leaves_init)], spec_init)
+        xs = pytree.tree_unflatten(
+            args[len(leaves_init) : len(leaves_init) + len(leaves_xs)],
+            spec_xs,
+        )
+        additional_inputs = tuple(args[len(leaves_init) + len(leaves_xs) :])
+        return combine_fn(carry, xs, additional_inputs)
+
+    result = _torch_scan_op(
+        wrapped_combine_fn,
+        leaves_init,
+        leaves_xs,
+        additional_inputs=lifted_args,
+    )
+    result = tuple(result)
+    # PyTorch scan returns final carry first; keep that as the final states.
+    final_states = result[:num_states]
+    output_seqs = result[num_states:]
+    return (*output_seqs, *final_states)
 
 
-def lowerable_while_loop_available() -> bool:
-    return False
+def _ensure_contiguous(tensor: torch.Tensor) -> torch.Tensor:
+    if tensor.dim() >= 4:
+        return tensor.contiguous(memory_format=torch.contiguous_format)
+    return tensor.contiguous()
+
+
+def _carry_device(*tensor_groups) -> torch.device:
+    for group in tensor_groups:
+        for tensor in group:
+            return tensor.device
+    return torch.device("cpu")
+
+
+def _append_to_tail(buffer: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
+    return torch.cat(
+        (buffer[1:], _ensure_contiguous(value).unsqueeze(0)),
+        dim=0,
+    )
+
+
+def _shift_input_queue(queue: torch.Tensor) -> torch.Tensor:
+    return torch.cat((queue[1:], queue[-1:]), dim=0)
+
+
+def lowerable_while_loop_scan(
+    core_fn: Callable,
+    num_inputs: int,
+    num_states: int,
+    num_outputs: int,
+    *flat_args: torch.Tensor,
+    output_template_specs: Optional[OutputTemplateSpecs] = None,
+) -> Tuple[torch.Tensor, ...]:
+    """Run FlexSN scan through PyTorch's built-in ``while_loop`` HOP.
+
+    This is an explicit research helper for probing whether a first-class loop
+    representation is a better fit than the current unrolled scan path.
+    Current PyTorch while-loop capture does not support indexing input
+    sequences by the symbolic loop counter in this path, so the implementation
+    keeps functional queue buffers. Prefer ``lowerable_scan`` for performance
+    experiments on long sequences.
+    """
+    if _torch_while_loop is None:
+        raise RuntimeError("PyTorch while_loop HOP is unavailable in this environment")
+
+    expected = num_inputs + num_states
+    if len(flat_args) < expected:
+        raise ValueError(
+            f"flex_sn_scan expected at least {expected} tensor args "
+            f"(num_inputs={num_inputs} + num_states={num_states}), "
+            f"got {len(flat_args)}"
+        )
+    if num_inputs == 0:
+        raise ValueError("flex_sn_scan requires at least one input sequence")
+
+    input_seqs = tuple(flat_args[:num_inputs])
+    init_states = tuple(flat_args[num_inputs:expected])
+    lifted_args = tuple(flat_args[expected:])
+    _check_lifted_arg_arity(core_fn, num_inputs, num_states, lifted_args)
+    lifted_args = tuple(_ensure_contiguous(arg) for arg in lifted_args)
+
+    T = input_seqs[0].shape[0]
+    for i, x in enumerate(input_seqs):
+        if x.shape[0] != T:
+            raise ValueError(f"input {i} has leading dim {x.shape[0]}, expected {T}")
+
+    if T == 0:
+        empty_outputs = _empty_outputs_from_template(
+            input_seqs, num_outputs, output_template_specs
+        )
+        empty_states = tuple(
+            state.new_empty((0, *state.shape))
+            for state in init_states
+        )
+        return (*empty_outputs, *empty_states)
+
+    input_seqs = tuple(_ensure_contiguous(seq) for seq in input_seqs)
+    init_states = tuple(_ensure_contiguous(state) for state in init_states)
+
+    first_step_inputs = tuple(_ensure_contiguous(x[0]) for x in input_seqs)
+    first_results = core_fn(*first_step_inputs, *init_states, *lifted_args)
+    first_results = (
+        tuple(first_results)
+        if not isinstance(first_results, torch.Tensor)
+        else (first_results,)
+    )
+    if len(first_results) != num_outputs + num_states:
+        raise ValueError(
+            f"core returned {len(first_results)} values, "
+            f"expected num_outputs + num_states = {num_outputs + num_states}"
+        )
+
+    first_outputs = tuple(_ensure_contiguous(x) for x in first_results[:num_outputs])
+    first_states = tuple(_ensure_contiguous(x) for x in first_results[num_outputs:])
+    output_buffers = tuple(
+        _append_to_tail(out.new_zeros((T, *out.shape)), out) for out in first_outputs
+    )
+    state_buffers = tuple(
+        _append_to_tail(state.new_zeros((T, *state.shape)), state)
+        for state in first_states
+    )
+    pending_inputs = tuple(_shift_input_queue(seq) for seq in input_seqs)
+
+    t0 = torch.tensor(
+        1,
+        dtype=torch.int64,
+        device=_carry_device(first_states, input_seqs, first_outputs),
+    )
+
+    def cond_fn(t, *carry):
+        return t < T
+
+    def body_fn(t, *carry):
+        pending_seq_end = num_inputs
+        states_end = pending_seq_end + num_states
+        outputs_end = states_end + num_outputs
+        lifted_end = outputs_end + len(lifted_args)
+
+        step_input_queues = carry[:pending_seq_end]
+        states = carry[pending_seq_end:states_end]
+        outputs_acc = carry[states_end:outputs_end]
+        lifted = carry[outputs_end:lifted_end]
+        states_acc = carry[lifted_end:]
+
+        step_inputs = tuple(_ensure_contiguous(queue[0]) for queue in step_input_queues)
+        results = core_fn(*step_inputs, *states, *lifted)
+        results = tuple(results) if not isinstance(results, torch.Tensor) else (results,)
+        if len(results) != len(first_results):
+            raise ValueError(
+                f"core returned {len(results)} values at runtime, "
+                f"expected {len(first_results)}"
+            )
+        outputs = tuple(_ensure_contiguous(x) for x in results[:num_outputs])
+        next_states = tuple(_ensure_contiguous(x) for x in results[num_outputs:])
+        next_pending_inputs = tuple(
+            _shift_input_queue(queue) for queue in step_input_queues
+        )
+        if len(outputs_acc) != len(outputs):
+            raise ValueError(
+                f"core returned {len(outputs)} outputs at runtime, "
+                f"expected {len(outputs_acc)}"
+            )
+        next_output_acc = tuple(
+            _append_to_tail(outputs_acc[i], outputs[i])
+            for i in range(len(outputs_acc))
+        )
+        if len(states_acc) != len(next_states):
+            raise ValueError(
+                f"core returned {len(next_states)} states at runtime, "
+                f"expected {len(states_acc)}"
+            )
+        next_state_acc = tuple(
+            _append_to_tail(states_acc[i], next_states[i])
+            for i in range(len(states_acc))
+        )
+        return (
+            t + 1,
+            *next_pending_inputs,
+            *next_states,
+            *next_output_acc,
+            *lifted,
+            *next_state_acc,
+        )
+
+    final = _torch_while_loop(
+        cond_fn,
+        body_fn,
+        (
+            t0,
+            *pending_inputs,
+            *first_states,
+            *output_buffers,
+            *lifted_args,
+            *state_buffers,
+        ),
+    )
+    final = tuple(final)
+    pending_seq_end = 1 + num_inputs
+    states_end = pending_seq_end + num_states
+    outputs_end = states_end + num_outputs
+    lifted_end = outputs_end + len(lifted_args)
+    final_output_buffers = final[states_end:outputs_end]
+    final_state_buffers = final[lifted_end:]
+    return (*final_output_buffers, *final_state_buffers)
+
+
+def lowerable_while_loop_scan_final_state(
+    core_fn: Callable,
+    num_inputs: int,
+    num_states: int,
+    num_outputs: int,
+    *flat_args: torch.Tensor,
+    output_template_specs: Optional[OutputTemplateSpecs] = None,
+) -> Tuple[torch.Tensor, ...]:
+    if _torch_while_loop is None:
+        raise RuntimeError("PyTorch while_loop HOP is unavailable in this environment")
+
+    expected = num_inputs + num_states
+    if len(flat_args) < expected:
+        raise ValueError(
+            f"flex_sn_scan expected at least {expected} tensor args "
+            f"(num_inputs={num_inputs} + num_states={num_states}), "
+            f"got {len(flat_args)}"
+        )
+    if num_inputs == 0:
+        raise ValueError("flex_sn_scan requires at least one input sequence")
+
+    input_seqs = tuple(flat_args[:num_inputs])
+    init_states = tuple(flat_args[num_inputs:expected])
+    lifted_args = tuple(flat_args[expected:])
+    _check_lifted_arg_arity(core_fn, num_inputs, num_states, lifted_args)
+    lifted_args = tuple(_ensure_contiguous(arg) for arg in lifted_args)
+
+    T = input_seqs[0].shape[0]
+    for i, x in enumerate(input_seqs):
+        if x.shape[0] != T:
+            raise ValueError(f"input {i} has leading dim {x.shape[0]}, expected {T}")
+
+    if T == 0:
+        empty_outputs = _empty_outputs_from_template(
+            input_seqs, num_outputs, output_template_specs
+        )
+        return (*empty_outputs, *(s.clone() for s in init_states))
+
+    input_seqs = tuple(_ensure_contiguous(seq) for seq in input_seqs)
+    init_states = tuple(_ensure_contiguous(state) for state in init_states)
+
+    first_step_inputs = tuple(_ensure_contiguous(x[0]) for x in input_seqs)
+    first_results = core_fn(*first_step_inputs, *init_states, *lifted_args)
+    first_results = (
+        tuple(first_results)
+        if not isinstance(first_results, torch.Tensor)
+        else (first_results,)
+    )
+    if len(first_results) != num_outputs + num_states:
+        raise ValueError(
+            f"core returned {len(first_results)} values, "
+            f"expected num_outputs + num_states = {num_outputs + num_states}"
+        )
+
+    first_outputs = tuple(_ensure_contiguous(x) for x in first_results[:num_outputs])
+    first_states = tuple(_ensure_contiguous(x) for x in first_results[num_outputs:])
+
+    output_buffers = tuple(
+        _append_to_tail(out.new_zeros((T, *out.shape)), out) for out in first_outputs
+    )
+    pending_inputs = tuple(_shift_input_queue(seq) for seq in input_seqs)
+
+    t0 = torch.tensor(
+        1,
+        dtype=torch.int64,
+        device=_carry_device(first_states, input_seqs, first_outputs),
+    )
+
+    def cond_fn(t, *carry):
+        return t < T
+
+    def body_fn(t, *carry):
+        pending_seq_end = num_inputs
+        states_end = pending_seq_end + num_states
+
+        step_input_queues = carry[:pending_seq_end]
+        outputs_end = states_end + num_outputs
+        lifted_end = outputs_end + len(lifted_args)
+        states = carry[pending_seq_end:states_end]
+        outputs_acc = carry[states_end:outputs_end]
+        lifted = carry[outputs_end:lifted_end]
+
+        step_inputs = tuple(_ensure_contiguous(queue[0]) for queue in step_input_queues)
+        results = core_fn(*step_inputs, *states, *lifted)
+        results = tuple(results) if not isinstance(results, torch.Tensor) else (results,)
+        if len(results) != len(first_results):
+            raise ValueError(
+                f"core returned {len(results)} values at runtime, "
+                f"expected {len(first_results)}"
+            )
+        outputs = tuple(_ensure_contiguous(x) for x in results[:num_outputs])
+        next_states = tuple(_ensure_contiguous(x) for x in results[num_outputs:])
+        next_pending_inputs = tuple(
+            _shift_input_queue(queue) for queue in step_input_queues
+        )
+        if len(outputs_acc) != len(outputs):
+            raise ValueError(
+                f"core returned {len(outputs)} outputs at runtime, "
+                f"expected {len(outputs_acc)}"
+            )
+        next_output_acc = tuple(
+            _append_to_tail(outputs_acc[i], outputs[i])
+            for i in range(len(outputs_acc))
+        )
+        return (
+            t + 1,
+            *next_pending_inputs,
+            *next_states,
+            *next_output_acc,
+            *lifted,
+        )
+
+    final = _torch_while_loop(
+        cond_fn,
+        body_fn,
+        (
+            t0,
+            *pending_inputs,
+            *first_states,
+            *output_buffers,
+            *lifted_args,
+        ),
+    )
+    final = tuple(final)
+    pending_seq_end = 1 + num_inputs
+    states_end = pending_seq_end + num_states
+    outputs_end = states_end + num_outputs
+    final_states = final[pending_seq_end:states_end]
+    final_output_buffers = final[states_end:outputs_end]
+    return (*final_output_buffers, *final_states)
+
+
+flex_sn_scan.py_impl(torch._C.DispatchKey.CompositeExplicitAutograd)(eager_scan)
+# HOPs route every tensor call through the Autograd dispatch key even when
+# ``requires_grad=False``. Re-entering ``eager_scan`` from Autograd is
+# correct: the inner ``core_fn`` invocations build a standard per-timestep
+# autograd graph which is chained via ``torch.stack``/indexing, giving a
+# full BPTT graph. AOTAutograd (``aot_function`` / ``make_fx``) traces this
+# graph natively by unrolling; see module docstring.
+flex_sn_scan.py_impl(torch._C.DispatchKey.Autograd)(eager_scan)
+
+
+def _register_dynamo_hop() -> None:
+    global _DYNAMO_HOP_REGISTERED
+    try:
+        from torch._dynamo.variables import higher_order_ops as hop_vars
+        from torch._dynamo.variables.builder import wrap_fx_proxy
+        from torch._dynamo.variables.constant import ConstantVariable
+        from torch._dynamo.variables.functions import (
+            NestedUserFunctionVariable,
+            UserFunctionVariable,
+        )
+        from torch._dynamo.variables.higher_order_ops import (
+            TorchHigherOrderOperatorVariable,
+            make_attr,
+            speculate_subgraph,
+        )
+        from torch._dynamo.variables.tensor import TensorVariable
+    except (ImportError, ModuleNotFoundError, AttributeError):
+        return
+    except Exception as e:
+        # Import-time registration must never break package import on
+        # unsupported or drifting Torch internals; warn and leave the HOP
+        # available through its eager fallback instead.
+        warnings.warn(
+            f"FlexSN HOP Dynamo registration failed unexpectedly: {type(e).__name__}: {e}",
+            stacklevel=2,
+        )
+        return
+
+    make_descriptor = TorchHigherOrderOperatorVariable.__dict__.get("make")
+    original_make_is_bound = make_descriptor is None
+    if make_descriptor is None:
+        make_descriptor = TorchHigherOrderOperatorVariable.make
+    make_func = (
+        make_descriptor.__func__
+        if isinstance(make_descriptor, (classmethod, staticmethod))
+        else make_descriptor
+    )
+    if getattr(make_func, "_spikingjelly_flexsn_hop", False):
+        _DYNAMO_HOP_REGISTERED = True
+        return
+
+    original_make = make_descriptor
+
+    install_subgraph = getattr(hop_vars, "add_subgraph", None)
+    if install_subgraph is None:
+        def install_subgraph(tx, source, name, gm):
+            return tx.output.install_subgraph(name, gm)
+
+    class FlexSNScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
+        _HOP_NAME = "spikingjelly.flex_sn_scan"
+        _ALLOW_FALLBACK_TO_EAGER = False
+
+        def call_function(self, tx, args, kwargs):
+            output_template_specs_arg = kwargs.pop("output_template_specs", None)
+            if kwargs:
+                raise hop_vars.unimplemented(
+                    "flex_sn_scan only supports output_template_specs as a kwarg"
+                )
+            explicit_output_template_specs = None
+            if output_template_specs_arg is not None:
+                try:
+                    explicit_output_template_specs = (
+                        output_template_specs_arg.as_python_constant()
+                    )
+                except Exception:
+                    raise hop_vars.unimplemented(
+                        "flex_sn_scan output_template_specs must be a Python constant"
+                    )
+
+            if len(args) < 4:
+                raise hop_vars.unimplemented(
+                    "flex_sn_scan expects body_fn, num_inputs, num_states, "
+                    "num_outputs, and tensor arguments"
+                )
+
+            body_fn = args[0]
+            if not isinstance(body_fn, (UserFunctionVariable, NestedUserFunctionVariable)):
+                raise hop_vars.unimplemented(
+                    "flex_sn_scan expects a user-defined Python function body"
+                )
+
+            const_args = args[1:4]
+            if not all(isinstance(arg, ConstantVariable) for arg in const_args):
+                raise hop_vars.unimplemented(
+                    "flex_sn_scan expects num_inputs/num_states/num_outputs to be constants"
+                )
+
+            num_inputs, num_states, num_outputs = [
+                arg.as_python_constant() for arg in const_args
+            ]
+            flat_args = args[4:]
+            expected = num_inputs + num_states
+            if len(flat_args) < expected:
+                raise hop_vars.unimplemented(
+                    f"flex_sn_scan expected at least {expected} tensor args, got {len(flat_args)}"
+                )
+            if num_inputs == 0:
+                raise hop_vars.unimplemented(
+                    "flex_sn_scan requires at least one input sequence"
+                )
+            if not all(isinstance(arg, TensorVariable) for arg in flat_args):
+                raise hop_vars.unimplemented(
+                    "flex_sn_scan only supports tensor inputs and states"
+                )
+
+            def _make_step_template(arg: TensorVariable):
+                example_value = arg.as_proxy().node.meta["example_value"]
+                if example_value.shape[0] > 0:
+                    return arg.call_method(tx, "__getitem__", [ConstantVariable(0)], {})
+
+                shape_without_t = tuple(example_value.shape[1:])
+                proxy = tx.output.create_proxy(
+                    "call_function",
+                    torch.ops.aten.new_empty.default,
+                    args=(arg.as_proxy(), shape_without_t),
+                    kwargs={},
+                )
+                return wrap_fx_proxy(
+                    tx=tx,
+                    proxy=proxy,
+                    example_value=example_value.new_empty(shape_without_t),
+                )
+
+            step_inputs = [_make_step_template(arg) for arg in flat_args[:num_inputs]]
+            body_args = [*step_inputs, *flat_args[num_inputs:]]
+            canonical_body_arg_names = tuple(
+                arg.as_proxy().node.name for arg in body_args
+            )
+
+            speculated = speculate_subgraph(
+                tx,
+                body_fn,
+                body_args,
+                {},
+                "flex_sn_scan",
+                source_target=self.value,
+            )
+            if len(speculated) == 4:
+                (
+                    _body_r,
+                    body_graph,
+                    body_lifted_freevars,
+                    _parent_proxy_map,
+                ) = speculated
+            elif len(speculated) == 3:
+                _body_r, body_graph, body_lifted_freevars = speculated
+            else:
+                raise hop_vars.unimplemented(
+                    "flex_sn_scan received an unsupported speculate_subgraph result"
+                )
+
+            if hasattr(body_lifted_freevars, "keys"):
+                lifted_freevars = tuple(body_lifted_freevars.keys())
+            else:
+                lifted_freevars = tuple(body_lifted_freevars)
+            if lifted_freevars and not all(
+                isinstance(freevar, torch.fx.Proxy) for freevar in lifted_freevars
+            ):
+                raise hop_vars.unimplemented(
+                    "flex_sn_scan only supports tensor lifted freevars"
+                )
+            for freevar in lifted_freevars:
+                example_value = freevar.node.meta.get("example_value")
+                if not isinstance(example_value, torch.Tensor):
+                    raise hop_vars.unimplemented(
+                        "flex_sn_scan only supports tensor lifted freevars"
+                    )
+
+            placeholders = _reorder_placeholders_to_canonical_args(
+                body_graph, canonical_body_arg_names
+            )
+            placeholder_freevar_names = tuple(
+                node.name for node in placeholders[len(body_args) :]
+            )
+            if placeholder_freevar_names:
+                freevars_by_name = {
+                    freevar.node.name: freevar for freevar in lifted_freevars
+                }
+                missing = [
+                    name
+                    for name in placeholder_freevar_names
+                    if name not in freevars_by_name
+                ]
+                if missing:
+                    raise hop_vars.unimplemented(
+                        "flex_sn_scan could not map lifted tensor freevars"
+                    )
+                lifted_freevars = tuple(
+                    freevars_by_name[name] for name in placeholder_freevar_names
+                )
+            else:
+                lifted_freevars = ()
+
+            body_gm = torch.fx.GraphModule(tx.output.nn_modules, body_graph)
+            body_name = install_subgraph(tx, self.source, "flex_sn_scan_body", body_gm)
+            body_node = make_attr(tx, body_name)
+            output_template_specs = _output_template_specs_from_dynamo_body_result(
+                _body_r,
+                num_outputs,
+            )
+            if explicit_output_template_specs is not None:
+                output_template_specs = explicit_output_template_specs
+            proxy_kwargs = (
+                {}
+                if output_template_specs is None
+                else {"output_template_specs": output_template_specs}
+            )
+
+            proxy = tx.output.create_proxy(
+                "call_function",
+                self.value,
+                args=(
+                    body_node,
+                    num_inputs,
+                    num_states,
+                    num_outputs,
+                    *(arg.as_proxy() for arg in flat_args),
+                    *lifted_freevars,
+                ),
+                kwargs=proxy_kwargs,
+            )
+            body_leaves = _flatten_dynamo_body_result(_body_r)
+            example_value = []
+            T = flat_args[0].as_proxy().node.meta["example_value"].shape[0]
+            for i in range(num_outputs + num_states):
+                if i >= len(body_leaves):
+                    example_value = None
+                    break
+                leaf_ev = _dynamo_leaf_example_value(body_leaves[i])
+                if not isinstance(leaf_ev, torch.Tensor):
+                    example_value = None
+                    break
+                example_value.append(leaf_ev.new_empty((T, *leaf_ev.shape)))
+            if example_value is None:
+                example_value = eager_scan(
+                    body_gm,
+                    num_inputs,
+                    num_states,
+                    num_outputs,
+                    *(
+                        arg.as_proxy().node.meta["example_value"]
+                        for arg in flat_args
+                    ),
+                    *(
+                        freevar.node.meta["example_value"]
+                        for freevar in lifted_freevars
+                    ),
+                    output_template_specs=output_template_specs,
+                )
+            else:
+                example_value = tuple(example_value)
+            return wrap_fx_proxy(tx=tx, proxy=proxy, example_value=example_value)
+
+    def patched_make(cls, value, source=None, **kwargs):
+        if value is flex_sn_scan:
+            return FlexSNScanHigherOrderVariable(value, source, **kwargs)
+        if isinstance(original_make, classmethod):
+            return original_make.__func__(cls, value, source=source, **kwargs)
+        if isinstance(original_make, staticmethod):
+            return original_make.__func__(value, source=source, **kwargs)
+        if original_make_is_bound:
+            return original_make(value, source=source, **kwargs)
+        return original_make(cls, value, source=source, **kwargs)
+
+    patched_make._spikingjelly_flexsn_hop = True
+    # Dynamo does not currently expose a public registry for this HOP hook.
+    # Patch only the flex_sn_scan dispatch and delegate every other operator
+    # back to PyTorch's original implementation.
+    TorchHigherOrderOperatorVariable.make = classmethod(patched_make)
+    _DYNAMO_HOP_REGISTERED = True
+
+
+_register_dynamo_hop()

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -117,6 +117,50 @@ class FlexSNScan(HigherOrderOperator):
         *flat_args: torch.Tensor,
         output_template_specs: Optional[OutputTemplateSpecs] = None,
     ) -> Tuple[torch.Tensor, ...]:
+        """Invoke the FlexSN scan HigherOrderOperator.
+
+        Chinese:
+            调用 FlexSN scan HigherOrderOperator。
+
+        English:
+            Invoke the FlexSN scan HigherOrderOperator with flattened
+            input-sequence, initial-state, and lifted tensor arguments.
+
+        :param core_fn: EN: Single-step core callable with signature
+            ``(*step_inputs, *states, *lifted_args)``.
+            Chinese: 单步 ``core`` 可调用对象, 签名为
+            ``(*step_inputs, *states, *lifted_args)``。
+        :type core_fn: Callable
+        :param num_inputs: EN: Number of T-leading input sequences.
+            Chinese: 带时间维 ``T`` 的输入序列数量。
+        :type num_inputs: int
+        :param num_states: EN: Number of initial-state tensors without a time
+            dimension. Chinese: 不带时间维的初始状态张量数量。
+        :type num_states: int
+        :param num_outputs: EN: Number of per-step outputs produced by
+            ``core_fn``. Chinese: ``core_fn`` 每个时间步产生的输出数量。
+        :type num_outputs: int
+        :param flat_args: EN: Flattened tensor arguments: first the
+            ``num_inputs`` input sequences ``[T, ...]``, then the
+            ``num_states`` initial states, then any lifted tensor freevars.
+            Chinese: 展平后的张量参数: 先是 ``num_inputs`` 个输入序列 ``[T, ...]``,
+            再是 ``num_states`` 个初始状态, 最后是提升出来的张量自由变量。
+        :type flat_args: torch.Tensor
+        :param output_template_specs: EN: Optional output templates used when
+            ``T == 0`` to materialize empty output sequences without executing
+            ``core_fn``. Each item is ``(shape, dtype)`` or
+            ``(shape, dtype, device)``; when ``device`` is omitted, the runtime
+            device follows the first input sequence. Chinese: 可选输出模板, 在
+            ``T == 0`` 时用于在不执行 ``core_fn`` 的情况下构造空输出序列。每个模板
+            为 ``(shape, dtype)`` 或 ``(shape, dtype, device)``；省略 ``device``
+            时, 运行时设备跟随第一个输入序列。
+        :type output_template_specs: Optional[OutputTemplateSpecs]
+        :return: EN: ``num_outputs`` output sequences followed by ``num_states``
+            state sequences, all stacked along the leading time dimension.
+            Chinese: 先返回 ``num_outputs`` 个输出序列, 再返回 ``num_states`` 个
+            状态序列, 均沿首个时间维进行堆叠。
+        :rtype: Tuple[torch.Tensor, ...]
+        """
         return super().__call__(
             core_fn,
             num_inputs,
@@ -236,28 +280,36 @@ def lowerable_while_loop_available() -> bool:
     return _torch_while_loop is not None
 
 
-def _callable_positional_arg_capacity(fn: Callable) -> int | None:
+def _callable_positional_arg_range(fn: Callable) -> tuple[int, int | None] | None:
     target = fn.forward if isinstance(fn, torch.nn.Module) else fn
     try:
         signature = inspect.signature(target)
     except (TypeError, ValueError):
         return None
-    positional = 0
+    min_required = 0
+    positional_capacity = 0
     for parameter in signature.parameters.values():
         if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
-            return None
+            return min_required, None
         if parameter.kind in (
             inspect.Parameter.POSITIONAL_ONLY,
             inspect.Parameter.POSITIONAL_OR_KEYWORD,
         ):
-            positional += 1
-    return positional
+            positional_capacity += 1
+            if parameter.default is inspect.Parameter.empty:
+                min_required += 1
+    return min_required, positional_capacity
 
 
 def _callable_accepts_positional_args(fn: Callable, n_args: int) -> bool | None:
-    capacity = _callable_positional_arg_capacity(fn)
-    if capacity is None:
+    arg_range = _callable_positional_arg_range(fn)
+    if arg_range is None:
         return None
+    min_required, capacity = arg_range
+    if n_args < min_required:
+        return False
+    if capacity is None:
+        return True
     return n_args <= capacity
 
 
@@ -289,8 +341,6 @@ def _check_lifted_arg_arity(
     num_states: int,
     lifted_args: Tuple[torch.Tensor, ...],
 ) -> None:
-    if not lifted_args:
-        return
     expected = num_inputs + num_states
     total = expected + len(lifted_args)
     accepts = _callable_accepts_positional_args(core_fn, total)
@@ -310,12 +360,49 @@ def eager_scan(
     *flat_args: torch.Tensor,
     output_template_specs: Optional[OutputTemplateSpecs] = None,
 ) -> Tuple[torch.Tensor, ...]:
-    """Plain-Python scan loop reused by both the HOP eager impl and the
-    Dynamo-friendly path in :class:`FlexSN` (see ``backend="inductor"``).
+    """Run the FlexSN scan with an eager Python time-step loop.
 
-    Dynamo cannot enter a :class:`HigherOrderOperator` today; calling this
-    helper directly under ``torch.compile`` lets Dynamo trace the unrolled
-    loop into an FX graph that Inductor can lower normally.
+    Chinese:
+        通过 Python 时间步循环执行 FlexSN scan。
+
+    English:
+        Run the FlexSN scan with an eager Python loop. This helper is reused by
+        both the HOP eager implementation and the Dynamo-friendly
+        ``backend="inductor"`` path, so ``torch.compile`` can trace the
+        unrolled loop into a standard FX graph.
+
+        When ``T == 0``, ``output_template_specs`` must describe the output
+        sequence shapes/dtypes so empty outputs can be materialized without
+        executing ``core_fn``.
+
+    :param core_fn: EN: Single-step core callable with signature
+        ``(*step_inputs, *states, *lifted_args)``.
+        Chinese: 单步 ``core`` 可调用对象, 签名为
+        ``(*step_inputs, *states, *lifted_args)``。
+    :type core_fn: Callable
+    :param num_inputs: EN: Number of T-leading input sequences.
+        Chinese: 带时间维 ``T`` 的输入序列数量。
+    :type num_inputs: int
+    :param num_states: EN: Number of initial-state tensors.
+        Chinese: 初始状态张量数量。
+    :type num_states: int
+    :param num_outputs: EN: Number of per-step outputs.
+        Chinese: 每个时间步输出数量。
+    :type num_outputs: int
+    :param flat_args: EN: Flattened input sequences, initial states, then lifted
+        tensor freevars. Chinese: 展平后的输入序列、初始状态以及提升出来的张量自由变量。
+    :type flat_args: torch.Tensor
+    :param output_template_specs: EN: Optional ``(shape, dtype)`` or
+        ``(shape, dtype, device)`` templates used to build empty output
+        sequences when ``T == 0``. Omitted devices follow the first input
+        sequence at runtime. Chinese: 在 ``T == 0`` 时用于构造空输出序列的可选模板,
+        每项为 ``(shape, dtype)`` 或 ``(shape, dtype, device)``；省略 ``device``
+        时运行时设备跟随第一个输入序列。
+    :type output_template_specs: Optional[OutputTemplateSpecs]
+    :return: EN: ``num_outputs`` output sequences followed by ``num_states``
+        state sequences. Chinese: 先返回 ``num_outputs`` 个输出序列, 再返回
+        ``num_states`` 个状态序列。
+    :rtype: Tuple[torch.Tensor, ...]
     """
     expected = num_inputs + num_states
     if len(flat_args) < expected:
@@ -384,11 +471,42 @@ def eager_scan_final_state(
     *flat_args: torch.Tensor,
     output_template_specs: Optional[OutputTemplateSpecs] = None,
 ) -> Tuple[torch.Tensor, ...]:
-    """Variant of :func:`eager_scan` that returns output sequences followed by
-    final states only.
+    """Run the eager scan and return output sequences plus final states.
 
-    This is used by :class:`FlexSN` when ``store_state_seqs=False`` so the HOP
-    backend does not materialize full state sequences only to discard them.
+    Chinese:
+        执行 eager scan, 返回输出序列以及最终状态。
+
+    English:
+        Variant of :func:`eager_scan` used when ``store_state_seqs=False`` so
+        the HOP backend does not materialize full state sequences only to
+        discard them. When ``T == 0``, ``output_template_specs`` is used to
+        build empty output sequences and the provided initial states are cloned
+        into the returned final states.
+
+    :param core_fn: EN: Single-step core callable. Chinese: 单步 ``core`` 可调用对象。
+    :type core_fn: Callable
+    :param num_inputs: EN: Number of T-leading input sequences.
+        Chinese: 带时间维 ``T`` 的输入序列数量。
+    :type num_inputs: int
+    :param num_states: EN: Number of initial-state tensors.
+        Chinese: 初始状态张量数量。
+    :type num_states: int
+    :param num_outputs: EN: Number of per-step outputs.
+        Chinese: 每个时间步输出数量。
+    :type num_outputs: int
+    :param flat_args: EN: Flattened input sequences, initial states, then lifted
+        tensor freevars. Chinese: 展平后的输入序列、初始状态以及提升出来的张量自由变量。
+    :type flat_args: torch.Tensor
+    :param output_template_specs: EN: Optional ``(shape, dtype)`` or
+        ``(shape, dtype, device)`` templates used to materialize empty output
+        sequences when ``T == 0``. Omitted devices follow the first input
+        sequence at runtime. Chinese: 在 ``T == 0`` 时用于构造空输出序列的可选模板,
+        每项为 ``(shape, dtype)`` 或 ``(shape, dtype, device)``；省略 ``device``
+        时运行时设备跟随第一个输入序列。
+    :type output_template_specs: Optional[OutputTemplateSpecs]
+    :return: EN: ``num_outputs`` output sequences followed by the final states.
+        Chinese: 先返回 ``num_outputs`` 个输出序列, 再返回最终状态。
+    :rtype: Tuple[torch.Tensor, ...]
     """
     expected = num_inputs + num_states
     if len(flat_args) < expected:
@@ -452,17 +570,45 @@ def lowerable_scan(
 ) -> Tuple[torch.Tensor, ...]:
     """Run FlexSN scan through PyTorch's built-in ``scan`` HOP.
 
-    This path keeps the scan as a single higher-order op under tracing so
-    downstream compilers can decompose it to a loop instead of unrolling the
-    body T times in the traced graph. It is currently intended as an
-    experimental helper for investigation rather than a production default.
+    Chinese:
+        通过 PyTorch 内置 ``scan`` HOP 执行 FlexSN scan。
 
-    Notes:
-    * On the PyTorch versions we validate against, fake/proxy/export handling
-      for this out-of-tree scan pattern is still not stable enough to make this
-      the default compiled path.
-    * We pass flattened input/state leaves directly to ``torch.ops.higher_order.scan``
-      and rebuild the structured inputs inside ``wrapped_combine_fn``.
+    English:
+        Keep the FlexSN scan as a single higher-order op under tracing so
+        downstream compilers can lower it as a loop instead of fully unrolling
+        the body ``T`` times. This remains an experimental helper rather than
+        the default compiled path.
+
+        When ``T == 0``, ``output_template_specs`` must contain
+        ``num_outputs`` items shaped as ``(shape, dtype)`` or
+        ``(shape, dtype, device)``. Runtime devices default to the first input
+        sequence when omitted.
+
+    :param core_fn: EN: Single-step core callable. Chinese: 单步 ``core`` 可调用对象。
+    :type core_fn: Callable
+    :param num_inputs: EN: Number of T-leading input sequences.
+        Chinese: 带时间维 ``T`` 的输入序列数量。
+    :type num_inputs: int
+    :param num_states: EN: Number of initial-state tensors.
+        Chinese: 初始状态张量数量。
+    :type num_states: int
+    :param num_outputs: EN: Number of per-step outputs.
+        Chinese: 每个时间步输出数量。
+    :type num_outputs: int
+    :param flat_args: EN: Flattened input sequences, initial states, then lifted
+        tensor freevars. Chinese: 展平后的输入序列、初始状态以及提升出来的张量自由变量。
+    :type flat_args: torch.Tensor
+    :param output_template_specs: EN: Optional ``(shape, dtype)`` or
+        ``(shape, dtype, device)`` templates used to materialize empty output
+        sequences when ``T == 0``. Omitted devices follow the first input
+        sequence at runtime. Chinese: 在 ``T == 0`` 时用于构造空输出序列的可选模板,
+        每项为 ``(shape, dtype)`` 或 ``(shape, dtype, device)``；省略 ``device``
+        时运行时设备跟随第一个输入序列。
+    :type output_template_specs: Optional[OutputTemplateSpecs]
+    :return: EN: ``num_outputs`` output sequences followed by ``num_states``
+        state sequences. Chinese: 先返回 ``num_outputs`` 个输出序列, 再返回
+        ``num_states`` 个状态序列。
+    :rtype: Tuple[torch.Tensor, ...]
     """
     if _torch_scan_op is None:
         raise RuntimeError("PyTorch scan HOP is unavailable in this environment")
@@ -554,6 +700,41 @@ def lowerable_scan_final_state(
     *flat_args: torch.Tensor,
     output_template_specs: Optional[OutputTemplateSpecs] = None,
 ) -> Tuple[torch.Tensor, ...]:
+    """Run the built-in ``scan`` HOP and return final states only.
+
+    Chinese:
+        通过内置 ``scan`` HOP 执行 FlexSN, 返回输出序列与最终状态。
+
+    English:
+        Final-state variant of :func:`lowerable_scan`. When ``T == 0``,
+        ``output_template_specs`` materializes empty output sequences and the
+        initial states are cloned into the returned final states.
+
+    :param core_fn: EN: Single-step core callable. Chinese: 单步 ``core`` 可调用对象。
+    :type core_fn: Callable
+    :param num_inputs: EN: Number of T-leading input sequences.
+        Chinese: 带时间维 ``T`` 的输入序列数量。
+    :type num_inputs: int
+    :param num_states: EN: Number of initial-state tensors.
+        Chinese: 初始状态张量数量。
+    :type num_states: int
+    :param num_outputs: EN: Number of per-step outputs.
+        Chinese: 每个时间步输出数量。
+    :type num_outputs: int
+    :param flat_args: EN: Flattened input sequences, initial states, then lifted
+        tensor freevars. Chinese: 展平后的输入序列、初始状态以及提升出来的张量自由变量。
+    :type flat_args: torch.Tensor
+    :param output_template_specs: EN: Optional ``(shape, dtype)`` or
+        ``(shape, dtype, device)`` templates used to materialize empty output
+        sequences when ``T == 0``. Omitted devices follow the first input
+        sequence at runtime. Chinese: 在 ``T == 0`` 时用于构造空输出序列的可选模板,
+        每项为 ``(shape, dtype)`` 或 ``(shape, dtype, device)``；省略 ``device``
+        时运行时设备跟随第一个输入序列。
+    :type output_template_specs: Optional[OutputTemplateSpecs]
+    :return: EN: ``num_outputs`` output sequences followed by the final states.
+        Chinese: 先返回 ``num_outputs`` 个输出序列, 再返回最终状态。
+    :rtype: Tuple[torch.Tensor, ...]
+    """
     if _torch_scan_op is None:
         raise RuntimeError("PyTorch scan HOP is unavailable in this environment")
 
@@ -667,12 +848,43 @@ def lowerable_while_loop_scan(
 ) -> Tuple[torch.Tensor, ...]:
     """Run FlexSN scan through PyTorch's built-in ``while_loop`` HOP.
 
-    This is an explicit research helper for probing whether a first-class loop
-    representation is a better fit than the current unrolled scan path.
-    Current PyTorch while-loop capture does not support indexing input
-    sequences by the symbolic loop counter in this path, so the implementation
-    keeps functional queue buffers. Prefer ``lowerable_scan`` for performance
-    experiments on long sequences.
+    Chinese:
+        通过 PyTorch 内置 ``while_loop`` HOP 执行 FlexSN scan。
+
+    English:
+        Experimental helper for studying whether a first-class loop
+        representation is a better fit than the current unrolled scan path.
+        Current while-loop capture does not support symbolic ``x[t]`` indexing
+        here, so this implementation keeps functional queue buffers.
+
+        When ``T == 0``, ``output_template_specs`` materializes empty output
+        sequences without running ``core_fn``.
+
+    :param core_fn: EN: Single-step core callable. Chinese: 单步 ``core`` 可调用对象。
+    :type core_fn: Callable
+    :param num_inputs: EN: Number of T-leading input sequences.
+        Chinese: 带时间维 ``T`` 的输入序列数量。
+    :type num_inputs: int
+    :param num_states: EN: Number of initial-state tensors.
+        Chinese: 初始状态张量数量。
+    :type num_states: int
+    :param num_outputs: EN: Number of per-step outputs.
+        Chinese: 每个时间步输出数量。
+    :type num_outputs: int
+    :param flat_args: EN: Flattened input sequences, initial states, then lifted
+        tensor freevars. Chinese: 展平后的输入序列、初始状态以及提升出来的张量自由变量。
+    :type flat_args: torch.Tensor
+    :param output_template_specs: EN: Optional ``(shape, dtype)`` or
+        ``(shape, dtype, device)`` templates used to materialize empty output
+        sequences when ``T == 0``. Omitted devices follow the first input
+        sequence at runtime. Chinese: 在 ``T == 0`` 时用于构造空输出序列的可选模板,
+        每项为 ``(shape, dtype)`` 或 ``(shape, dtype, device)``；省略 ``device``
+        时运行时设备跟随第一个输入序列。
+    :type output_template_specs: Optional[OutputTemplateSpecs]
+    :return: EN: ``num_outputs`` output sequences followed by ``num_states``
+        state sequences. Chinese: 先返回 ``num_outputs`` 个输出序列, 再返回
+        ``num_states`` 个状态序列。
+    :rtype: Tuple[torch.Tensor, ...]
     """
     if _torch_while_loop is None:
         raise RuntimeError("PyTorch while_loop HOP is unavailable in this environment")
@@ -826,6 +1038,42 @@ def lowerable_while_loop_scan_final_state(
     *flat_args: torch.Tensor,
     output_template_specs: Optional[OutputTemplateSpecs] = None,
 ) -> Tuple[torch.Tensor, ...]:
+    """Run the while-loop HOP and return output sequences plus final states.
+
+    Chinese:
+        执行 while-loop HOP, 返回输出序列以及最终状态。
+
+    English:
+        Final-state variant of :func:`lowerable_while_loop_scan`. When
+        ``T == 0``, ``output_template_specs`` is used to build empty output
+        sequences and the provided initial states are cloned into the returned
+        final states.
+
+    :param core_fn: EN: Single-step core callable. Chinese: 单步 ``core`` 可调用对象。
+    :type core_fn: Callable
+    :param num_inputs: EN: Number of T-leading input sequences.
+        Chinese: 带时间维 ``T`` 的输入序列数量。
+    :type num_inputs: int
+    :param num_states: EN: Number of initial-state tensors.
+        Chinese: 初始状态张量数量。
+    :type num_states: int
+    :param num_outputs: EN: Number of per-step outputs.
+        Chinese: 每个时间步输出数量。
+    :type num_outputs: int
+    :param flat_args: EN: Flattened input sequences, initial states, then lifted
+        tensor freevars. Chinese: 展平后的输入序列、初始状态以及提升出来的张量自由变量。
+    :type flat_args: torch.Tensor
+    :param output_template_specs: EN: Optional ``(shape, dtype)`` or
+        ``(shape, dtype, device)`` templates used to materialize empty output
+        sequences when ``T == 0``. Omitted devices follow the first input
+        sequence at runtime. Chinese: 在 ``T == 0`` 时用于构造空输出序列的可选模板,
+        每项为 ``(shape, dtype)`` 或 ``(shape, dtype, device)``；省略 ``device``
+        时运行时设备跟随第一个输入序列。
+    :type output_template_specs: Optional[OutputTemplateSpecs]
+    :return: EN: ``num_outputs`` output sequences followed by the final states.
+        Chinese: 先返回 ``num_outputs`` 个输出序列, 再返回最终状态。
+    :rtype: Tuple[torch.Tensor, ...]
+    """
     if _torch_while_loop is None:
         raise RuntimeError("PyTorch while_loop HOP is unavailable in this environment")
 

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -1221,6 +1221,9 @@ def _register_dynamo_hop() -> None:
         if isinstance(original_make, staticmethod):
             return original_make.__func__(value, source=source, **kwargs)
         if original_make_is_bound:
+            original_make_func = getattr(original_make, "__func__", None)
+            if original_make_func is not None:
+                return original_make_func(cls, value, source=source, **kwargs)
             return original_make(value, source=source, **kwargs)
         return original_make(cls, value, source=source, **kwargs)
 

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/hop.py
@@ -262,21 +262,63 @@ def _output_template_specs_from_dynamo_body_result(
         example_value = _dynamo_leaf_example_value(leaf)
         if not isinstance(example_value, torch.Tensor):
             return None
-        specs.append(
-            (tuple(example_value.shape), example_value.dtype, example_value.device)
-        )
+        specs.append((tuple(example_value.shape), example_value.dtype))
     return tuple(specs)
 
 
 def lowerable_scan_available() -> bool:
+    """Report whether PyTorch's built-in ``scan`` HOP is available.
+
+    Chinese:
+        返回当前环境是否提供 PyTorch 内置 ``scan`` HOP。
+
+    English:
+        Return whether the current environment exposes PyTorch's built-in
+        ``scan`` higher-order operator.
+
+    :returns: EN: ``True`` when ``torch.ops.higher_order.scan`` is available;
+        otherwise ``False``. Chinese: 若 ``torch.ops.higher_order.scan`` 可用则
+        返回 ``True``，否则返回 ``False``。
+    :rtype: bool
+    """
     return _torch_scan_op is not None
 
 
 def dynamo_hop_available() -> bool:
+    """Report whether the FlexSN Dynamo HOP registration succeeded.
+
+    Chinese:
+        返回 FlexSN 的 Dynamo HOP 注册是否成功。
+
+    English:
+        Return whether the FlexSN-specific Dynamo HigherOrderOperator
+        registration has been installed successfully.
+
+    :returns: EN: ``True`` when the Dynamo compatibility shim for
+        ``flex_sn_scan`` is registered; otherwise ``False``. Chinese:
+        当 ``flex_sn_scan`` 的 Dynamo 兼容注册已完成时返回 ``True``，否则返回
+        ``False``。
+    :rtype: bool
+    """
     return _DYNAMO_HOP_REGISTERED
 
 
 def lowerable_while_loop_available() -> bool:
+    """Report whether PyTorch's built-in ``while_loop`` HOP is available.
+
+    Chinese:
+        返回当前环境是否提供 PyTorch 内置 ``while_loop`` HOP。
+
+    English:
+        Return whether the current environment exposes PyTorch's built-in
+        ``while_loop`` higher-order operator.
+
+    :returns: EN: ``True`` when ``torch.ops.higher_order.while_loop`` is
+        available; otherwise ``False``. Chinese: 若
+        ``torch.ops.higher_order.while_loop`` 可用则返回 ``True``，否则返回
+        ``False``。
+    :rtype: bool
+    """
     return _torch_while_loop is not None
 
 

--- a/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/kernel.py
+++ b/spikingjelly/activation_based/triton_kernel/flex_sn_inductor/kernel.py
@@ -1,46 +1,39 @@
 """Build Triton scan kernels from a user-defined core_fn for FlexSN inductor backend.
 
-Two entry points:
+Three entry points:
 * build_inference_kernel  — no-grad fast path (make_fx, no PYTORCH_JIT=0 needed)
 * build_inference_final_state_kernel — inference path that returns final states only
 * build_training_kernels  — forward + backward kernels for full BPTT training
 """
 from __future__ import annotations
 
-import hashlib
 from typing import Callable, List, Optional, Tuple
 
 import torch
 
 
-def _clone_example_inputs(
-    example_inputs: Tuple[torch.Tensor, ...] | None,
-    count: int,
-):
+def _example_build_device(example_inputs: Optional[Tuple[torch.Tensor, ...]]):
+    if example_inputs is not None:
+        for tensor in example_inputs:
+            if tensor.device.type == "cuda":
+                return tensor.device
+    return torch.device("cuda", torch.cuda.current_device())
+
+
+def _prepare_example_inputs(
+    example_inputs: Optional[Tuple[torch.Tensor, ...]],
+    num_inputs: int,
+    num_states: int,
+) -> Tuple[torch.Tensor, ...]:
+    build_device = _example_build_device(example_inputs)
     if example_inputs is None:
-        return tuple(torch.zeros(1, device="cuda") for _ in range(count))
-    return tuple(x.detach().clone() for x in example_inputs)
-
-
-def _make_core_name(core_fn: Callable, suffix: str, *graphs) -> str:
-    raw_name = getattr(core_fn, "__name__", type(core_fn).__name__)
-    safe_name = "".join(c if c.isalnum() else "_" for c in raw_name) or "core"
-    graph_fingerprint = hashlib.sha1(
-        "||".join(str(graph) for graph in graphs).encode("utf-8")
-    ).hexdigest()[:8]
-    return f"{safe_name}_{graph_fingerprint}_{suffix}"
-
-
-def _training_final_state_specialized_wins(info) -> bool:
-    saved_non_output_indices = []
-    seen = set()
-    for idx in info.c2k_return_mapping:
-        if idx < info.num_outputs or idx in seen:
-            continue
-        saved_non_output_indices.append(idx)
-        seen.add(idx)
-    specialized_seq_count = info.num_outputs + len(saved_non_output_indices)
-    return specialized_seq_count < info.num_fwd_kernel_returns
+        return tuple(
+            torch.zeros(1, device=build_device)
+            for _ in range(num_inputs + num_states)
+        )
+    # .clone() breaks aliasing: in-place ops inside core_fn during tracing
+    # must not silently mutate the caller's original buffers.
+    return tuple(x.detach().to(build_device).clone() for x in example_inputs)
 
 
 def build_inference_kernel(
@@ -74,9 +67,7 @@ def build_inference_kernel(
     from ..torch2triton import generate_triton_code_str
     from ..flexsn import extract_info, get_flexsn_inference_kernel
 
-    # .clone() breaks aliasing: in-place ops inside core_fn during tracing
-    # must not silently mutate the caller's original buffers.
-    example_inputs = _clone_example_inputs(example_inputs, num_inputs + num_states)
+    example_inputs = _prepare_example_inputs(example_inputs, num_inputs, num_states)
 
     # Trace core_fn to an aten-level FX graph (no PYTORCH_JIT=0 needed).
     traced = make_fx(core_fn)(*example_inputs)
@@ -85,7 +76,9 @@ def build_inference_kernel(
     # Generate Triton function source for the per-step body.
     # Sanitize name: lambdas → "<lambda>", functools.partial → no __name__.
     # Replace every non-alphanumeric character (including < > space) with "_".
-    core_name = _make_core_name(core_fn, "inductor_scan", graph)
+    raw_name = getattr(core_fn, "__name__", type(core_fn).__name__)
+    safe_name = "".join(c if c.isalnum() else "_" for c in raw_name)
+    core_name = f"{safe_name}_inductor_scan"
     core_str, core_name = generate_triton_code_str(graph, core_name)
 
     # Extract metadata: arg/return names, output/state counts.
@@ -104,16 +97,36 @@ def build_inference_final_state_kernel(
     num_outputs: int,
     example_inputs: Optional[Tuple[torch.Tensor, ...]] = None,
 ):
+    """Build an inference kernel that returns output sequences and final states.
+
+    This final-state variant traces ``core_fn`` and generates a Triton kernel
+    like :func:`build_inference_kernel`, but returns only the final state
+    tensors instead of full state sequences.
+
+    Args:
+        core_fn: single-step dynamics callable with signature
+            ``(*inputs, *states) -> (*outputs, *updated_states)``.
+        num_inputs: number of per-step input tensors.
+        num_states: number of state tensors.
+        num_outputs: number of per-step output tensors.
+        example_inputs: optional example tensors ``[*inputs, *states]``.
+
+    Returns:
+        ``(kernel, info)`` from ``get_flexsn_inference_final_state_kernel``
+        and ``extract_info``.
+    """
     from torch.fx.experimental.proxy_tensor import make_fx
     from ..torch2triton import generate_triton_code_str
     from ..flexsn import extract_info, get_flexsn_inference_final_state_kernel
 
-    example_inputs = _clone_example_inputs(example_inputs, num_inputs + num_states)
+    example_inputs = _prepare_example_inputs(example_inputs, num_inputs, num_states)
 
     traced = make_fx(core_fn)(*example_inputs)
     graph = traced.graph
 
-    core_name = _make_core_name(core_fn, "inductor_scan_final_state", graph)
+    raw_name = getattr(core_fn, "__name__", type(core_fn).__name__)
+    safe_name = "".join(c if c.isalnum() else "_" for c in raw_name)
+    core_name = f"{safe_name}_inductor_scan_final_state"
     core_str, core_name = generate_triton_code_str(graph, core_name)
     info = extract_info(graph, num_inputs, num_states, num_outputs)
     kernel = get_flexsn_inference_final_state_kernel(core_str, core_name, info=info)
@@ -193,20 +206,13 @@ def build_training_kernels(
     graph but the kernel template still passes them.
 
     Returns:
-        ``(fwd_kernel, fwd_final_state_kernel, bwd_kernel, bwd_final_state_kernel, info)`` — compatible with
+        ``(fwd_kernel, bwd_kernel, info)`` — compatible with
         :class:`spikingjelly.activation_based.triton_kernel.flexsn.wrapper.FlexSNFunction`.
     """
     from ..torch2triton import generate_forward_and_backward_graph, generate_triton_code_str
-    from ..flexsn import (
-        extract_info,
-        get_flexsn_backward_kernel,
-        get_flexsn_backward_final_state_kernel,
-        get_flexsn_forward_final_state_kernel,
-        get_flexsn_forward_kernel,
-    )
+    from ..flexsn import extract_info, get_flexsn_forward_kernel, get_flexsn_backward_kernel
 
-    # .clone() breaks aliasing so tracing cannot mutate the caller's buffers.
-    example_inputs = _clone_example_inputs(example_inputs, num_inputs + num_states)
+    example_inputs = _prepare_example_inputs(example_inputs, num_inputs, num_states)
 
     # Build requires_grad mask: only float/complex tensors support autograd.
     # Passing the mask prevents generate_forward_and_backward_graph from calling
@@ -232,20 +238,13 @@ def build_training_kernels(
         )
     n_saved = len(info.c2k_return_mapping)
 
-    core_name = _make_core_name(core_fn, "inductor_train", fwd_graph, bwd_graph)
+    raw_name = getattr(core_fn, "__name__", type(core_fn).__name__)
+    safe_name = "".join(c if c.isalnum() else "_" for c in raw_name)
+    core_name = safe_name + "_inductor_train"
 
     # Forward kernel — saves intermediates needed by backward
     fwd_str, fwd_name = generate_triton_code_str(fwd_graph, core_name + "_fwd")
     fwd_kernel = get_flexsn_forward_kernel(fwd_str, fwd_name, info=info)
-    if _training_final_state_specialized_wins(info):
-        try:
-            fwd_final_state_kernel = get_flexsn_forward_final_state_kernel(
-                fwd_str, fwd_name, info=info
-            )
-        except Exception:
-            fwd_final_state_kernel = None
-    else:
-        fwd_final_state_kernel = None
 
     # Backward kernel — wrap with shim if non-differentiable outputs exist
     bwd_str, bwd_name = generate_triton_code_str(bwd_graph, core_name + "_bwd")
@@ -257,11 +256,5 @@ def build_training_kernels(
     else:
         bwd_call_name = bwd_name
     bwd_kernel = get_flexsn_backward_kernel(bwd_str, bwd_call_name, info=info)
-    try:
-        bwd_final_state_kernel = get_flexsn_backward_final_state_kernel(
-            bwd_str, bwd_call_name, info=info
-        )
-    except Exception:
-        bwd_final_state_kernel = None
 
-    return fwd_kernel, fwd_final_state_kernel, bwd_kernel, bwd_final_state_kernel, info
+    return fwd_kernel, bwd_kernel, info

--- a/spikingjelly/activation_based/triton_kernel/flexsn/template.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/template.py
@@ -15,21 +15,15 @@ __all__ = [
     "get_flexsn_inference_kernel",
     "get_flexsn_inference_final_state_kernel",
     "get_flexsn_forward_kernel",
-    "get_flexsn_forward_final_state_kernel",
     "get_flexsn_backward_kernel",
-    "get_flexsn_backward_final_state_kernel",
 ]
 
 
 INDENTATION = " " * 4
 
 
-def _join_signature(parts):
-    return f",\n{INDENTATION}".join(parts)
-
-
-def _join_args(parts):
-    return ", ".join(parts)
+def _signature(names):
+    return f",\n{INDENTATION}".join(names)
 
 init_state_load_template = """
     {name}_init_ptrs = tl.make_block_ptr(
@@ -83,20 +77,6 @@ final_state_store_template = """
     convert_and_store({name}_final_ptrs, {name}, boundary_check=(1,))
 """
 
-grad_final_state_load_template = """
-    {name}_final_ptrs = tl.make_block_ptr(
-        {name}_final_ptr,
-        shape=(1, NCL),
-        strides=(NCL, 1),
-        offsets=(0, ncl_offset),
-        block_shape=(1, BLOCK_NCL),
-        order=(1, 0)
-    )
-    {name}_accumulate = tl.load(
-        {name}_final_ptrs, boundary_check=(1,), padding_option="zero"
-    )
-"""
-
 load_template = """
         {name}_ptrs = tl.make_block_ptr(
             {name}_seq_ptr,
@@ -110,29 +90,6 @@ load_template = """
             {name}_ptrs, boundary_check=(1,), padding_option="zero"
         )
 """
-
-BASE_AUTOTUNE_CONFIGS = """[
-        triton.Config({"BLOCK_NCL": 256}, num_warps=4),
-    ]"""
-
-BASE_AUTOTUNE_TAG = "b256w4"
-INFERENCE_AUTOTUNE_CONFIGS = BASE_AUTOTUNE_CONFIGS
-INFERENCE_AUTOTUNE_TAG = BASE_AUTOTUNE_TAG
-BACKWARD_AUTOTUNE_CONFIGS = """[
-        triton.Config({"BLOCK_NCL": 128}, num_warps=2),
-        triton.Config({"BLOCK_NCL": 256}, num_warps=4),
-        triton.Config({"BLOCK_NCL": 512}, num_warps=8),
-    ]"""
-BACKWARD_AUTOTUNE_TAG = "bw128_2_256_4_512_8"
-INFERENCE_FINAL_STATE_AUTOTUNE_CONFIGS = """[
-        triton.Config({"BLOCK_NCL": 512}, num_warps=8),
-    ]"""
-INFERENCE_FINAL_STATE_AUTOTUNE_TAG = "i512w8"
-FORWARD_FINAL_STATE_AUTOTUNE_CONFIGS = """[
-        triton.Config({"BLOCK_NCL": 128}, num_warps=2),
-        triton.Config({"BLOCK_NCL": 256}, num_warps=4),
-    ]"""
-FORWARD_FINAL_STATE_AUTOTUNE_TAG = "f128w2_256w4"
 
 kernel_template = """import triton
 import triton.language as tl
@@ -149,8 +106,12 @@ def convert_and_store(pointer, value, boundary_check):
 {core_str}
 
 @triton.autotune(
-    configs={autotune_configs},
-    key={autotune_key},
+    configs=[
+        triton.Config({{"BLOCK_NCL": f * w * 32}}, num_warps=w)
+        for f in [1, 2]
+        for w in [2, 4]
+    ],
+    key=["T", "dtype"],
     restore_value=[{autotune_restore}],
 )
 @triton.jit
@@ -160,7 +121,7 @@ def flexsn_{kernel_type}_kernel_{hash}(
     T: tl.constexpr,
     NCL: tl.constexpr,
     BLOCK_NCL: tl.constexpr,
-    dtype: tl.constexpr{meta_signature},
+    dtype: tl.constexpr,
 ):
     pid_ncl = tl.program_id(0)
     ncl_offset = pid_ncl * BLOCK_NCL
@@ -181,25 +142,24 @@ def flexsn_{kernel_type}_kernel_{hash}(
 def get_flexsn_inference_kernel(
     core_str: str, core_name: str, info: FlexSNInfo, verbose: bool = False
 ):
-    hash = f"{core_name[-8:]}_{INFERENCE_AUTOTUNE_TAG}"
+    kernel_hash = core_name[-8:]
     num_inputs = info.num_inputs
     num_states = info.num_states
     num_outputs = info.num_outputs
 
-    kernel_input_signature = _join_signature(
+    kernel_input_signature = _signature(
         [f"x{i}_seq_ptr" for i in range(num_inputs)]
         + [f"v{i}_init_ptr" for i in range(num_states)]
     )
 
-    kernel_output_signature = _join_signature(
+    kernel_output_signature = _signature(
         [f"s{i}_seq_ptr" for i in range(num_outputs)]
         + [f"v{i}_seq_ptr" for i in range(num_states)]
     )
 
-    autotune_restore = _join_args(
-        [f'"s{i}_seq_ptr"' for i in range(num_outputs)]
-        + [f'"v{i}_seq_ptr"' for i in range(num_states)]
-    )
+    restore_names = [f'"s{i}_seq_ptr"' for i in range(num_outputs)]
+    restore_names += [f'"v{i}_seq_ptr"' for i in range(num_states)]
+    autotune_restore = ", ".join(restore_names)
 
     init_state_loads = "".join(
         [
@@ -214,21 +174,19 @@ def get_flexsn_inference_kernel(
     stores = "".join([store_template.format(name=f"s{i}") for i in range(num_outputs)])
     stores += "".join([store_template.format(name=f"v{i}") for i in range(num_states)])
 
-    lhs = _join_args(
-        [f"s{i}" for i in range(num_outputs)] + [f"v{i}" for i in range(num_states)]
-    )
-    core_args = _join_args(
-        [f"x{i}" for i in range(num_inputs)] + [f"v{i}" for i in range(num_states)]
-    )
+    lhs_list = [f"s{i}" for i in range(num_outputs)] + [
+        f"v{i}" for i in range(num_states)
+    ]
+    lhs = ", ".join(lhs_list)
+    core_args = ", ".join([f"x{i}" for i in range(num_inputs)])
+    core_args += ", "
+    core_args += ", ".join([f"v{i}" for i in range(num_states)])
 
     kernel_str = kernel_template.format(
         core_str=core_str,
-        autotune_configs=INFERENCE_AUTOTUNE_CONFIGS,
-        autotune_key='["T", "dtype"]',
-        meta_signature="",
         autotune_restore=autotune_restore,
         kernel_type="inference",
-        hash=hash,
+        hash=kernel_hash,
         kernel_input_signature=kernel_input_signature,
         kernel_output_signature=kernel_output_signature,
         init_state_loads=init_state_loads,
@@ -238,7 +196,7 @@ def get_flexsn_inference_kernel(
         stores=stores,
         tail="",
     ).strip()
-    kernel_name = f"flexsn_inference_kernel_{hash}"
+    kernel_name = f"flexsn_inference_kernel_{kernel_hash}"
 
     if verbose:
         print("=" * 40, core_name, "=" * 40)
@@ -256,25 +214,24 @@ def get_flexsn_inference_kernel(
 def get_flexsn_inference_final_state_kernel(
     core_str: str, core_name: str, info: FlexSNInfo, verbose: bool = False
 ):
-    hash = f"{core_name[-8:]}_{INFERENCE_FINAL_STATE_AUTOTUNE_TAG}"
+    kernel_hash = core_name[-8:]
     num_inputs = info.num_inputs
     num_states = info.num_states
     num_outputs = info.num_outputs
 
-    kernel_input_signature = _join_signature(
+    kernel_input_signature = _signature(
         [f"x{i}_seq_ptr" for i in range(num_inputs)]
         + [f"v{i}_init_ptr" for i in range(num_states)]
     )
 
-    kernel_output_signature = _join_signature(
+    kernel_output_signature = _signature(
         [f"s{i}_seq_ptr" for i in range(num_outputs)]
         + [f"v{i}_final_ptr" for i in range(num_states)]
     )
 
-    autotune_restore = _join_args(
-        [f'"s{i}_seq_ptr"' for i in range(num_outputs)]
-        + [f'"v{i}_final_ptr"' for i in range(num_states)]
-    )
+    restore_names = [f'"s{i}_seq_ptr"' for i in range(num_outputs)]
+    restore_names += [f'"v{i}_final_ptr"' for i in range(num_states)]
+    autotune_restore = ", ".join(restore_names)
 
     init_state_loads = "".join(
         [init_state_load_template.format(name=f"v{i}") for i in range(num_states)]
@@ -286,21 +243,19 @@ def get_flexsn_inference_final_state_kernel(
         [final_state_store_template.format(name=f"v{i}") for i in range(num_states)]
     )
 
-    lhs = _join_args(
-        [f"s{i}" for i in range(num_outputs)] + [f"v{i}" for i in range(num_states)]
-    )
-    core_args = _join_args(
-        [f"x{i}" for i in range(num_inputs)] + [f"v{i}" for i in range(num_states)]
-    )
+    lhs_list = [f"s{i}" for i in range(num_outputs)] + [
+        f"v{i}" for i in range(num_states)
+    ]
+    lhs = ", ".join(lhs_list)
+    core_args = ", ".join([f"x{i}" for i in range(num_inputs)])
+    core_args += ", "
+    core_args += ", ".join([f"v{i}" for i in range(num_states)])
 
     kernel_str = kernel_template.format(
         core_str=core_str,
-        autotune_configs=INFERENCE_FINAL_STATE_AUTOTUNE_CONFIGS,
-        autotune_key='["T", "dtype"]',
-        meta_signature="",
         autotune_restore=autotune_restore,
         kernel_type="inference_final_state",
-        hash=hash,
+        hash=kernel_hash,
         kernel_input_signature=kernel_input_signature,
         kernel_output_signature=kernel_output_signature,
         init_state_loads=init_state_loads,
@@ -310,7 +265,7 @@ def get_flexsn_inference_final_state_kernel(
         stores=stores,
         tail=tail,
     ).strip()
-    kernel_name = f"flexsn_inference_final_state_kernel_{hash}"
+    kernel_name = f"flexsn_inference_final_state_kernel_{kernel_hash}"
 
     if verbose:
         print("=" * 40, core_name, "=" * 40)
@@ -331,20 +286,18 @@ def get_flexsn_forward_kernel(
     info: FlexSNInfo,
     verbose: bool = False,
 ):
-    hash = f"{core_name[-8:]}_{BASE_AUTOTUNE_TAG}"
+    kernel_hash = core_name[-8:]
     num_inputs = info.num_inputs
     num_states = info.num_states
     fwd_kernel_returns = info.fwd_kernel_returns  # unique
     fwd_core_recipients = info.fwd_core_recipients  # `_` for duplicates
 
-    kernel_input_signature = _join_signature(
+    kernel_input_signature = _signature(
         [f"x{i}_seq_ptr" for i in range(num_inputs)]
         + [f"v{i}_init_ptr" for i in range(num_states)]
     )
 
-    kernel_output_signature = f",\n{INDENTATION}".join(
-        [f"{r}_seq_ptr" for r in fwd_kernel_returns]
-    )
+    kernel_output_signature = _signature([f"{r}_seq_ptr" for r in fwd_kernel_returns])
 
     autotune_restore = ", ".join([f'"{r}_seq_ptr"' for r in fwd_kernel_returns])
 
@@ -359,19 +312,16 @@ def get_flexsn_forward_kernel(
 
     loads = "".join([load_template.format(name=f"x{i}") for i in range(num_inputs)])
     stores = "".join([store_template.format(name=r) for r in fwd_kernel_returns])
-    lhs = _join_args([r for r in fwd_core_recipients])
-    core_args = _join_args(
-        [f"x{i}" for i in range(num_inputs)] + [f"v{i}" for i in range(num_states)]
-    )
+    lhs = ", ".join([r for r in fwd_core_recipients])
+    core_args = ", ".join([f"x{i}" for i in range(num_inputs)])
+    core_args += ", "
+    core_args += ", ".join([f"v{i}" for i in range(num_states)])
 
     kernel_str = kernel_template.format(
         core_str=core_str,
-        autotune_configs=BASE_AUTOTUNE_CONFIGS,
-        autotune_key='["T", "dtype"]',
-        meta_signature="",
         autotune_restore=autotune_restore,
         kernel_type="forward",
-        hash=hash,
+        hash=kernel_hash,
         kernel_input_signature=kernel_input_signature,
         kernel_output_signature=kernel_output_signature,
         init_state_loads=init_state_loads,
@@ -381,101 +331,11 @@ def get_flexsn_forward_kernel(
         stores=stores,
         tail="",
     ).strip()
-    kernel_name = f"flexsn_forward_kernel_{hash}"
+    kernel_name = f"flexsn_forward_kernel_{kernel_hash}"
 
     if verbose:
         print("=" * 40, core_name, "=" * 40)
         print("Generating flexsn forward kernel:")
-        print("```")
-        print(kernel_str)
-        print("```")
-        print(info)
-        print("=" * 40, "=" * len(core_name), "=" * 40)
-
-    kernel_exe = compile_triton_code_str(kernel_str, kernel_name, verbose)
-    return kernel_exe
-
-
-def get_flexsn_forward_final_state_kernel(
-    core_str: str,
-    core_name: str,
-    info: FlexSNInfo,
-    verbose: bool = False,
-):
-    hash = f"{core_name[-8:]}_{FORWARD_FINAL_STATE_AUTOTUNE_TAG}"
-    num_inputs = info.num_inputs
-    num_states = info.num_states
-    num_outputs = info.num_outputs
-
-    saved_non_output_indices = []
-    seen_saved_non_output_indices = set()
-    for idx in info.c2k_return_mapping:
-        if idx < num_outputs or idx in seen_saved_non_output_indices:
-            continue
-        saved_non_output_indices.append(idx)
-        seen_saved_non_output_indices.add(idx)
-
-    saved_non_output_returns = [
-        info.fwd_kernel_returns[idx] for idx in saved_non_output_indices
-    ]
-
-    kernel_input_signature = _join_signature(
-        [f"x{i}_seq_ptr" for i in range(num_inputs)]
-        + [f"v{i}_init_ptr" for i in range(num_states)]
-    )
-
-    kernel_output_signature = f",\n{INDENTATION}".join(
-        [f"s{i}_seq_ptr" for i in range(num_outputs)]
-        + [f"v{i}_final_ptr" for i in range(num_states)]
-        + [f"{name}_seq_ptr" for name in saved_non_output_returns]
-    )
-
-    autotune_restore = _join_args(
-        [f'"s{i}_seq_ptr"' for i in range(num_outputs)]
-        + [f'"v{i}_final_ptr"' for i in range(num_states)]
-        + [f'"{name}_seq_ptr"' for name in saved_non_output_returns]
-    )
-
-    init_state_loads = "".join(
-        [init_state_load_template.format(name=f"v{i}") for i in range(num_states)]
-    )
-
-    loads = "".join([load_template.format(name=f"x{i}") for i in range(num_inputs)])
-    stores = "".join([store_template.format(name=f"s{i}") for i in range(num_outputs)])
-    stores += "".join(
-        [store_template.format(name=name) for name in saved_non_output_returns]
-    )
-    tail = "".join(
-        [final_state_store_template.format(name=f"v{i}") for i in range(num_states)]
-    )
-
-    lhs = _join_args([r for r in info.fwd_core_recipients])
-    core_args = _join_args(
-        [f"x{i}" for i in range(num_inputs)] + [f"v{i}" for i in range(num_states)]
-    )
-
-    kernel_str = kernel_template.format(
-        core_str=core_str,
-        autotune_configs=FORWARD_FINAL_STATE_AUTOTUNE_CONFIGS,
-        autotune_key='["T", "dtype"]',
-        meta_signature="",
-        autotune_restore=autotune_restore,
-        kernel_type="forward_final_state",
-        hash=hash,
-        kernel_input_signature=kernel_input_signature,
-        kernel_output_signature=kernel_output_signature,
-        init_state_loads=init_state_loads,
-        loop_range="0, T, 1",
-        loads=loads,
-        computes=f"{lhs} = {core_name}({core_args})",
-        stores=stores,
-        tail=tail,
-    ).strip()
-    kernel_name = f"flexsn_forward_final_state_kernel_{hash}"
-
-    if verbose:
-        print("=" * 40, core_name, "=" * 40)
-        print("Generating flexsn forward-final-state kernel:")
         print("```")
         print(kernel_str)
         print("```")
@@ -492,7 +352,7 @@ def get_flexsn_backward_kernel(
     info: FlexSNInfo,
     verbose: bool = False,
 ):
-    hash = f"{core_name[-8:]}_{BACKWARD_AUTOTUNE_TAG}"
+    kernel_hash = core_name[-8:]
     num_outputs = info.num_outputs
     num_inputs = info.num_inputs
     num_states = info.num_states
@@ -500,23 +360,22 @@ def get_flexsn_backward_kernel(
 
     assert n + num_outputs + num_states == len(info.fwd_core_returns)
 
-    kernel_input_signature_parts = [f"grad_s{i}_seq_ptr" for i in range(num_outputs)]
-    kernel_input_signature_parts += [f"grad_v{i}_seq_ptr" for i in range(num_states)]
-    if n > 0:
-        kernel_input_signature_parts += [f"res{i}_b_seq_ptr" for i in range(n)]
-    kernel_input_signature = _join_signature(kernel_input_signature_parts)
+    kernel_input_signature = _signature(
+        [f"grad_s{i}_seq_ptr" for i in range(num_outputs)]
+        + [f"grad_v{i}_seq_ptr" for i in range(num_states)]
+        + [f"res{i}_b_seq_ptr" for i in range(n)]
+    )
     # res{i}_b slightly different from res{i}_f in the forward kernel
     # as res{i}_b might be from s{i} or v{i}
 
-    kernel_output_signature = _join_signature(
+    kernel_output_signature = _signature(
         [f"grad_x{i}_seq_ptr" for i in range(num_inputs)]
         + [f"grad_v{i}_init_ptr" for i in range(num_states)]
     )
 
-    autotune_restore = _join_args(
-        [f'"grad_x{i}_seq_ptr"' for i in range(num_inputs)]
-        + [f'"grad_v{i}_init_ptr"' for i in range(num_states)]
-    )
+    autotune_restore = ", ".join([f'"grad_x{i}_seq_ptr"' for i in range(num_inputs)])
+    autotune_restore += ", "
+    autotune_restore += ", ".join([f'"grad_v{i}_init_ptr"' for i in range(num_states)])
 
     init_state_loads = f"\n{INDENTATION}".join(
         [
@@ -543,10 +402,9 @@ def get_flexsn_backward_kernel(
             for i in range(num_states)
         ]
     )  # accumulate gradients of states
-    lhs = _join_args(
-        [f"grad_x{i}" for i in range(num_inputs)]
-        + [f"grad_v{i}_accumulate" for i in range(num_states)]
-    )
+    lhs = ", ".join([f"grad_x{i}" for i in range(num_inputs)])
+    lhs += ", "
+    lhs += ", ".join([f"grad_v{i}_accumulate" for i in range(num_states)])
     _core_args_parts = []
     if n > 0:
         _core_args_parts += [f"res{i}_b" for i in range(n)]
@@ -564,12 +422,9 @@ def get_flexsn_backward_kernel(
 
     kernel_str = kernel_template.format(
         core_str=core_str,
-        autotune_configs=BACKWARD_AUTOTUNE_CONFIGS,
-        autotune_key='["T", "dtype", "NCL_BUCKET"]',
-        meta_signature=",\n    NCL_BUCKET: tl.constexpr",
         autotune_restore=autotune_restore,
         kernel_type="backward",
-        hash=hash,
+        hash=kernel_hash,
         kernel_input_signature=kernel_input_signature,
         kernel_output_signature=kernel_output_signature,
         init_state_loads=init_state_loads,
@@ -579,103 +434,11 @@ def get_flexsn_backward_kernel(
         stores=stores,
         tail=tail,
     ).strip()
-    kernel_name = f"flexsn_backward_kernel_{hash}"
+    kernel_name = f"flexsn_backward_kernel_{kernel_hash}"
 
     if verbose:
         print("=" * 40, core_name, "=" * 40)
         print("Generated flexsn backward kernel:")
-        print("```")
-        print(kernel_str)
-        print("```\n")
-        print(info)
-        print("=" * 40, "=" * len(core_name), "=" * 40)
-
-    kernel_exe = compile_triton_code_str(kernel_str, kernel_name, verbose)
-    return kernel_exe
-
-
-def get_flexsn_backward_final_state_kernel(
-    core_str: str,
-    core_name: str,
-    info: FlexSNInfo,
-    verbose: bool = False,
-):
-    hash = f"{core_name[-8:]}_{BACKWARD_AUTOTUNE_TAG}_final"
-    num_outputs = info.num_outputs
-    num_inputs = info.num_inputs
-    num_states = info.num_states
-    n = len(info.c2k_return_mapping)
-
-    kernel_input_signature_parts = [f"grad_s{i}_seq_ptr" for i in range(num_outputs)]
-    kernel_input_signature_parts += [f"grad_v{i}_final_ptr" for i in range(num_states)]
-    if n > 0:
-        kernel_input_signature_parts += [f"res{i}_b_seq_ptr" for i in range(n)]
-    kernel_input_signature = _join_signature(kernel_input_signature_parts)
-
-    kernel_output_signature = _join_signature(
-        [f"grad_x{i}_seq_ptr" for i in range(num_inputs)]
-        + [f"grad_v{i}_init_ptr" for i in range(num_states)]
-    )
-
-    autotune_restore = _join_args(
-        [f'"grad_x{i}_seq_ptr"' for i in range(num_inputs)]
-        + [f'"grad_v{i}_init_ptr"' for i in range(num_states)]
-    )
-
-    init_state_loads = "".join(
-        [grad_final_state_load_template.format(name=f"grad_v{i}") for i in range(num_states)]
-    )
-
-    loads = "".join(
-        [load_template.format(name=f"grad_s{i}") for i in range(num_outputs)]
-    )
-    loads += "".join([load_template.format(name=f"res{i}_b") for i in range(n)])
-
-    stores = "".join(
-        [store_template.format(name=f"grad_x{i}") for i in range(num_inputs)]
-    )
-
-    lhs = _join_args(
-        [f"grad_x{i}" for i in range(num_inputs)]
-        + [f"grad_v{i}_accumulate" for i in range(num_states)]
-    )
-    _core_args_parts = []
-    if n > 0:
-        _core_args_parts += [f"res{i}_b" for i in range(n)]
-    _core_args_parts += [f"grad_s{i}" for i in range(num_outputs)]
-    _core_args_parts += [f"grad_v{i}_accumulate" for i in range(num_states)]
-    core_args = ", ".join(_core_args_parts)
-    computes = f"{lhs} = {core_name}({core_args})"
-
-    tail = f"\n{INDENTATION}".join(
-        [
-            grad_init_state_store_template.format(name=f"grad_v{i}")
-            for i in range(num_states)
-        ]
-    )
-
-    kernel_str = kernel_template.format(
-        core_str=core_str,
-        autotune_configs=BACKWARD_AUTOTUNE_CONFIGS,
-        autotune_key='["T", "dtype", "NCL_BUCKET"]',
-        meta_signature=",\n    NCL_BUCKET: tl.constexpr",
-        autotune_restore=autotune_restore,
-        kernel_type="backward_final_state",
-        hash=hash,
-        kernel_input_signature=kernel_input_signature,
-        kernel_output_signature=kernel_output_signature,
-        init_state_loads=init_state_loads,
-        loop_range="T-1, -1, -1",
-        loads=loads,
-        computes=computes,
-        stores=stores,
-        tail=tail,
-    ).strip()
-    kernel_name = f"flexsn_backward_final_state_kernel_{hash}"
-
-    if verbose:
-        print("=" * 40, core_name, "=" * 40)
-        print("Generated flexsn backward-final-state kernel:")
         print("```")
         print(kernel_str)
         print("```\n")

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -318,6 +318,10 @@ def flexsn_backward(
     grad_state_seq_examples = grad_output_args[
         info.num_outputs : info.num_outputs + info.num_states
     ]
+    grad_kernel_args = [
+        grad if grad is not None else torch.zeros_like(grad_example)
+        for grad in grad_output_args
+    ]
     # State-sequence gradients include the leading time dimension. The wrapper
     # returns gradients for the initial states, so their templates are shape[1:].
     grad_inputs += [
@@ -336,7 +340,8 @@ def flexsn_backward(
     grid = _make_grid(NCL)
 
     f[grid](
-        *args,
+        *grad_kernel_args,
+        *args[required_grad_count:],
         *grad_inputs,
         T=T,
         NCL=NCL,

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -15,36 +15,40 @@ from ..triton_utils import amp_custom_fwd, amp_custom_bwd
 from .info import FlexSNInfo
 
 
-__all__ = ["flexsn_inference", "flexsn_inference_final_state", "flexsn_forward", "flexsn_backward", "flexsn_backward_ncl_bucket", "FlexSNFunction"]
+__all__ = [
+    "flexsn_inference",
+    "flexsn_inference_final_state",
+    "flexsn_forward",
+    "flexsn_backward",
+    "FlexSNFunction",
+]
 
 
-_BACKWARD_SMALL_MAX_NCL = 1 << 12
-_BACKWARD_MEDIUM_MAX_NCL = 1 << 17
-_BACKWARD_LARGE_MAX_NCL = 1 << 20
-_BACKWARD_XLARGE_MAX_NCL = 1 << 23
+def _num_elements_per_step(x: torch.Tensor) -> int:
+    n = 1
+    for dim in x.shape[1:]:
+        n *= dim
+    return n
 
 
-def flexsn_backward_ncl_bucket(ncl: int) -> int:
-    if ncl <= _BACKWARD_SMALL_MAX_NCL:
-        return 0
-    if ncl <= _BACKWARD_MEDIUM_MAX_NCL:
-        return 1
-    if ncl <= _BACKWARD_LARGE_MAX_NCL:
-        return 2
-    if ncl <= _BACKWARD_XLARGE_MAX_NCL:
-        return 3
-    return 4
+def _make_grid(ncl: int):
+    def grid(meta):
+        return (triton.cdiv(ncl, meta["BLOCK_NCL"]),)
+
+    return grid
 
 
 def flexsn_inference(f, info: FlexSNInfo, *args) -> tuple:
     x_example = args[0]
     T = x_example.shape[0]
-    NCL = x_example[0].numel()
+    NCL = _num_elements_per_step(x_example)
     dtype = x_example.dtype
     outputs = [
         torch.empty_like(x_example) for _ in range(info.num_outputs + info.num_states)
     ]
-    grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
+    if T == 0:
+        return tuple(outputs)
+    grid = _make_grid(NCL)
 
     f[grid](
         *args,
@@ -59,13 +63,27 @@ def flexsn_inference(f, info: FlexSNInfo, *args) -> tuple:
 def flexsn_inference_final_state(f, info: FlexSNInfo, *args) -> tuple:
     x_example = args[0]
     T = x_example.shape[0]
-    NCL = x_example[0].numel()
+    NCL = _num_elements_per_step(x_example)
     dtype = x_example.dtype
     output_seqs = [torch.empty_like(x_example) for _ in range(info.num_outputs)]
+    init_states = args[info.num_inputs : info.num_inputs + info.num_states]
     final_states = [
-        torch.empty_like(x_example[0]) for _ in range(info.num_states)
+        init_states[i].new_empty(init_states[i].shape)
+        if i < len(init_states)
+        else x_example.new_empty(x_example.shape[1:])
+        for i in range(info.num_states)
     ]
-    grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
+    if T == 0:
+        final_states = [
+            (
+                init_states[i].clone()
+                if i < len(init_states)
+                else x_example.new_zeros(x_example.shape[1:])
+            )
+            for i in range(info.num_states)
+        ]
+        return tuple([*output_seqs, *final_states])
+    grid = _make_grid(NCL)
 
     f[grid](
         *args,
@@ -81,10 +99,12 @@ def flexsn_inference_final_state(f, info: FlexSNInfo, *args) -> tuple:
 def flexsn_forward(f, info: FlexSNInfo, *args) -> tuple:
     x_example = args[0]
     T = x_example.shape[0]
-    NCL = x_example[0].numel()
+    NCL = _num_elements_per_step(x_example)
     returns = [torch.empty_like(x_example) for _ in range(info.num_fwd_kernel_returns)]
     dtype = x_example.dtype
-    grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
+    if T == 0:
+        return tuple(returns)
+    grid = _make_grid(NCL)
 
     f[grid](
         *args,
@@ -99,11 +119,40 @@ def flexsn_forward(f, info: FlexSNInfo, *args) -> tuple:
 def flexsn_backward(f, info: FlexSNInfo, *args) -> tuple:
     grad_example = args[0]
     T = grad_example.shape[0]
-    NCL = grad_example[0].numel()
-    grad_inputs = [torch.empty_like(grad_example) for _ in range(info.num_inputs)]
-    grad_inputs += [torch.empty_like(grad_example[0]) for _ in range(info.num_states)]
+    NCL = _num_elements_per_step(grad_example)
+    grad_inputs = [
+        (
+            torch.zeros_like(grad_example)
+            if T == 0
+            else torch.empty_like(grad_example)
+        )
+        for _ in range(info.num_inputs)
+    ]
+    grad_state_seq_examples = args[
+        info.num_outputs : info.num_outputs + info.num_states
+    ]
+    # State-sequence gradients include the leading time dimension. The wrapper
+    # returns gradients for the initial states, so their templates are shape[1:].
+    grad_inputs += [
+        (
+            grad_state_seq_examples[i].new_zeros(grad_state_seq_examples[i].shape[1:])
+            if T == 0
+            else grad_state_seq_examples[i].new_empty(
+                grad_state_seq_examples[i].shape[1:]
+            )
+        )
+        if i < len(grad_state_seq_examples) and grad_state_seq_examples[i] is not None
+        else (
+            grad_example.new_zeros(grad_example.shape[1:])
+            if T == 0
+            else grad_example.new_empty(grad_example.shape[1:])
+        )
+        for i in range(info.num_states)
+    ]
     dtype = grad_example.dtype
-    grid = lambda meta: (triton.cdiv(NCL, meta["BLOCK_NCL"]),)
+    if T == 0:
+        return tuple(grad_inputs)
+    grid = _make_grid(NCL)
 
     f[grid](
         *args,
@@ -111,7 +160,6 @@ def flexsn_backward(f, info: FlexSNInfo, *args) -> tuple:
         T=T,
         NCL=NCL,
         dtype=type_dict[dtype],
-        NCL_BUCKET=flexsn_backward_ncl_bucket(NCL),
     )
     return tuple(grad_inputs)
 

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -1,4 +1,6 @@
 import torch
+from typing import Optional, Tuple
+
 from torch import autograd
 
 try:
@@ -202,8 +204,8 @@ def flexsn_backward(
     f,
     info: FlexSNInfo,
     *args,
-    input_templates=None,
-    state_templates=None,
+    input_templates: Optional[Tuple[torch.Tensor, ...]] = None,
+    state_templates: Optional[Tuple[torch.Tensor, ...]] = None,
 ) -> tuple:
     """Run the training backward kernel for FlexSN.
 
@@ -215,8 +217,29 @@ def flexsn_backward(
 
     :param f: EN: Triton kernel callable. Chinese: Triton kernel 可调用对象。
     :param info: EN: FlexSN metadata. Chinese: FlexSN 元信息。
-    :param args: EN: Gradients and saved tensors accepted by the kernel. Chinese: kernel 接收的梯度与保存张量。
-    :return: EN: Gradients for inputs and initial states. When ``T == 0``, returns zero-filled gradients. Chinese: 输入与初始状态的梯度；当 ``T == 0`` 时, 返回零填充梯度。
+    :param args: EN: Gradients followed by any saved tensors accepted by the kernel.
+        The leading ``info.num_outputs + info.num_states`` entries correspond to
+        output/state-sequence gradients, and the remaining entries are saved tensors
+        from the forward pass. Chinese: kernel 接收的梯度与保存张量。前
+        ``info.num_outputs + info.num_states`` 个参数对应输出/状态序列梯度, 其余参数
+        为前向保存张量。
+    :type args: tuple
+    :param input_templates: EN: Per-input-sequence templates used to allocate input
+        gradients. They are required when all incoming gradients are ``None`` and
+        ensure that state-only cores still return correctly shaped input-sequence
+        gradients. Chinese: 每个输入序列的模板, 用于分配输入梯度。当所有传入梯度都为
+        ``None`` 时必须提供, 并确保仅有状态输出的 core 仍返回形状正确的输入梯度。
+    :type input_templates: Optional[Tuple[torch.Tensor, ...]]
+    :param state_templates: EN: Per-initial-state templates used to allocate initial
+        state gradients. When provided, the returned state gradients preserve the
+        original initial-state shapes instead of inferring them from state-sequence
+        gradients. Chinese: 每个初始状态的模板, 用于分配初始状态梯度。提供后, 返回的
+        状态梯度会保持初始状态原始形状, 而不是从状态序列梯度中推断。
+    :type state_templates: Optional[Tuple[torch.Tensor, ...]]
+    :return: EN: Gradients for inputs and initial states. When ``T == 0`` or all
+        incoming gradients are ``None``, returns zero-filled gradients that follow
+        the provided templates. Chinese: 输入与初始状态的梯度；当 ``T == 0`` 或所有传入
+        梯度都为 ``None`` 时, 返回符合模板的零梯度。
     :rtype: tuple
     """
     required_grad_count = info.num_outputs + info.num_states

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -71,6 +71,13 @@ def _make_grid(ncl: int):
     return grid
 
 
+def _first_non_none_tensor(tensors):
+    for tensor in tensors:
+        if tensor is not None:
+            return tensor
+    return None
+
+
 def flexsn_inference(f, info: FlexSNInfo, *args) -> tuple:
     """Run the inference kernel for a multi-step FlexSN core.
 
@@ -196,6 +203,7 @@ def flexsn_backward(
     info: FlexSNInfo,
     *args,
     input_templates=None,
+    state_templates=None,
 ) -> tuple:
     """Run the training backward kernel for FlexSN.
 
@@ -211,15 +219,34 @@ def flexsn_backward(
     :return: EN: Gradients for inputs and initial states. When ``T == 0``, returns zero-filled gradients. Chinese: 输入与初始状态的梯度；当 ``T == 0`` 时, 返回零填充梯度。
     :rtype: tuple
     """
-    grad_example = args[0]
-    T = grad_example.shape[0]
-    NCL = _num_elements_per_step(grad_example)
+    required_grad_count = info.num_outputs + info.num_states
+    grad_output_args = args[:required_grad_count]
+    grad_example = _first_non_none_tensor(grad_output_args)
     if input_templates is None:
+        if grad_example is None:
+            raise ValueError(
+                "input_templates are required when all incoming FlexSN gradients are None"
+            )
         input_templates = tuple(grad_example for _ in range(info.num_inputs))
     if len(input_templates) != info.num_inputs:
         raise ValueError(
             "input_templates must provide one template per FlexSN input sequence"
         )
+    if state_templates is not None and len(state_templates) != info.num_states:
+        raise ValueError(
+            "state_templates must provide one template per FlexSN initial state"
+        )
+    if grad_example is None:
+        if state_templates is None and info.num_states > 0:
+            raise ValueError(
+                "state_templates are required when all incoming FlexSN gradients are None"
+            )
+        grad_inputs = [torch.zeros_like(template) for template in input_templates]
+        if state_templates is not None:
+            grad_inputs.extend(torch.zeros_like(template) for template in state_templates)
+        return tuple(grad_inputs)
+    T = grad_example.shape[0]
+    NCL = _num_elements_per_step(grad_example)
     grad_inputs = [
         (
             torch.zeros_like(input_templates[i])
@@ -228,13 +255,19 @@ def flexsn_backward(
         )
         for i in range(info.num_inputs)
     ]
-    grad_state_seq_examples = args[
+    grad_state_seq_examples = grad_output_args[
         info.num_outputs : info.num_outputs + info.num_states
     ]
     # State-sequence gradients include the leading time dimension. The wrapper
     # returns gradients for the initial states, so their templates are shape[1:].
     grad_inputs += [
         (
+            torch.zeros_like(state_templates[i])
+            if T == 0
+            else torch.empty_like(state_templates[i])
+        )
+        if state_templates is not None
+        else (
             grad_state_seq_examples[i].new_zeros(grad_state_seq_examples[i].shape[1:])
             if T == 0
             else grad_state_seq_examples[i].new_empty(
@@ -297,6 +330,10 @@ class FlexSNFunction(autograd.Function):
                 (tuple(arg.shape), arg.dtype, arg.device)
                 for arg in args[: info.num_inputs]
             )
+            ctx.state_template_specs = tuple(
+                (tuple(arg.shape), arg.dtype, arg.device)
+                for arg in args[info.num_inputs : info.num_inputs + info.num_states]
+            )
         else:
             outputs_states = flexsn_inference(fn_inf, info, *args)
         if len(outputs_states) == 1:
@@ -314,11 +351,16 @@ class FlexSNFunction(autograd.Function):
             torch.empty(shape, dtype=dtype, device=device)
             for shape, dtype, device in getattr(ctx, "input_template_specs", ())
         )
+        state_templates = tuple(
+            torch.empty(shape, dtype=dtype, device=device)
+            for shape, dtype, device in getattr(ctx, "state_template_specs", ())
+        )
         grads = flexsn_backward(
             fn_bwd,
             ctx.info,
             *args,
             *required_results,
             input_templates=input_templates,
+            state_templates=state_templates,
         )
         return None, None, None, None, *grads

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -20,8 +20,27 @@ __all__ = [
     "flexsn_inference_final_state",
     "flexsn_forward",
     "flexsn_backward",
+    "flexsn_backward_ncl_bucket",
     "FlexSNFunction",
 ]
+
+
+_BACKWARD_SMALL_MAX_NCL = 1 << 12
+_BACKWARD_MEDIUM_MAX_NCL = 1 << 17
+_BACKWARD_LARGE_MAX_NCL = 1 << 20
+_BACKWARD_XLARGE_MAX_NCL = 1 << 23
+
+
+def flexsn_backward_ncl_bucket(ncl: int) -> int:
+    if ncl <= _BACKWARD_SMALL_MAX_NCL:
+        return 0
+    if ncl <= _BACKWARD_MEDIUM_MAX_NCL:
+        return 1
+    if ncl <= _BACKWARD_LARGE_MAX_NCL:
+        return 2
+    if ncl <= _BACKWARD_XLARGE_MAX_NCL:
+        return 3
+    return 4
 
 
 def _num_elements_per_step(x: torch.Tensor) -> int:

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -18,12 +18,12 @@ from .info import FlexSNInfo
 
 
 __all__ = [
-    "flexsn_inference",
-    "flexsn_inference_final_state",
-    "flexsn_forward",
+    "FlexSNFunction",
     "flexsn_backward",
     "flexsn_backward_ncl_bucket",
-    "FlexSNFunction",
+    "flexsn_forward",
+    "flexsn_inference",
+    "flexsn_inference_final_state",
 ]
 
 
@@ -78,6 +78,35 @@ def _first_non_none_tensor(tensors):
         if tensor is not None:
             return tensor
     return None
+
+
+def _allocate_state_grad(
+    i: int,
+    T: int,
+    state_templates: Optional[Tuple[torch.Tensor, ...]],
+    grad_state_seq_examples,
+    grad_example: torch.Tensor,
+) -> torch.Tensor:
+    if state_templates is not None:
+        return (
+            torch.zeros_like(state_templates[i])
+            if T == 0
+            else torch.empty_like(state_templates[i])
+        )
+
+    if i < len(grad_state_seq_examples) and grad_state_seq_examples[i] is not None:
+        example = grad_state_seq_examples[i]
+        return (
+            example.new_zeros(example.shape[1:])
+            if T == 0
+            else example.new_empty(example.shape[1:])
+        )
+
+    return (
+        grad_example.new_zeros(grad_example.shape[1:])
+        if T == 0
+        else grad_example.new_empty(grad_example.shape[1:])
+    )
 
 
 def flexsn_inference(f, info: FlexSNInfo, *args) -> tuple:
@@ -227,8 +256,12 @@ def flexsn_backward(
     :param input_templates: EN: Per-input-sequence templates used to allocate input
         gradients. They are required when all incoming gradients are ``None`` and
         ensure that state-only cores still return correctly shaped input-sequence
-        gradients. Chinese: 每个输入序列的模板, 用于分配输入梯度。当所有传入梯度都为
-        ``None`` 时必须提供, 并确保仅有状态输出的 core 仍返回形状正确的输入梯度。
+        gradients. When omitted, the fallback allocation path is only valid for
+        single-input cores because it infers the input gradient shape from the
+        first non-``None`` incoming gradient. Chinese: 每个输入序列的模板, 用于分配
+        输入梯度。当所有传入梯度都为 ``None`` 时必须提供, 并确保仅有状态输出的 core
+        仍返回形状正确的输入梯度。若省略该参数, 当前仅支持单输入 core, 因为回退路径会从
+        第一个非 ``None`` 的传入梯度推断输入梯度形状。
     :type input_templates: Optional[Tuple[torch.Tensor, ...]]
     :param state_templates: EN: Per-initial-state templates used to allocate initial
         state gradients. When provided, the returned state gradients preserve the
@@ -249,6 +282,10 @@ def flexsn_backward(
         if grad_example is None:
             raise ValueError(
                 "input_templates are required when all incoming FlexSN gradients are None"
+            )
+        if info.num_inputs != 1:
+            raise ValueError(
+                "input_templates are required when FlexSN has multiple input sequences"
             )
         input_templates = tuple(grad_example for _ in range(info.num_inputs))
     if len(input_templates) != info.num_inputs:
@@ -284,24 +321,12 @@ def flexsn_backward(
     # State-sequence gradients include the leading time dimension. The wrapper
     # returns gradients for the initial states, so their templates are shape[1:].
     grad_inputs += [
-        (
-            torch.zeros_like(state_templates[i])
-            if T == 0
-            else torch.empty_like(state_templates[i])
-        )
-        if state_templates is not None
-        else (
-            grad_state_seq_examples[i].new_zeros(grad_state_seq_examples[i].shape[1:])
-            if T == 0
-            else grad_state_seq_examples[i].new_empty(
-                grad_state_seq_examples[i].shape[1:]
-            )
-        )
-        if i < len(grad_state_seq_examples) and grad_state_seq_examples[i] is not None
-        else (
-            grad_example.new_zeros(grad_example.shape[1:])
-            if T == 0
-            else grad_example.new_empty(grad_example.shape[1:])
+        _allocate_state_grad(
+            i,
+            T,
+            state_templates,
+            grad_state_seq_examples,
+            grad_example,
         )
         for i in range(info.num_states)
     ]

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -32,6 +32,20 @@ _BACKWARD_XLARGE_MAX_NCL = 1 << 23
 
 
 def flexsn_backward_ncl_bucket(ncl: int) -> int:
+    """Bucket a flattened sequence size for backward-kernel tuning.
+
+    Chinese:
+        将展平后的单步元素数 ``NCL`` 映射到 backward kernel 的调优分桶。
+
+    English:
+        Map the flattened per-step element count ``NCL`` to the backward-kernel
+        autotuning bucket.
+
+    :param ncl: EN: Flattened element count per time step. Chinese: 单个时间步展平后的元素数。
+    :type ncl: int
+    :return: EN: Bucket index in ``[0, 4]``. Chinese: ``[0, 4]`` 范围内的分桶索引。
+    :rtype: int
+    """
     if ncl <= _BACKWARD_SMALL_MAX_NCL:
         return 0
     if ncl <= _BACKWARD_MEDIUM_MAX_NCL:
@@ -58,6 +72,20 @@ def _make_grid(ncl: int):
 
 
 def flexsn_inference(f, info: FlexSNInfo, *args) -> tuple:
+    """Run the inference kernel for a multi-step FlexSN core.
+
+    Chinese:
+        执行 FlexSN 多步推理 kernel。
+
+    English:
+        Execute the FlexSN multi-step inference kernel.
+
+    :param f: EN: Triton kernel callable. Chinese: Triton kernel 可调用对象。
+    :param info: EN: FlexSN metadata. Chinese: FlexSN 元信息。
+    :param args: EN: Input/state sequences accepted by the kernel. Chinese: kernel 接收的输入/状态序列。
+    :return: EN: Output/state sequences. When ``T == 0``, returns empty tensors with the expected templates. Chinese: 输出/状态序列；当 ``T == 0`` 时, 返回符合模板的空张量。
+    :rtype: tuple
+    """
     x_example = args[0]
     T = x_example.shape[0]
     NCL = _num_elements_per_step(x_example)
@@ -80,6 +108,20 @@ def flexsn_inference(f, info: FlexSNInfo, *args) -> tuple:
 
 
 def flexsn_inference_final_state(f, info: FlexSNInfo, *args) -> tuple:
+    """Run the inference kernel and materialize final states.
+
+    Chinese:
+        执行带最终状态物化的 FlexSN 多步推理 kernel。
+
+    English:
+        Execute the FlexSN inference kernel and materialize final states.
+
+    :param f: EN: Triton kernel callable. Chinese: Triton kernel 可调用对象。
+    :param info: EN: FlexSN metadata. Chinese: FlexSN 元信息。
+    :param args: EN: Input/state sequences accepted by the kernel. Chinese: kernel 接收的输入/状态序列。
+    :return: EN: Output sequences followed by final states. When ``T == 0``, output sequences are empty, provided initial states are cloned, and missing states are zero-filled. Chinese: 输出序列后接最终状态；当 ``T == 0`` 时, 输出序列为空, 已提供的初始状态会被克隆, 缺失状态会以零填充。
+    :rtype: tuple
+    """
     x_example = args[0]
     T = x_example.shape[0]
     NCL = _num_elements_per_step(x_example)
@@ -116,6 +158,20 @@ def flexsn_inference_final_state(f, info: FlexSNInfo, *args) -> tuple:
 
 
 def flexsn_forward(f, info: FlexSNInfo, *args) -> tuple:
+    """Run the training forward kernel for FlexSN.
+
+    Chinese:
+        执行 FlexSN 训练前向 kernel。
+
+    English:
+        Execute the FlexSN training forward kernel.
+
+    :param f: EN: Triton kernel callable. Chinese: Triton kernel 可调用对象。
+    :param info: EN: FlexSN metadata. Chinese: FlexSN 元信息。
+    :param args: EN: Input/state sequences accepted by the kernel. Chinese: kernel 接收的输入/状态序列。
+    :return: EN: Forward outputs plus any saved tensors required by backward. When ``T == 0``, returns empty tensors following the expected templates. Chinese: 前向输出以及 backward 所需的保存张量；当 ``T == 0`` 时, 返回符合模板的空张量。
+    :rtype: tuple
+    """
     x_example = args[0]
     T = x_example.shape[0]
     NCL = _num_elements_per_step(x_example)
@@ -136,6 +192,20 @@ def flexsn_forward(f, info: FlexSNInfo, *args) -> tuple:
 
 
 def flexsn_backward(f, info: FlexSNInfo, *args) -> tuple:
+    """Run the training backward kernel for FlexSN.
+
+    Chinese:
+        执行 FlexSN 训练反向 kernel。
+
+    English:
+        Execute the FlexSN training backward kernel.
+
+    :param f: EN: Triton kernel callable. Chinese: Triton kernel 可调用对象。
+    :param info: EN: FlexSN metadata. Chinese: FlexSN 元信息。
+    :param args: EN: Gradients and saved tensors accepted by the kernel. Chinese: kernel 接收的梯度与保存张量。
+    :return: EN: Gradients for inputs and initial states. When ``T == 0``, returns zero-filled gradients. Chinese: 输入与初始状态的梯度；当 ``T == 0`` 时, 返回零填充梯度。
+    :rtype: tuple
+    """
     grad_example = args[0]
     T = grad_example.shape[0]
     NCL = _num_elements_per_step(grad_example)
@@ -184,6 +254,14 @@ def flexsn_backward(f, info: FlexSNInfo, *args) -> tuple:
 
 
 class FlexSNFunction(autograd.Function):
+    """Autograd bridge between FlexSN Python code and Triton kernels.
+
+    Chinese:
+        连接 FlexSN Python 逻辑与 Triton kernel 的 autograd 桥接类。
+
+    English:
+        Autograd bridge between FlexSN Python logic and Triton kernels.
+    """
     @staticmethod
     @contiguous_and_device_guard
     @amp_custom_fwd

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -191,7 +191,12 @@ def flexsn_forward(f, info: FlexSNInfo, *args) -> tuple:
     return tuple(returns)
 
 
-def flexsn_backward(f, info: FlexSNInfo, *args) -> tuple:
+def flexsn_backward(
+    f,
+    info: FlexSNInfo,
+    *args,
+    input_templates=None,
+) -> tuple:
     """Run the training backward kernel for FlexSN.
 
     Chinese:
@@ -209,13 +214,19 @@ def flexsn_backward(f, info: FlexSNInfo, *args) -> tuple:
     grad_example = args[0]
     T = grad_example.shape[0]
     NCL = _num_elements_per_step(grad_example)
+    if input_templates is None:
+        input_templates = tuple(grad_example for _ in range(info.num_inputs))
+    if len(input_templates) != info.num_inputs:
+        raise ValueError(
+            "input_templates must provide one template per FlexSN input sequence"
+        )
     grad_inputs = [
         (
-            torch.zeros_like(grad_example)
+            torch.zeros_like(input_templates[i])
             if T == 0
-            else torch.empty_like(grad_example)
+            else torch.empty_like(input_templates[i])
         )
-        for _ in range(info.num_inputs)
+        for i in range(info.num_inputs)
     ]
     grad_state_seq_examples = args[
         info.num_outputs : info.num_outputs + info.num_states
@@ -282,6 +293,10 @@ class FlexSNFunction(autograd.Function):
             ctx.save_for_backward(*to_save)
             ctx.fn_bwd = fn_bwd
             ctx.info = info
+            ctx.input_template_specs = tuple(
+                (tuple(arg.shape), arg.dtype, arg.device)
+                for arg in args[: info.num_inputs]
+            )
         else:
             outputs_states = flexsn_inference(fn_inf, info, *args)
         if len(outputs_states) == 1:
@@ -295,5 +310,15 @@ class FlexSNFunction(autograd.Function):
     def backward(ctx, *args):  # len(args) = num_outputs + num_states
         required_results = ctx.saved_tensors
         fn_bwd = ctx.fn_bwd
-        grads = flexsn_backward(fn_bwd, ctx.info, *args, *required_results)
+        input_templates = tuple(
+            torch.empty(shape, dtype=dtype, device=device)
+            for shape, dtype, device in getattr(ctx, "input_template_specs", ())
+        )
+        grads = flexsn_backward(
+            fn_bwd,
+            ctx.info,
+            *args,
+            *required_results,
+            input_templates=input_templates,
+        )
         return None, None, None, None, *grads

--- a/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/wrapper.py
@@ -257,11 +257,12 @@ def flexsn_backward(
         gradients. They are required when all incoming gradients are ``None`` and
         ensure that state-only cores still return correctly shaped input-sequence
         gradients. When omitted, the fallback allocation path is only valid for
-        single-input cores because it infers the input gradient shape from the
-        first non-``None`` incoming gradient. Chinese: 每个输入序列的模板, 用于分配
-        输入梯度。当所有传入梯度都为 ``None`` 时必须提供, 并确保仅有状态输出的 core
-        仍返回形状正确的输入梯度。若省略该参数, 当前仅支持单输入 core, 因为回退路径会从
-        第一个非 ``None`` 的传入梯度推断输入梯度形状。
+        single-input cores whose output-sequence gradients are present, because
+        it infers the input gradient shape from the first non-``None``
+        output-sequence gradient. Chinese: 每个输入序列的模板, 用于分配输入梯度。
+        当所有传入梯度都为 ``None`` 时必须提供, 并确保仅有状态输出的 core 仍返回
+        形状正确的输入梯度。若省略该参数, 当前仅支持单输入且存在输出序列梯度的 core,
+        因为回退路径会从第一个非 ``None`` 的输出序列梯度推断输入梯度形状。
     :type input_templates: Optional[Tuple[torch.Tensor, ...]]
     :param state_templates: EN: Per-initial-state templates used to allocate initial
         state gradients. When provided, the returned state gradients preserve the
@@ -277,6 +278,7 @@ def flexsn_backward(
     """
     required_grad_count = info.num_outputs + info.num_states
     grad_output_args = args[:required_grad_count]
+    grad_output_example = _first_non_none_tensor(grad_output_args[: info.num_outputs])
     grad_example = _first_non_none_tensor(grad_output_args)
     if input_templates is None:
         if grad_example is None:
@@ -287,7 +289,12 @@ def flexsn_backward(
             raise ValueError(
                 "input_templates are required when FlexSN has multiple input sequences"
             )
-        input_templates = tuple(grad_example for _ in range(info.num_inputs))
+        if grad_output_example is None:
+            raise ValueError(
+                "input_templates are required when FlexSN output-sequence gradients "
+                "are all None"
+            )
+        input_templates = tuple(grad_output_example for _ in range(info.num_inputs))
     if len(input_templates) != info.num_inputs:
         raise ValueError(
             "input_templates must provide one template per FlexSN input sequence"
@@ -318,6 +325,13 @@ def flexsn_backward(
     grad_state_seq_examples = grad_output_args[
         info.num_outputs : info.num_outputs + info.num_states
     ]
+    if state_templates is None and any(
+        grad is None for grad in grad_state_seq_examples
+    ):
+        raise ValueError(
+            "state_templates are required when any incoming FlexSN "
+            "state-sequence gradient is None"
+        )
     grad_kernel_args = [
         grad if grad is not None else torch.zeros_like(grad_example)
         for grad in grad_output_args

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/graph2triton.py
@@ -1,7 +1,16 @@
-from typing import Tuple
-import tempfile
+from typing import Optional, Tuple
+import errno
+import importlib.util
+import linecache
+import os
 from pathlib import Path
 import hashlib
+import re
+import stat
+import sys
+import tempfile
+import threading
+import types
 
 import torch
 import torch.fx as fx
@@ -20,7 +29,6 @@ except BaseException as e:
     tl = dummy.DummyImport()
 
 from ..triton_utils import type_str_dict
-from ..triton_utils import ensure_cleanup_tmp_python_files
 
 
 __all__ = [
@@ -29,9 +37,95 @@ __all__ = [
 ]
 
 
+_MODULE_CACHE_LOCK_GUARD = threading.Lock()
+_MODULE_CACHE_LOCKS = {}
+_CODEGEN_CACHE_DIR = None
+_CODEGEN_CACHE_DIR_LOCK = threading.Lock()
+_NAMESPACE_METADATA_KEYS = {
+    "__name__",
+    "__spec__",
+    "__loader__",
+    "__package__",
+    "__path__",
+    "__file__",
+    "__cached__",
+    "__builtins__",
+    "__doc__",
+}
+
+
+def _get_module_cache_lock(module_name: str) -> threading.Lock:
+    with _MODULE_CACHE_LOCK_GUARD:
+        return _MODULE_CACHE_LOCKS.setdefault(module_name, threading.Lock())
+
+
 def _generate_hash(s: str, w: int = 8) -> str:
     hasher = hashlib.sha256(s.encode("utf-8"))
     return hasher.hexdigest()[:w]
+
+
+def _safe_codegen_stem(kernel_name: str) -> str:
+    name = str(kernel_name).replace("\\", "/").rsplit("/", 1)[-1]
+    safe = re.sub(r"[^0-9A-Za-z_.-]+", "_", name).strip("._")
+    return (safe or "kernel")[:128]
+
+
+def _has_real_triton_runtime() -> bool:
+    return isinstance(triton, types.ModuleType) and isinstance(tl, types.ModuleType)
+
+
+def _codegen_cache_dir() -> Path:
+    global _CODEGEN_CACHE_DIR
+    if _CODEGEN_CACHE_DIR is not None:
+        return _CODEGEN_CACHE_DIR
+    with _CODEGEN_CACHE_DIR_LOCK:
+        if _CODEGEN_CACHE_DIR is not None:
+            return _CODEGEN_CACHE_DIR
+        cache_dir = _resolve_codegen_cache_dir()
+        _CODEGEN_CACHE_DIR = cache_dir
+        return cache_dir
+
+
+def _resolve_codegen_cache_dir() -> Path:
+    candidates = []
+    uid = getattr(os, "getuid", lambda: None)()
+    try:
+        candidates.append(Path.home() / ".spikingjelly" / "triton_codegen")
+    except RuntimeError:
+        pass
+    temp_suffix = f"_{uid}" if uid is not None else ""
+    candidates.append(
+        Path(tempfile.gettempdir()) / f"spikingjelly_triton_codegen{temp_suffix}"
+    )
+    last_error = None
+    for cache_dir in candidates:
+        try:
+            cache_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+            if uid is not None:
+                st = cache_dir.stat()
+                if st.st_uid == uid:
+                    try:
+                        os.chmod(cache_dir, 0o700)
+                    except OSError:
+                        pass
+                    st = cache_dir.stat()
+                mode = stat.S_IMODE(st.st_mode)
+                if (
+                    st.st_uid != uid
+                    or not (mode & stat.S_IWUSR)
+                    or (mode & 0o077)
+                ):
+                    continue
+            with tempfile.NamedTemporaryFile(dir=cache_dir, delete=True):
+                pass
+            return cache_dir
+        except OSError as e:
+            last_error = e
+            if e.errno not in (errno.EACCES, errno.EROFS, errno.EPERM):
+                raise
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("Failed to initialize Triton codegen cache directory")
 
 
 def _uw(arg) -> str:
@@ -267,47 +361,103 @@ def generate_triton_code_str(
     return f"{prefix}\n\n{signature}\n{triton_code_lines}", fn_name
 
 
-@ensure_cleanup_tmp_python_files
 def compile_triton_code_str(
     triton_code: str,
     kernel_name: str,
     verbose: bool = False,
-    name_space: dict = {},
+    name_space: Optional[dict] = None,
 ):
     """Compile a Triton code string into a runnable Triton JIT function.
 
-    Writes the Triton code to a temporary file, compiles it, and extracts the
-    JIT function from the compiled namespace.
+    Materializes the Triton code under the persistent codegen cache, loads or
+    reuses the matching module object, and extracts the requested JIT function.
 
     Args:
-        triton_code (str): The Triton code string to compile.
+        triton_code (str): The Triton code string to compile/cache.
         kernel_name (str): The name of the Triton function to extract.
-        verbose (bool, optional): If True, print the path to the temporary file. Defaults to False.
-        name_space (dict, optional): A namespace dictionary to use for `exec`. Defaults to {}.
+        verbose (bool, optional): If True, print whether the cached source was
+            written or reused, along with its path. Defaults to False.
+        name_space (Optional[dict], optional): Optional globals injected before execution.
+            When provided, it will be updated with symbols defined by the compiled module.
+            Calls without ``name_space`` reuse a cached module keyed by the generated
+            source hash; calls with ``name_space`` reload so injected symbols stay fresh.
 
     Returns:
         triton.JITFunction: The compiled Triton JIT function.
     """
-    # create a temporary file
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-        f.write(triton_code)
-        fpath = Path(f.name)
-        if verbose:
-            print(f"Triton code `{kernel_name}` written to {fpath}")
-        # the file will not be deleted until the end of the program
+    if not _has_real_triton_runtime():
+        raise ImportError(
+            "compile_triton_code_str requires a real Triton installation; "
+            "the imported triton/tl modules are unavailable."
+        )
 
-    name_space.update(
-        {
-            "triton": triton,
-            "tl": tl,
-            "__name__": "spikingjelly.activation_based.triton_kernel.codegen",
-        }
-    )
-    with open(fpath, "r") as f:
-        code = compile(f.read(), fpath, "exec")
-        exec(code, name_space)  # name_space will be updated
-
-    if kernel_name in name_space:
-        return name_space[kernel_name]
+    caller_namespace = name_space
+    cacheable = caller_namespace is None
+    if caller_namespace is None:
+        module_globals = {"triton": triton, "tl": tl}
     else:
-        raise ValueError(f"Function {kernel_name} not found in compiled namespace")
+        module_globals = {
+            key: value
+            for key, value in caller_namespace.items()
+            if key not in _NAMESPACE_METADATA_KEYS
+        }
+        module_globals.pop(kernel_name, None)
+        module_globals.setdefault("triton", triton)
+        module_globals.setdefault("tl", tl)
+
+    safe_kernel_name = _safe_codegen_stem(kernel_name)
+    module_hash = _generate_hash(f"{kernel_name}\n{triton_code}", w=16)
+    module_name = (
+        "spikingjelly.activation_based.triton_kernel.codegen."
+        f"{safe_kernel_name}_{module_hash}"
+    )
+    fpath = _codegen_cache_dir() / f"{safe_kernel_name}_{module_hash}.py"
+
+    needs_write = not fpath.exists()
+    if needs_write:
+        tmp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w", encoding="utf-8", dir=fpath.parent, delete=False, suffix=".tmp"
+            ) as tmp_file:
+                tmp_path = Path(tmp_file.name)
+                tmp_file.write(triton_code)
+            os.replace(tmp_path, fpath)
+            try:
+                os.chmod(fpath, 0o600)
+            except OSError:
+                pass
+        except Exception:
+            if tmp_path is not None:
+                try:
+                    tmp_path.unlink()
+                except FileNotFoundError:
+                    pass
+            raise
+    if verbose:
+        action = "written to" if needs_write else "loaded from cache"
+        print(f"Triton code `{kernel_name}` {action} {fpath}")
+
+    linecache.checkcache(str(fpath))
+
+    with _get_module_cache_lock(module_name):
+        module = sys.modules.get(module_name) if cacheable else None
+        if module is None:
+            spec = importlib.util.spec_from_file_location(module_name, fpath)
+            if spec is None or spec.loader is None:
+                raise ImportError(f"Could not create import spec for {fpath}")
+            module = importlib.util.module_from_spec(spec)
+            module.__dict__.update(module_globals)
+            spec.loader.exec_module(module)
+            if cacheable:
+                sys.modules[module_name] = module
+    if caller_namespace is not None:
+        exported_symbols = {
+            key: value
+            for key, value in module.__dict__.items()
+            if key not in _NAMESPACE_METADATA_KEYS
+        }
+        caller_namespace.update(exported_symbols)
+    if kernel_name in module.__dict__:
+        return module.__dict__[kernel_name]
+    raise ValueError(f"Function {kernel_name} not found in compiled namespace")

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/torch2graph.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/torch2graph.py
@@ -3,7 +3,7 @@ from typing import Callable, Optional, Tuple
 
 import torch
 import torch.fx as fx
-from functorch.compile import aot_function
+from functorch.compile import aot_function, min_cut_rematerialization_partition
 
 warnings.filterwarnings("ignore", category=UserWarning)
 
@@ -49,12 +49,6 @@ def _optimize_graph(graph: fx.Graph):
     return GraphOptimizer(fx.GraphModule({}, graph)).transform().graph
 
 
-def _normalize_outputs(outputs):
-    if isinstance(outputs, torch.Tensor):
-        return (outputs,)
-    return tuple(outputs)
-
-
 def generate_inference_graph(fn: Callable, example_inputs: tuple):
     """Generate an optimized inference graph from a PyTorch function.
 
@@ -80,7 +74,7 @@ def generate_inference_graph(fn: Callable, example_inputs: tuple):
             i.requires_grad = False  # for inference
 
     # feed the fake inputs
-    ys = _normalize_outputs(f(*example_inputs))
+    _ = f(*example_inputs)
     return _optimize_graph(collector.fwd_graph)
 
 
@@ -108,6 +102,7 @@ def generate_forward_and_backward_graph(
         fn,
         fw_compiler=collector.get_forward_compiler(),
         bw_compiler=collector.get_backward_compiler(),
+        partition_fn=min_cut_rematerialization_partition,
     )
 
     if requires_grad is not None:
@@ -120,7 +115,14 @@ def generate_forward_and_backward_graph(
                 i.requires_grad = True
 
     # feed the fake inputs
-    ys = _normalize_outputs(f(*example_inputs))
+    ys = f(*example_inputs)
+    # Normalise to tuple so iteration always walks outputs, not tensor dimensions
+    if isinstance(ys, torch.Tensor):
+        ys = (ys,)
+    elif not isinstance(ys, (list, tuple)):
+        raise ValueError(
+            f"Expected {fn} to return a tuple/list of Tensors, got {type(ys)}"
+        )
     # choose a differentiable Tensor in ys as the starting point of .backward()
     # (some outputs, e.g. spike signals from comparisons, have no grad_fn)
     o = None

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/torch2graph.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/torch2graph.py
@@ -123,19 +123,17 @@ def generate_forward_and_backward_graph(
         raise ValueError(
             f"Expected {fn} to return a tuple/list of Tensors, got {type(ys)}"
         )
-    # choose a differentiable Tensor in ys as the starting point of .backward()
-    # (some outputs, e.g. spike signals from comparisons, have no grad_fn)
-    o = None
-    for y in ys:
-        if isinstance(y, torch.Tensor) and (y.requires_grad or y.grad_fn is not None):
-            o = y
-            break
-    if o is None:
+    diff_outputs = [
+        y
+        for y in ys
+        if isinstance(y, torch.Tensor) and (y.requires_grad or y.grad_fn is not None)
+    ]
+    if not diff_outputs:
         raise ValueError(f"No differentiable Tensor found in the output of the function {fn}")
-    # create a fake gradient
-    g = torch.randn_like(o)
-    # backward
-    o.backward(g)
+    torch.autograd.backward(
+        diff_outputs,
+        [torch.randn_like(y) for y in diff_outputs],
+    )
 
     collector.bwd_graph.lint()
 

--- a/spikingjelly/activation_based/triton_kernel/torch2triton/torch2graph.py
+++ b/spikingjelly/activation_based/triton_kernel/torch2triton/torch2graph.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional, Sequence, Tuple
 
 import torch
 import torch.fx as fx
@@ -49,18 +49,22 @@ def _optimize_graph(graph: fx.Graph):
     return GraphOptimizer(fx.GraphModule({}, graph)).transform().graph
 
 
-def generate_inference_graph(fn: Callable, example_inputs: tuple):
-    """Generate an optimized inference graph from a PyTorch function.
+def generate_inference_graph(fn: Callable, example_inputs: tuple) -> fx.Graph:
+    """Generate an optimized inference FX graph.
 
-    For inference scenarios, all input tensors are set to `requires_grad=False`
-    to disable gradient tracking.
+    Chinese:
+        为给定的 PyTorch 函数生成优化后的推理 FX 图。
 
-    Args:
-        fn (Callable): The PyTorch function to generate the inference graph for.
-        example_inputs (tuple): A tuple of example inputs to trace the function's execution.
+    English:
+        Generate an optimized inference FX graph for a PyTorch callable.
 
-    Returns:
-        fx.Graph: The optimized inference graph.
+    :param fn: EN: Callable to trace. Chinese: 待追踪的可调用对象。
+    :type fn: Callable
+    :param example_inputs: EN: Example inputs used for tracing. Chinese: 用于追踪的示例输入。
+    :type example_inputs: tuple
+    :return: EN: Optimized forward FX graph. Chinese: 优化后的前向 FX 图。
+    :rtype: torch.fx.Graph
+    :raises ValueError: EN: Raised when the traced callable fails to produce a forward graph. Chinese: 当被追踪函数未能产生前向 FX 图时抛出。
     """
     collector = GraphCollector()
     f = aot_function(
@@ -75,27 +79,33 @@ def generate_inference_graph(fn: Callable, example_inputs: tuple):
 
     # feed the fake inputs
     _ = f(*example_inputs)
+    if collector.fwd_graph is None:
+        raise ValueError(f"Failed to capture an inference graph for {fn}.")
     return _optimize_graph(collector.fwd_graph)
 
 
 def generate_forward_and_backward_graph(
-    fn: Callable, example_inputs: tuple, requires_grad: Optional[Tuple[bool]] = None
-):
-    """Generate optimized forward and backward graphs from a PyTorch function.
+    fn: Callable,
+    example_inputs: tuple,
+    requires_grad: Optional[Sequence[bool]] = None,
+) -> Tuple[fx.Graph, fx.Graph]:
+    """Generate optimized forward/backward FX graphs.
 
-    Allows specifying gradient requirements for input tensors; if not specified,
-    all tensors default to `requires_grad=True`.
+    Chinese:
+        为给定的 PyTorch 函数生成优化后的前向与反向 FX 图。
 
-    Args:
-        fn (Callable): The PyTorch function to generate the graphs for.
-        example_inputs (tuple): A tuple of example inputs to trace the function's execution.
-        requires_grad (Tuple[bool], optional): A tuple indicating whether each
-            input tensor requires gradient. If given, must match the length of
-            `example_inputs`. Defaults to None, where all input tensors are set
-            to `requires_grad=True`.
+    English:
+        Generate optimized forward and backward FX graphs for a PyTorch callable.
 
-    Returns:
-        Tuple[fx.Graph, fx.Graph]: the optimized forward and backward graph.
+    :param fn: EN: Callable to trace. Chinese: 待追踪的可调用对象。
+    :type fn: Callable
+    :param example_inputs: EN: Example inputs used for tracing. Chinese: 用于追踪的示例输入。
+    :type example_inputs: tuple
+    :param requires_grad: EN: Optional gradient-requirement flags for each example input. Chinese: 每个示例输入对应的可选求导标志。
+    :type requires_grad: Optional[Sequence[bool]]
+    :return: EN: Optimized forward and backward FX graphs. Chinese: 优化后的前向与反向 FX 图。
+    :rtype: Tuple[torch.fx.Graph, torch.fx.Graph]
+    :raises ValueError: EN: Raised when ``requires_grad`` length mismatches ``example_inputs``, when the callable does not return a tensor/list/tuple, or when no differentiable output exists. Chinese: 当 ``requires_grad`` 长度与 ``example_inputs`` 不匹配、函数返回值不是张量/列表/元组、或不存在可求导输出时抛出。
     """
     collector = GraphCollector()
     f = aot_function(
@@ -106,6 +116,10 @@ def generate_forward_and_backward_graph(
     )
 
     if requires_grad is not None:
+        if len(requires_grad) != len(example_inputs):
+            raise ValueError(
+                "requires_grad must have the same length as example_inputs"
+            )
         for i, r in zip(example_inputs, requires_grad):
             if isinstance(i, torch.Tensor):
                 i.requires_grad = r
@@ -120,21 +134,23 @@ def generate_forward_and_backward_graph(
     if isinstance(ys, torch.Tensor):
         ys = (ys,)
     elif not isinstance(ys, (list, tuple)):
-        raise ValueError(
-            f"Expected {fn} to return a tuple/list of Tensors, got {type(ys)}"
-        )
+        raise ValueError(f"Expected {fn} to return a tuple/list of Tensors, got {type(ys)}")
     diff_outputs = [
         y
         for y in ys
         if isinstance(y, torch.Tensor) and (y.requires_grad or y.grad_fn is not None)
     ]
     if not diff_outputs:
-        raise ValueError(f"No differentiable Tensor found in the output of the function {fn}")
+        raise ValueError(
+            f"No differentiable Tensor found in the output of the function {fn}"
+        )
     torch.autograd.backward(
         diff_outputs,
         [torch.randn_like(y) for y in diff_outputs],
     )
 
+    if collector.fwd_graph is None or collector.bwd_graph is None:
+        raise ValueError(f"Failed to capture both forward and backward graphs for {fn}.")
     collector.bwd_graph.lint()
 
     return (

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -702,6 +702,7 @@ def test_flexsn_wrapper_backward_zero_fills_mixed_none_gradients(monkeypatch):
 
     info = SimpleNamespace(num_inputs=1, num_states=1, num_outputs=1)
     grad_output = torch.randn(3, 4)
+    state_template = torch.randn(6)
     monkeypatch.setitem(wrapper.type_dict, grad_output.dtype, "float32")
 
     grad_x, grad_v = wrapper.flexsn_backward(
@@ -709,12 +710,35 @@ def test_flexsn_wrapper_backward_zero_fills_mixed_none_gradients(monkeypatch):
         info,
         grad_output,
         None,
+        state_templates=(state_template,),
     )
 
     torch.testing.assert_close(seen["grad_output"], grad_output)
     torch.testing.assert_close(seen["grad_state_seq"], torch.zeros_like(grad_output))
     torch.testing.assert_close(grad_x, torch.ones_like(grad_x))
     torch.testing.assert_close(grad_v, torch.ones_like(grad_v))
+
+
+def test_flexsn_wrapper_backward_requires_state_templates_for_missing_state_seq_grad():
+    from spikingjelly.activation_based.triton_kernel.flexsn import wrapper
+
+    info = SimpleNamespace(num_inputs=1, num_states=1, num_outputs=1)
+    grad_output = torch.randn(3, 4)
+
+    with pytest.raises(ValueError, match="state_templates are required"):
+        wrapper.flexsn_backward(None, info, grad_output, None)
+
+
+def test_flexsn_wrapper_backward_requires_input_templates_when_output_grads_missing():
+    from spikingjelly.activation_based.triton_kernel.flexsn import wrapper
+
+    info = SimpleNamespace(num_inputs=1, num_states=1, num_outputs=1)
+    grad_state_seq = torch.randn(3, 4)
+
+    with pytest.raises(
+        ValueError, match="output-sequence gradients are all None"
+    ):
+        wrapper.flexsn_backward(None, info, None, grad_state_seq)
 
 
 def test_inductor_final_state_warmup_args_use_example_shapes():
@@ -1360,6 +1384,23 @@ def test_eager_scan_empty_state_only_does_not_require_output_template():
     assert v_seq.shape == (0, 3)
     torch.testing.assert_close(v_final, v0)
     assert v_final is not v0
+
+
+def test_eager_scan_empty_sequence_validates_core_arity():
+    x = torch.empty(0, 2)
+    v0 = torch.zeros(2)
+    specs = (((2,), x.dtype),)
+
+    def bad_core(x_t, v_t, extra):
+        return x_t, v_t
+
+    with pytest.raises(ValueError, match="expected 2 tensor args"):
+        eager_scan(bad_core, 1, 1, 1, x, v0, output_template_specs=specs)
+
+    with pytest.raises(ValueError, match="expected 2 tensor args"):
+        eager_scan_final_state(
+            bad_core, 1, 1, 1, x, v0, output_template_specs=specs
+        )
 
 
 def test_inference_final_state_template_handles_zero_states(monkeypatch):

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -1140,6 +1140,8 @@ def test_hop_rejects_mismatched_T():
 
 
 def test_hop_registers_with_dynamo():
+    _skip_if_dynamo_hop_unavailable()
+
     try:
         from torch._dynamo.variables.higher_order_ops import (
             TorchHigherOrderOperatorVariable,
@@ -1400,6 +1402,19 @@ def test_eager_scan_empty_sequence_validates_core_arity():
     with pytest.raises(ValueError, match="expected 2 tensor args"):
         eager_scan_final_state(
             bad_core, 1, 1, 1, x, v0, output_template_specs=specs
+        )
+
+    def bad_keyword_core(x_t, v_t, *, bias):
+        return x_t, v_t
+
+    with pytest.raises(ValueError, match="expected 2 tensor args"):
+        eager_scan(
+            bad_keyword_core, 1, 1, 1, x, v0, output_template_specs=specs
+        )
+
+    with pytest.raises(ValueError, match="expected 2 tensor args"):
+        eager_scan_final_state(
+            bad_keyword_core, 1, 1, 1, x, v0, output_template_specs=specs
         )
 
 

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -39,6 +39,9 @@ from spikingjelly.activation_based.triton_kernel.flexsn.info import FlexSNInfo
 from spikingjelly.activation_based.triton_kernel.torch2triton import (
     graph2triton as graph2triton_module,
 )
+from spikingjelly.activation_based.triton_kernel.torch2triton import (
+    torch2graph as torch2graph_module,
+)
 
 
 def _lif_core(x: torch.Tensor, v: torch.Tensor):
@@ -232,6 +235,29 @@ def test_scan_backends_reject_mismatched_example_output_template():
             backend="inductor",
             example_inputs=(torch.zeros(3), torch.zeros(3)),
             example_outputs=(torch.zeros(4),),
+        )
+
+
+def test_scan_backends_reject_mismatched_example_input_numel():
+    with pytest.raises(ValueError, match="same number of elements"):
+        FlexSN(
+            core=_lif_core,
+            num_inputs=1,
+            num_states=1,
+            num_outputs=1,
+            step_mode="m",
+            backend="inductor",
+            example_inputs=(torch.zeros(2, 3), torch.zeros(5)),
+            example_outputs=(torch.zeros(2, 3),),
+        )
+
+
+def test_generate_forward_and_backward_graph_rejects_requires_grad_length_mismatch():
+    with pytest.raises(ValueError, match="requires_grad must have the same length"):
+        torch2graph_module.generate_forward_and_backward_graph(
+            _lif_core,
+            (torch.zeros(3), torch.zeros(3)),
+            requires_grad=(True,),
         )
 
 

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -557,6 +557,62 @@ def test_flexsn_wrapper_t0_backward_state_grads_use_state_templates(monkeypatch)
     torch.testing.assert_close(grad_v1, torch.zeros_like(grad_v1))
 
 
+def test_flexsn_wrapper_backward_uses_input_templates_for_state_only_core(monkeypatch):
+    from spikingjelly.activation_based.triton_kernel.flexsn import wrapper
+
+    class _FakeKernel:
+        def __getitem__(self, grid):
+            def _run(*args, **kwargs):
+                return None
+
+            return _run
+
+    info = SimpleNamespace(num_inputs=1, num_states=1, num_outputs=0)
+    input_template = torch.empty(2, 2, 3)
+    grad_state_seq = torch.empty(2, 6)
+
+    monkeypatch.setitem(wrapper.type_dict, grad_state_seq.dtype, "float32")
+
+    grad_x, grad_v = wrapper.flexsn_backward(
+        _FakeKernel(),
+        info,
+        grad_state_seq,
+        input_templates=(input_template,),
+    )
+
+    assert grad_x.shape == input_template.shape
+    assert grad_v.shape == (6,)
+
+
+def test_flexsn_wrapper_t0_backward_uses_input_templates_for_state_only_core(monkeypatch):
+    from spikingjelly.activation_based.triton_kernel.flexsn import wrapper
+
+    class _FakeKernel:
+        def __getitem__(self, grid):
+            def _run(*args, **kwargs):
+                return None
+
+            return _run
+
+    info = SimpleNamespace(num_inputs=1, num_states=1, num_outputs=0)
+    input_template = torch.empty(0, 2, 3)
+    grad_state_seq = torch.empty(0, 6)
+
+    monkeypatch.setitem(wrapper.type_dict, grad_state_seq.dtype, "float32")
+
+    grad_x, grad_v = wrapper.flexsn_backward(
+        _FakeKernel(),
+        info,
+        grad_state_seq,
+        input_templates=(input_template,),
+    )
+
+    assert grad_x.shape == input_template.shape
+    assert grad_v.shape == (6,)
+    torch.testing.assert_close(grad_x, torch.zeros_like(input_template))
+    torch.testing.assert_close(grad_v, torch.zeros_like(grad_v))
+
+
 def test_inductor_final_state_warmup_args_use_example_shapes():
     info = SimpleNamespace(num_inputs=2, num_states=2)
     specs = (

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -685,6 +685,38 @@ def test_flexsn_wrapper_backward_requires_input_templates_for_multi_input_core()
         wrapper.flexsn_backward(None, info, grad_output)
 
 
+def test_flexsn_wrapper_backward_zero_fills_mixed_none_gradients(monkeypatch):
+    from spikingjelly.activation_based.triton_kernel.flexsn import wrapper
+
+    seen = {}
+
+    class _FakeKernel:
+        def __getitem__(self, grid):
+            def _run(*args, **kwargs):
+                seen["grad_output"] = args[0]
+                seen["grad_state_seq"] = args[1]
+                args[2].copy_(torch.ones_like(args[2]))
+                args[3].copy_(torch.ones_like(args[3]))
+
+            return _run
+
+    info = SimpleNamespace(num_inputs=1, num_states=1, num_outputs=1)
+    grad_output = torch.randn(3, 4)
+    monkeypatch.setitem(wrapper.type_dict, grad_output.dtype, "float32")
+
+    grad_x, grad_v = wrapper.flexsn_backward(
+        _FakeKernel(),
+        info,
+        grad_output,
+        None,
+    )
+
+    torch.testing.assert_close(seen["grad_output"], grad_output)
+    torch.testing.assert_close(seen["grad_state_seq"], torch.zeros_like(grad_output))
+    torch.testing.assert_close(grad_x, torch.ones_like(grad_x))
+    torch.testing.assert_close(grad_v, torch.ones_like(grad_v))
+
+
 def test_inductor_final_state_warmup_args_use_example_shapes():
     info = SimpleNamespace(num_inputs=2, num_states=2)
     specs = (

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -1179,8 +1179,8 @@ def test_dynamo_body_result_templates_use_speculated_outputs():
     )
 
     assert specs == (
-        ((2,), torch.float64, torch.device("cpu")),
-        ((3,), torch.float16, torch.device("cpu")),
+        ((2,), torch.float64),
+        ((3,), torch.float16),
     )
 
 

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -613,6 +613,55 @@ def test_flexsn_wrapper_t0_backward_uses_input_templates_for_state_only_core(mon
     torch.testing.assert_close(grad_v, torch.zeros_like(grad_v))
 
 
+def test_flexsn_wrapper_backward_uses_state_templates_for_state_only_core(monkeypatch):
+    from spikingjelly.activation_based.triton_kernel.flexsn import wrapper
+
+    class _FakeKernel:
+        def __getitem__(self, grid):
+            def _run(*args, **kwargs):
+                return None
+
+            return _run
+
+    info = SimpleNamespace(num_inputs=1, num_states=1, num_outputs=0)
+    input_template = torch.empty(2, 2, 3)
+    state_template = torch.empty(6)
+    grad_state_seq = torch.empty(2, 2, 3)
+
+    monkeypatch.setitem(wrapper.type_dict, grad_state_seq.dtype, "float32")
+
+    grad_x, grad_v = wrapper.flexsn_backward(
+        _FakeKernel(),
+        info,
+        grad_state_seq,
+        input_templates=(input_template,),
+        state_templates=(state_template,),
+    )
+
+    assert grad_x.shape == input_template.shape
+    assert grad_v.shape == state_template.shape
+
+
+def test_flexsn_wrapper_backward_all_none_gradients_use_templates():
+    from spikingjelly.activation_based.triton_kernel.flexsn import wrapper
+
+    info = SimpleNamespace(num_inputs=1, num_states=1, num_outputs=1)
+    input_template = torch.randn(2, 2, 3)
+    state_template = torch.randn(6)
+
+    grad_x, grad_v = wrapper.flexsn_backward(
+        None,
+        info,
+        None,
+        None,
+        input_templates=(input_template,),
+        state_templates=(state_template,),
+    )
+
+    torch.testing.assert_close(grad_x, torch.zeros_like(input_template))
+    torch.testing.assert_close(grad_v, torch.zeros_like(state_template))
+
+
 def test_inductor_final_state_warmup_args_use_example_shapes():
     info = SimpleNamespace(num_inputs=2, num_states=2)
     specs = (
@@ -769,6 +818,48 @@ def test_inductor_training_final_state_backward_pads_missing_grads(monkeypatch):
     )
     torch.testing.assert_close(grads[0], torch.zeros_like(x))
     torch.testing.assert_close(grads[1], torch.zeros_like(v))
+
+
+def test_inductor_backward_impl_passes_state_templates_to_wrapper(monkeypatch):
+    from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
+        custom_ops,
+    )
+
+    input_template = torch.randn(2, 2, 3)
+    state_template = torch.randn(6)
+    grad_state_seq = torch.randn(2, 2, 3)
+    bundle = SimpleNamespace(
+        backward_kernel=object(),
+        training_info=SimpleNamespace(num_inputs=1, num_outputs=0, num_states=1),
+    )
+    seen = {}
+
+    def fake_backward(
+        kernel,
+        info,
+        *args,
+        input_templates=None,
+        state_templates=None,
+    ):
+        seen["input_templates"] = input_templates
+        seen["state_templates"] = state_templates
+        return [torch.zeros_like(input_template), torch.zeros_like(state_template)]
+
+    monkeypatch.setattr(custom_ops, "flexsn_backward", fake_backward)
+
+    grads = custom_ops._flexsn_inductor_backward_impl(
+        bundle,
+        [grad_state_seq],
+        [],
+        [input_template, state_template],
+    )
+
+    assert len(seen["input_templates"]) == 1
+    assert len(seen["state_templates"]) == 1
+    assert seen["input_templates"][0].shape == input_template.shape
+    assert seen["state_templates"][0].shape == state_template.shape
+    assert grads[0].shape == input_template.shape
+    assert grads[1].shape == state_template.shape
 
 
 @pytest.mark.parametrize("T", [1, 4, 16])
@@ -1456,6 +1547,41 @@ def test_hop_backend_zero_length_sequence_delegates_to_hop_scan(monkeypatch):
 
     assert calls["count"] == 1
     assert hop_out.shape == (0, 5)
+
+
+def test_hop_backend_runtime_templates_ignore_example_output_device(monkeypatch):
+    captured = {}
+
+    def fake_run_hop_scan(
+        core,
+        num_inputs,
+        num_states,
+        num_outputs,
+        store_state_seqs,
+        *flat_args,
+        output_template_specs=None,
+    ):
+        captured["output_template_specs"] = output_template_specs
+        return (flat_args[0].new_empty((0, 5)),)
+
+    monkeypatch.setattr(flexsn_module, "_run_hop_scan", fake_run_hop_scan)
+    hop_neuron = FlexSN(
+        core=lambda x: (x.new_empty(5),),
+        num_inputs=1,
+        num_states=0,
+        num_outputs=1,
+        step_mode="m",
+        backend="hop",
+        store_state_seqs=False,
+        example_inputs=(torch.zeros(2),),
+        example_outputs=(torch.empty(5, device="meta"),),
+    )
+
+    hop_out = hop_neuron(torch.empty(0, 2))
+
+    assert captured["output_template_specs"] == (((5,), torch.float32),)
+    assert hop_out.shape == (0, 5)
+    assert hop_out.device.type == "cpu"
 
 
 def test_compile_fullgraph_hop_store_state_seqs_false_matches_eager_with_lowerable_while_loop(

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -10,28 +10,34 @@ so these tests do not require a CUDA GPU.
 from __future__ import annotations
 
 import sys
+from types import SimpleNamespace
 
 import pytest
 import torch
-from torch.fx.experimental.proxy_tensor import make_fx
 
-from spikingjelly.activation_based.neuron.flexsn import FlexSN
+from spikingjelly.activation_based.neuron.flexsn import (
+    FlexSN,
+    _make_inductor_final_state_warmup_args,
+)
+from spikingjelly.activation_based.neuron import flexsn as flexsn_module
+from spikingjelly.activation_based import base as base_module
 from spikingjelly.activation_based.model.spiking_vgg import spiking_vgg16_bn
 from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
-    custom_ops as flexsn_custom_ops,
+    dynamo_hop_available,
+    eager_scan,
+    eager_scan_final_state,
     flex_sn_scan,
-    kernel as flexsn_inductor_kernel,
     lowerable_scan,
+    lowerable_scan_final_state,
     lowerable_scan_available,
     lowerable_while_loop_scan,
     lowerable_while_loop_available,
 )
-from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
-    hop as flexsn_hop,
-)
+from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import hop as hop_module
+from spikingjelly.activation_based.triton_kernel.flexsn import template as template_module
 from spikingjelly.activation_based.triton_kernel.flexsn.info import FlexSNInfo
-from spikingjelly.activation_based.triton_kernel.flexsn.wrapper import (
-    flexsn_backward_ncl_bucket,
+from spikingjelly.activation_based.triton_kernel.torch2triton import (
+    graph2triton as graph2triton_module,
 )
 
 
@@ -45,15 +51,642 @@ def _lif_core(x: torch.Tensor, v: torch.Tensor):
     return s, v_new
 
 
-def _stateful_tanh_core(x: torch.Tensor, v: torch.Tensor):
-    v_new = torch.tanh(x + 0.5 * v)
-    y = torch.sigmoid(v_new)
-    return y, v_new
-
-
 @pytest.fixture
 def rng():
     return torch.Generator().manual_seed(42)
+
+
+def _skip_if_dynamo_hop_unavailable():
+    if not callable(dynamo_hop_available) or not dynamo_hop_available():
+        pytest.skip("FlexSN Dynamo HOP registration is unavailable")
+
+
+def test_torch_backend_empty_sequence_does_not_call_core():
+    calls = {"count": 0}
+
+    def core(x, v):
+        calls["count"] += 1
+        raise AssertionError("core should not run for an empty multi-step input")
+
+    m = FlexSN(
+        core=core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+        example_outputs=(torch.zeros(3),),
+    )
+
+    out = m(torch.empty(0, 3))
+
+    assert calls["count"] == 0
+    assert out.shape == (0, 3)
+    assert m.states[0].shape == (3,)
+
+
+def test_torch_backend_empty_sequence_does_not_probe_core_at_construction():
+    calls = {"count": 0}
+
+    def core(x, v):
+        calls["count"] += 1
+        return x.new_zeros(4), v
+
+    m = FlexSN(
+        core=core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+        example_inputs=(torch.zeros(2), torch.zeros(3)),
+        example_outputs=(torch.zeros(4),),
+    )
+    assert calls["count"] == 0
+    m.states = [torch.zeros(3)]
+
+    out = m.multi_step_forward(torch.empty(0, 2))[0]
+
+    assert calls["count"] == 0
+    assert out.shape == (0, 4)
+
+
+def test_torch_backend_empty_sequence_requires_example_output_template():
+    calls = {"count": 0}
+
+    def core(x, v):
+        calls["count"] += 1
+        return x, v
+
+    m = FlexSN(
+        core=core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+    )
+
+    with pytest.raises(ValueError, match="requires example_outputs"):
+        m(torch.empty(0, 3))
+
+    assert calls["count"] == 0
+
+
+def test_torch_backend_empty_sequence_rejects_example_input_template():
+    calls = {"count": 0}
+
+    def core(x, v):
+        calls["count"] += 1
+        return x.new_zeros(5), v
+
+    m = FlexSN(
+        core=core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+        example_inputs=(torch.zeros(4), torch.zeros(3)),
+    )
+    m.states = [torch.zeros(3)]
+
+    with pytest.raises(ValueError, match="requires example_outputs"):
+        m.multi_step_forward(torch.empty(0, 4))
+
+    assert calls["count"] == 0
+
+
+def test_torch_backend_empty_state_only_sequence_does_not_require_output_template():
+    calls = {"count": 0}
+
+    def core(x, v):
+        calls["count"] += 1
+        raise AssertionError("core should not run for an empty multi-step input")
+
+    m = FlexSN(
+        core=core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=0,
+        step_mode="m",
+        backend="torch",
+    )
+    m.states = [torch.zeros(3)]
+
+    outputs = m.multi_step_forward(torch.empty(0, 3))
+
+    assert calls["count"] == 0
+    assert outputs == []
+    torch.testing.assert_close(m.states[0], torch.zeros(3))
+
+
+def test_torch_backend_empty_sequence_uses_example_output_template_without_core_probe():
+    calls = {"count": 0}
+
+    def core(x, v):
+        calls["count"] += 1
+        raise AssertionError("core should not run for an empty multi-step input")
+
+    m = FlexSN(
+        core=core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+        example_inputs=(torch.zeros(2), torch.zeros(3)),
+        example_outputs=(torch.zeros(4, dtype=torch.float64),),
+    )
+    assert calls["count"] == 0
+    m.states = [torch.zeros(3)]
+
+    out = m.multi_step_forward(torch.empty(0, 2))[0]
+
+    assert calls["count"] == 0
+    assert out.shape == (0, 4)
+    assert out.dtype == torch.float64
+
+
+def test_flexsn_rejects_invalid_example_output_template():
+    with pytest.raises(ValueError, match="expected 1 example output tensors"):
+        FlexSN(
+            core=_lif_core,
+            num_inputs=1,
+            num_states=1,
+            num_outputs=1,
+            step_mode="m",
+            backend="torch",
+            example_outputs=(),
+        )
+
+
+def test_scan_backends_reject_mismatched_example_output_template():
+    with pytest.raises(ValueError, match="example_outputs"):
+        FlexSN(
+            core=_lif_core,
+            num_inputs=1,
+            num_states=1,
+            num_outputs=1,
+            step_mode="m",
+            backend="inductor",
+            example_inputs=(torch.zeros(3), torch.zeros(3)),
+            example_outputs=(torch.zeros(4),),
+        )
+
+
+def test_output_template_specs_from_outputs_preserve_device():
+    output = torch.zeros(4, dtype=torch.float64)
+
+    specs = flexsn_module._make_output_template_specs_from_outputs(1, (output,))
+
+    assert specs == (((4,), torch.float64, output.device),)
+
+
+def test_empty_multistep_outputs_honor_template_device():
+    specs = (((4,), torch.float64, torch.device("meta")),)
+
+    outputs = flexsn_module._empty_multistep_outputs((torch.empty(0, 3),), [], 1, specs)
+
+    assert outputs[0].shape == (0, 4)
+    assert outputs[0].dtype == torch.float64
+    assert outputs[0].device.type == "meta"
+
+
+def test_flexsn_empty_multistep_outputs_follow_runtime_device():
+    def core(x, v):
+        raise AssertionError("core should not run for an empty multi-step input")
+
+    m = FlexSN(
+        core=core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+        example_outputs=(torch.empty(4, device="meta"),),
+    )
+    m.states = [torch.zeros(3)]
+
+    out = m.multi_step_forward(torch.empty(0, 2))[0]
+
+    assert out.shape == (0, 4)
+    assert out.device.type == "cpu"
+
+
+def test_empty_multistep_outputs_rejects_missing_template_reference():
+    with pytest.raises(ValueError, match="at least one input or state"):
+        flexsn_module._empty_multistep_outputs((), [], 1)
+
+
+def test_multi_step_forward_initializes_states_for_torch_backend():
+    m = FlexSN(
+        core=_lif_core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+    )
+
+    out = m.multi_step_forward(torch.randn(2, 3))[0]
+
+    assert out.shape == (2, 3)
+    assert m.states is not None
+    assert m.states[0].shape == (3,)
+
+
+def test_multi_step_forward_initializes_states_for_hop_backend():
+    m = FlexSN(
+        core=_lif_core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="hop",
+    )
+
+    out = m.multi_step_forward(torch.randn(2, 3))[0]
+
+    assert out.shape == (2, 3)
+    assert m.states is not None
+    assert m.states[0].shape == (3,)
+
+
+def test_multi_step_forward_initializes_states_for_triton_backend(monkeypatch):
+    class FakeKernel:
+        def __call__(self, x_seq, v):
+            assert v.shape == x_seq.shape[1:]
+            return x_seq.new_zeros(x_seq.shape), x_seq.new_zeros(x_seq.shape)
+
+    m = FlexSN(
+        core=_lif_core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+    )
+    monkeypatch.setattr(base_module, "triton", object())
+    m.backend = "triton"
+    m.kernel = FakeKernel()
+
+    out = m.multi_step_forward(torch.randn(2, 3))[0]
+
+    assert out.shape == (2, 3)
+    assert m.states is not None
+    assert m.states[0].shape == (3,)
+
+
+def test_multi_step_forward_initializes_states_for_inductor_training_fallback():
+    m = FlexSN(
+        core=_lif_core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="inductor",
+    )
+
+    out = m.multi_step_forward(torch.randn(2, 3, requires_grad=True))[0]
+
+    assert out.shape == (2, 3)
+    assert m.states is not None
+    assert m.states[0].shape == (3,)
+
+
+def test_core_requires_grad_detects_functor_tensor_attributes():
+    class Core:
+        def __init__(self, weight):
+            self.weight = weight
+
+        def __call__(self, x, v):
+            return x * self.weight, v
+
+    assert flexsn_module._core_requires_grad(Core(torch.ones(3, requires_grad=True)))
+    assert not flexsn_module._core_requires_grad(
+        Core(torch.ones(3, requires_grad=False))
+    )
+
+
+def test_core_requires_grad_detects_bound_method_self_parameters():
+    class Core(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.ones(3))
+
+        def forward(self, x, v):
+            return x * self.weight, v
+
+    assert flexsn_module._core_requires_grad(Core().forward)
+
+
+def test_core_requires_grad_detects_module_unregistered_tensors():
+    class Core(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.ones(3, requires_grad=True)
+
+        def forward(self, x, v):
+            return x * self.weight, v
+
+    assert flexsn_module._core_requires_grad(Core().forward)
+
+
+def test_core_requires_grad_detects_plain_bound_method_self_tensors():
+    class Core:
+        def __init__(self):
+            self.weight = torch.ones(3, requires_grad=True)
+
+        def forward(self, x, v):
+            return x * self.weight, v
+
+    assert flexsn_module._core_requires_grad(Core().forward)
+
+
+def test_flexsn_wrapper_final_states_use_init_state_templates():
+    from spikingjelly.activation_based.triton_kernel.flexsn.wrapper import (
+        flexsn_inference_final_state,
+        _num_elements_per_step,
+    )
+
+    info = SimpleNamespace(num_inputs=1, num_states=1, num_outputs=1)
+    x = torch.empty(0, 2)
+    state = torch.ones(3, dtype=torch.float64)
+
+    assert _num_elements_per_step(x) == 2
+
+    out, final_state = flexsn_inference_final_state(None, info, x, state)
+
+    assert out.shape == (0, 2)
+    assert final_state.shape == (3,)
+    assert final_state.dtype == torch.float64
+    assert final_state.data_ptr() != state.data_ptr()
+    torch.testing.assert_close(final_state, state)
+
+
+def test_codegen_stem_sanitizes_cache_filenames():
+    assert graph2triton_module._safe_codegen_stem("../escape") == "escape"
+    assert graph2triton_module._safe_codegen_stem("/tmp/absolute") == "absolute"
+    assert graph2triton_module._safe_codegen_stem("bad/name?x") == "name_x"
+    assert graph2triton_module._safe_codegen_stem("..") == "kernel"
+    assert "__path__" in graph2triton_module._NAMESPACE_METADATA_KEYS
+
+
+def test_compile_triton_code_str_rejects_stale_namespace_symbol(
+    tmp_path, monkeypatch
+):
+    stale = object()
+    namespace = {"missing_kernel": stale}
+
+    monkeypatch.setattr(graph2triton_module, "_CODEGEN_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(graph2triton_module, "_has_real_triton_runtime", lambda: True)
+
+    with pytest.raises(ValueError, match="missing_kernel"):
+        graph2triton_module.compile_triton_code_str(
+            "other_symbol = 1\n",
+            "missing_kernel",
+            name_space=namespace,
+        )
+
+    assert namespace["missing_kernel"] is stale
+
+
+def test_flexsn_wrapper_t0_final_states_preserve_num_states_without_init():
+    from spikingjelly.activation_based.triton_kernel.flexsn.wrapper import (
+        flexsn_inference_final_state,
+    )
+
+    info = SimpleNamespace(num_inputs=1, num_states=2, num_outputs=1)
+    x = torch.empty(0, 3)
+
+    out, state0, state1 = flexsn_inference_final_state(None, info, x)
+
+    assert out.shape == (0, 3)
+    assert state0.shape == (3,)
+    assert state1.shape == (3,)
+    torch.testing.assert_close(state0, torch.zeros_like(state0))
+    torch.testing.assert_close(state1, torch.zeros_like(state1))
+
+
+def test_flexsn_wrappers_skip_kernel_launch_for_t0():
+    from spikingjelly.activation_based.triton_kernel.flexsn import wrapper
+
+    class _RaisingKernel:
+        def __getitem__(self, grid):
+            raise AssertionError("T == 0 wrappers should not launch Triton")
+
+    x = torch.empty(0, 3)
+    info = SimpleNamespace(
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        num_fwd_kernel_returns=2,
+    )
+
+    inference_outputs = wrapper.flexsn_inference(_RaisingKernel(), info, x)
+    forward_outputs = wrapper.flexsn_forward(_RaisingKernel(), info, x)
+    backward_outputs = wrapper.flexsn_backward(_RaisingKernel(), info, x)
+
+    assert [tuple(t.shape) for t in inference_outputs] == [(0, 3), (0, 3)]
+    assert [tuple(t.shape) for t in forward_outputs] == [(0, 3), (0, 3)]
+    assert [tuple(t.shape) for t in backward_outputs] == [(0, 3), (3,)]
+    torch.testing.assert_close(backward_outputs[0], torch.zeros_like(x))
+    torch.testing.assert_close(
+        backward_outputs[1],
+        torch.zeros_like(backward_outputs[1]),
+    )
+
+
+def test_flexsn_wrapper_t0_backward_state_grads_use_state_templates(monkeypatch):
+    from spikingjelly.activation_based.triton_kernel.flexsn import wrapper
+
+    class _FakeKernel:
+        def __getitem__(self, grid):
+            def _run(*args, **kwargs):
+                return None
+
+            return _run
+
+    info = SimpleNamespace(num_inputs=1, num_states=2, num_outputs=1)
+    grad_y = torch.empty(0, 2)
+    grad_s0 = torch.empty(0, 3)
+    grad_s1 = torch.empty(0, 4, dtype=torch.float64)
+
+    monkeypatch.setitem(wrapper.type_dict, grad_y.dtype, "float32")
+
+    grad_x, grad_v0, grad_v1 = wrapper.flexsn_backward(
+        _FakeKernel(),
+        info,
+        grad_y,
+        grad_s0,
+        grad_s1,
+    )
+
+    assert grad_x.shape == (0, 2)
+    assert grad_v0.shape == (3,)
+    assert grad_v1.shape == (4,)
+    assert grad_v1.dtype == torch.float64
+    torch.testing.assert_close(grad_v0, torch.zeros_like(grad_v0))
+    torch.testing.assert_close(grad_v1, torch.zeros_like(grad_v1))
+
+
+def test_inductor_final_state_warmup_args_use_example_shapes():
+    info = SimpleNamespace(num_inputs=2, num_states=2)
+    specs = (
+        ((3, 4), torch.float32),
+        ((5,), torch.float64),
+        ((3, 4), torch.float32),
+        ((2, 3), torch.float64),
+    )
+
+    warm_args = _make_inductor_final_state_warmup_args(
+        info,
+        torch.device("cpu"),
+        specs,
+    )
+
+    assert [tuple(arg.shape) for arg in warm_args] == [
+        (1, 3, 4),
+        (1, 5),
+        (3, 4),
+        (2, 3),
+    ]
+    assert [arg.dtype for arg in warm_args] == [
+        torch.float32,
+        torch.float64,
+        torch.float32,
+        torch.float64,
+    ]
+
+
+def test_inductor_final_state_wrapper_t0_returns_non_aliased_states():
+    from spikingjelly.activation_based.triton_kernel.flexsn.wrapper import (
+        flexsn_inference_final_state,
+    )
+
+    info = SimpleNamespace(num_inputs=1, num_outputs=1, num_states=1)
+    x = torch.randn(0, 3)
+    v = torch.randn(3)
+
+    y_seq, v_final = flexsn_inference_final_state(None, info, x, v)
+
+    assert tuple(y_seq.shape) == (0, 3)
+    torch.testing.assert_close(v_final, v)
+    assert v_final.data_ptr() != v.data_ptr()
+
+
+def test_inductor_training_final_state_impl_t0_returns_non_aliased_states(
+    monkeypatch,
+):
+    from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
+        custom_ops,
+    )
+
+    info = SimpleNamespace(
+        num_inputs=1,
+        num_outputs=1,
+        num_states=1,
+        c2k_return_mapping=[],
+    )
+    bundle = SimpleNamespace(training_info=info)
+    x = torch.randn(0, 3)
+    v = torch.randn(3)
+    full_returns = [x.new_empty(x.shape), x.new_empty((0, *v.shape))]
+
+    def fake_training_impl(bundle_arg, flat_args):
+        assert bundle_arg is bundle
+        assert len(flat_args) == 2
+        assert flat_args[0] is x
+        assert flat_args[1] is v
+        return full_returns
+
+    monkeypatch.setattr(
+        custom_ops,
+        "_flexsn_inductor_training_impl",
+        fake_training_impl,
+    )
+
+    y_seq, v_final = custom_ops._flexsn_inductor_training_final_state_impl(
+        bundle,
+        [x, v],
+    )
+
+    assert tuple(y_seq.shape) == (0, 3)
+    torch.testing.assert_close(v_final, v)
+    assert v_final.data_ptr() != v.data_ptr()
+
+
+def test_inductor_fake_final_state_templates_use_explicit_states():
+    from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
+        custom_ops,
+    )
+
+    info = SimpleNamespace(num_inputs=1, num_states=2)
+    x = torch.randn(4, 3, dtype=torch.float32)
+    state_a = torch.randn(5, dtype=torch.float64)
+    state_b = torch.empty(2, 3, dtype=torch.float16)
+
+    templates = custom_ops._make_state_templates_like(info, [x, state_a, state_b])
+
+    assert [tuple(template.shape) for template in templates] == [(5,), (2, 3)]
+    assert [template.dtype for template in templates] == [
+        torch.float64,
+        torch.float16,
+    ]
+
+
+def test_inductor_training_final_state_backward_pads_missing_grads(monkeypatch):
+    from spikingjelly.activation_based.triton_kernel.flex_sn_inductor import (
+        custom_ops,
+    )
+
+    x = torch.randn(2, 3)
+    v = torch.randn(3)
+    y = torch.randn(2, 3)
+    bundle = SimpleNamespace(
+        backward_kernel=object(),
+        training_info=SimpleNamespace(num_inputs=1, num_outputs=1, num_states=1),
+    )
+    ctx = SimpleNamespace(
+        handle=1,
+        input_template_specs=[
+            (tuple(x.shape), x.dtype, x.device),
+            (tuple(v.shape), v.dtype, v.device),
+        ],
+        output_template_specs=[(tuple(y.shape), y.dtype, y.device)],
+        state_seq_template_specs=[((x.shape[0], *v.shape), v.dtype, v.device)],
+        saved_tensors=[],
+        _active_ref_finalizer=SimpleNamespace(
+            alive=False,
+            detach=lambda: None,
+        ),
+    )
+    seen = {}
+
+    def fake_backward(handle, grad_inputs, saved_tensors, input_templates):
+        seen["grad_inputs"] = grad_inputs
+        assert handle == ctx.handle
+        assert saved_tensors == []
+        return [torch.zeros_like(x), torch.zeros_like(v)]
+
+    monkeypatch.setattr(custom_ops, "_lookup_kernel_handle", lambda handle: bundle)
+    monkeypatch.setattr(custom_ops, "flexsn_inductor_backward", fake_backward)
+    monkeypatch.setattr(
+        custom_ops,
+        "release_active_flexsn_kernel_handle",
+        lambda handle: None,
+    )
+
+    _, grads = custom_ops._flexsn_training_final_state_backward(ctx, [])
+
+    assert len(seen["grad_inputs"]) == 2
+    torch.testing.assert_close(seen["grad_inputs"][0], torch.zeros_like(y))
+    torch.testing.assert_close(
+        seen["grad_inputs"][1], torch.zeros((x.shape[0], *v.shape))
+    )
+    torch.testing.assert_close(grads[0], torch.zeros_like(x))
+    torch.testing.assert_close(grads[1], torch.zeros_like(v))
 
 
 @pytest.mark.parametrize("T", [1, 4, 16])
@@ -97,41 +730,6 @@ def test_hop_matches_manual_loop_with_lifted_tensor(rng):
 
     torch.testing.assert_close(s_seq, torch.stack(expected_s, dim=0))
     torch.testing.assert_close(v_seq, torch.stack(expected_v, dim=0))
-
-
-def test_hop_rejects_empty_input_sequence():
-    x = torch.empty(0, 8)
-    v0 = torch.zeros(8)
-
-    with pytest.raises(ValueError, match="T == 0"):
-        flex_sn_scan(_lif_core, 1, 1, 1, x, v0)
-
-    with pytest.raises(ValueError, match="T == 0"):
-        flexsn_hop.eager_scan_final_state(_lif_core, 1, 1, 1, x, v0)
-
-
-def test_kernel_names_include_graph_fingerprint():
-    def core_a(x):
-        return x + 1
-
-    def core_b(x):
-        return x * 2
-
-    example = torch.randn(4)
-    graph_a = make_fx(core_a)(example).graph
-    graph_b = make_fx(core_b)(example).graph
-
-    name_a = flexsn_inductor_kernel._make_core_name(
-        core_a, "inductor_scan", graph_a
-    )
-    name_b = flexsn_inductor_kernel._make_core_name(
-        core_b, "inductor_scan", graph_b
-    )
-
-    assert name_a != name_b
-    assert name_a == flexsn_inductor_kernel._make_core_name(
-        core_a, "inductor_scan", graph_a
-    )
 
 
 @pytest.mark.parametrize("T", [1, 4, 16])
@@ -184,6 +782,7 @@ def test_hop_backend_matches_torch_backend(rng, T, shape):
         num_outputs=1,
         step_mode="m",
         backend="hop",
+        store_state_seqs=True,
         example_inputs=(torch.zeros(shape), torch.zeros(shape)),
     )
 
@@ -218,6 +817,7 @@ def test_hop_backend_matches_torch_backend_with_closure(rng):
         num_outputs=1,
         step_mode="m",
         backend="hop",
+        store_state_seqs=True,
         example_inputs=(torch.zeros(N), torch.zeros(N)),
     )
 
@@ -250,220 +850,6 @@ def test_inductor_backend_store_state_seqs(rng):
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
-@pytest.mark.parametrize("store_state_seqs", [False, True])
-def test_inductor_backend_segmented_inference_matches_unsegmented(
-    rng, monkeypatch, store_state_seqs
-):
-    T, N = 9, 16
-    x = torch.randn((T, N), generator=rng).cuda()
-
-    reference = FlexSN(
-        core=_lif_core, num_inputs=1, num_states=1, num_outputs=1,
-        step_mode="m", backend="inductor", store_state_seqs=store_state_seqs,
-    ).cuda()
-    segmented = FlexSN(
-        core=_lif_core, num_inputs=1, num_states=1, num_outputs=1,
-        step_mode="m", backend="inductor", store_state_seqs=store_state_seqs,
-    ).cuda()
-
-    with torch.no_grad():
-        ref_out = reference(x)
-        monkeypatch.setenv("SJ_FLEXSN_INDUCTOR_SEGMENT_T", "4")
-        seg_out = segmented(x)
-
-    torch.testing.assert_close(seg_out, ref_out)
-    torch.testing.assert_close(segmented.states[0], reference.states[0])
-    if store_state_seqs:
-        torch.testing.assert_close(segmented.state_seqs[0], reference.state_seqs[0])
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
-def test_inductor_training_final_state_matches_full_training(rng):
-    T, N = 8, 16
-    x_ref = torch.randn((T, N), generator=rng, device="cpu").cuda().requires_grad_(True)
-    x_opt = x_ref.detach().clone().requires_grad_(True)
-
-    reference = FlexSN(
-        core=_stateful_tanh_core,
-        num_inputs=1,
-        num_states=1,
-        num_outputs=1,
-        step_mode="m",
-        backend="inductor",
-        store_state_seqs=True,
-    ).cuda()
-    optimized = FlexSN(
-        core=_stateful_tanh_core,
-        num_inputs=1,
-        num_states=1,
-        num_outputs=1,
-        step_mode="m",
-        backend="inductor",
-        store_state_seqs=False,
-    ).cuda()
-
-    ref_out = reference(x_ref)
-    opt_out = optimized(x_opt)
-
-    torch.testing.assert_close(opt_out, ref_out)
-    torch.testing.assert_close(optimized.states[0], reference.states[0])
-
-    ref_loss = ref_out.sum() + reference.states[0].sum()
-    opt_loss = opt_out.sum() + optimized.states[0].sum()
-    ref_loss.backward()
-    opt_loss.backward()
-
-    torch.testing.assert_close(x_opt.grad, x_ref.grad)
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
-def test_inductor_training_final_state_kernel_only_builds_when_it_reduces_saved_sequences():
-    lif_neuron = FlexSN(
-        core=_lif_core,
-        num_inputs=1,
-        num_states=1,
-        num_outputs=1,
-        step_mode="m",
-        backend="inductor",
-    ).cuda()
-    tanh_neuron = FlexSN(
-        core=_stateful_tanh_core,
-        num_inputs=1,
-        num_states=1,
-        num_outputs=1,
-        step_mode="m",
-        backend="inductor",
-    ).cuda()
-
-    assert lif_neuron._inductor_fwd_final_state_kernel is not None
-    assert tanh_neuron._inductor_fwd_final_state_kernel is None
-
-
-def _stateless_passthrough_core(x: torch.Tensor, v: torch.Tensor):
-    return x, x
-
-
-@pytest.mark.parametrize("backend", ["inductor", "hop"])
-def test_scan_backends_reject_mismatched_example_state_shape(backend):
-    with pytest.raises(ValueError, match="example input/state tensor"):
-        FlexSN(
-            core=_stateless_passthrough_core,
-            num_inputs=1,
-            num_states=1,
-            num_outputs=1,
-            step_mode="m",
-            backend=backend,
-            example_inputs=(torch.zeros(8), torch.zeros(4)),
-        )
-
-
-def test_inductor_zero_state_materialization_uses_registered_state_specs():
-    info = FlexSNInfo(
-        num_inputs=1,
-        num_outputs=1,
-        num_states=1,
-        fwd_core_args=[],
-        fwd_core_returns=[],
-        fwd_core_recipients=[],
-        fwd_kernel_returns=[],
-        num_fwd_kernel_returns=0,
-        c2k_return_mapping=[],
-    )
-    bundle = flexsn_custom_ops.FlexSNKernelHandle(
-        inference_kernel=None,
-        inference_info=info,
-        inference_final_state_kernel=None,
-        inference_final_state_info=None,
-        forward_kernel=None,
-        forward_final_state_kernel=None,
-        backward_kernel=None,
-        backward_final_state_kernel=None,
-        training_info=None,
-        state_template_specs=(((3, 5), torch.float32, torch.device("cpu")),),
-    )
-    x_seq = torch.randn(4, 8, dtype=torch.float16)
-
-    materialized = flexsn_custom_ops._materialize_zero_state_args(bundle, info, [x_seq])
-
-    assert len(materialized) == 2
-    assert materialized[1].shape == (3, 5)
-    assert materialized[1].dtype == torch.float32
-    assert materialized[1].device.type == "cpu"
-    torch.testing.assert_close(materialized[1], torch.zeros(3, 5))
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
-def test_inductor_zero_state_materialization_overrides_registered_device_at_runtime():
-    info = FlexSNInfo(
-        num_inputs=1,
-        num_outputs=1,
-        num_states=1,
-        fwd_core_args=[],
-        fwd_core_returns=[],
-        fwd_core_recipients=[],
-        fwd_kernel_returns=[],
-        num_fwd_kernel_returns=0,
-        c2k_return_mapping=[],
-    )
-    bundle = flexsn_custom_ops.FlexSNKernelHandle(
-        inference_kernel=None,
-        inference_info=info,
-        inference_final_state_kernel=None,
-        inference_final_state_info=None,
-        forward_kernel=None,
-        forward_final_state_kernel=None,
-        backward_kernel=None,
-        backward_final_state_kernel=None,
-        training_info=None,
-        state_template_specs=(((3, 5), torch.float32, torch.device("cpu")),),
-    )
-    device = (
-        torch.device("cuda", 1)
-        if torch.cuda.device_count() > 1
-        else torch.device("cuda")
-    )
-    x_seq = torch.randn(4, 8, dtype=torch.float16, device=device)
-
-    materialized = flexsn_custom_ops._materialize_zero_state_args(bundle, info, [x_seq])
-
-    assert len(materialized) == 2
-    assert materialized[1].shape == (3, 5)
-    assert materialized[1].dtype == torch.float32
-    assert materialized[1].device == x_seq.device
-    torch.testing.assert_close(materialized[1], torch.zeros(3, 5, device=x_seq.device))
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
-def test_inductor_backward_final_state_kernel_handles_small_t_large_token_workloads():
-    small_t_large_tokens = torch.randn((4, 8, 224, 224), device="cuda")
-    small_t_medium_tokens = torch.randn((4, 32, 3, 32, 32), device="cuda")
-    small_t_small_tokens = torch.randn((4, 16, 64), device="cuda")
-
-    assert flexsn_custom_ops._should_use_backward_final_state_kernel(
-        [small_t_large_tokens]
-    )
-    assert flexsn_custom_ops._should_use_backward_final_state_kernel(
-        [small_t_medium_tokens]
-    )
-    assert not flexsn_custom_ops._should_use_backward_final_state_kernel(
-        [small_t_small_tokens]
-    )
-
-
-def test_flexsn_backward_ncl_bucket_boundaries():
-    assert flexsn_backward_ncl_bucket(512) == 0
-    assert flexsn_backward_ncl_bucket(1 << 12) == 0
-    assert flexsn_backward_ncl_bucket((1 << 12) + 1) == 1
-    assert flexsn_backward_ncl_bucket(1 << 17) == 1
-    assert flexsn_backward_ncl_bucket((1 << 17) + 1) == 2
-    assert flexsn_backward_ncl_bucket(1 << 20) == 2
-    assert flexsn_backward_ncl_bucket((1 << 20) + 1) == 3
-    assert flexsn_backward_ncl_bucket(1 << 23) == 3
-    assert flexsn_backward_ncl_bucket((1 << 23) + 1) == 4
-
-
-
 def test_inductor_backend_skips_flex_sn_kernel_construction():
     neuron = FlexSN(
         core=_lif_core, num_inputs=1, num_states=1, num_outputs=1,
@@ -483,19 +869,10 @@ def test_inductor_backend_in_supported_backends():
 def test_hop_rejects_wrong_arity():
     x = torch.randn(4, 8)
     v0 = torch.zeros(8)
+    extra = torch.zeros(8)
 
-    with pytest.raises(ValueError, match="expected at least 2 tensor args"):
-        flex_sn_scan(_lif_core, 1, 1, 1, x)
-
-
-def test_hop_accepts_single_tensor_return(rng):
-    x = torch.randn(4, 8, generator=rng)
-
-    def stateless_core(x_step):
-        return x_step.sin()
-
-    (y_seq,) = flex_sn_scan(stateless_core, 1, 0, 1, x)
-    torch.testing.assert_close(y_seq, x.sin())
+    with pytest.raises(ValueError, match="expected 2 tensor args"):
+        flex_sn_scan(_lif_core, 1, 1, 1, x, v0, extra)
 
 
 def test_hop_rejects_mismatched_T():
@@ -510,95 +887,131 @@ def test_hop_rejects_mismatched_T():
         flex_sn_scan(two_input_core, 2, 1, 1, x1, x2, v0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
-def test_inductor_inference_without_final_state_kernel_keeps_final_state_semantics(rng):
-    x = torch.randn((6, 16), generator=rng).cuda()
-    reference = FlexSN(
-        core=_lif_core,
-        num_inputs=1,
-        num_states=1,
-        num_outputs=1,
-        step_mode="m",
-        backend="inductor",
-        store_state_seqs=False,
-    ).cuda()
-    fallback = FlexSN(
-        core=_lif_core,
-        num_inputs=1,
-        num_states=1,
-        num_outputs=1,
-        step_mode="m",
-        backend="inductor",
-        store_state_seqs=False,
-    ).cuda()
-    if not reference._inductor_inference_available:
-        pytest.skip("inductor inference kernel unavailable")
-
-    with torch.no_grad():
-        expected = reference(x)
-        expected_state = reference.states[0].detach().clone()
-        fallback._inductor_scan_final_state_kernel = None
-        fallback._inductor_scan_final_state_info = None
-        fallback._inductor_inference_final_state_available = False
-        actual = fallback(x)
-        actual_state = fallback.states[0].detach().clone()
-
-    torch.testing.assert_close(actual, expected)
-    torch.testing.assert_close(actual_state, expected_state)
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
-def test_inductor_stateless_final_state_kernel_builds():
-    def stateless_core(x):
-        return (x,)
-
-    neuron = FlexSN(
-        core=stateless_core,
-        num_inputs=1,
-        num_states=0,
-        num_outputs=1,
-        step_mode="m",
-        backend="inductor",
-        store_state_seqs=False,
-        example_inputs=(torch.zeros(8, device="cuda"),),
-    ).cuda()
-
-    assert neuron._inductor_inference_available
-    assert neuron._inductor_inference_final_state_available
-
-
-def test_backward_final_state_kernel_threshold_knobs_do_not_force_specialization(monkeypatch):
-    monkeypatch.setattr(
-        flexsn_custom_ops,
-        "_BACKWARD_FINAL_STATE_SPECIALIZED_MIN_STEPS",
-        0,
-    )
-    monkeypatch.setattr(
-        flexsn_custom_ops,
-        "_BACKWARD_FINAL_STATE_SPECIALIZED_MIN_TOKENS",
-        1024,
-    )
-    grad = torch.randn(4, 8)
-    assert not flexsn_custom_ops._should_use_backward_final_state_kernel([grad])
-
-    monkeypatch.setattr(
-        flexsn_custom_ops,
-        "_BACKWARD_FINAL_STATE_SPECIALIZED_MIN_STEPS",
-        1024,
-    )
-    monkeypatch.setattr(
-        flexsn_custom_ops,
-        "_BACKWARD_FINAL_STATE_SPECIALIZED_MIN_TOKENS",
-        0,
-    )
-    assert not flexsn_custom_ops._should_use_backward_final_state_kernel([grad])
-
-
 def test_hop_registers_with_dynamo():
-    from torch._dynamo.variables.higher_order_ops import TorchHigherOrderOperatorVariable
+    try:
+        from torch._dynamo.variables.higher_order_ops import (
+            TorchHigherOrderOperatorVariable,
+        )
+    except (ImportError, ModuleNotFoundError, AttributeError):
+        pytest.skip("torch._dynamo higher-order-op internals are unavailable")
 
     hop_var = TorchHigherOrderOperatorVariable.make(flex_sn_scan)
     assert hop_var.value is flex_sn_scan
+
+
+def test_dynamo_body_result_templates_use_speculated_outputs():
+    class _FakeVar:
+        def __init__(self, example_value):
+            self._proxy = SimpleNamespace(
+                node=SimpleNamespace(meta={"example_value": example_value})
+            )
+
+        def as_proxy(self):
+            return self._proxy
+
+    class _FakeTupleVariable:
+        def __init__(self, items):
+            self.items = items
+
+    body_result = _FakeTupleVariable(
+        [
+            _FakeVar(torch.empty(2, dtype=torch.float64)),
+            _FakeVar(torch.empty(3, dtype=torch.float16)),
+            _FakeVar(torch.empty(4, dtype=torch.float32)),
+        ]
+    )
+
+    specs = hop_module._output_template_specs_from_dynamo_body_result(
+        body_result,
+        num_outputs=2,
+    )
+
+    assert specs == (
+        ((2,), torch.float64, torch.device("cpu")),
+        ((3,), torch.float16, torch.device("cpu")),
+    )
+
+
+def test_run_hop_scan_compiled_falls_back_when_dynamo_hop_unavailable(monkeypatch):
+    x = torch.randn(2, 3)
+    v = torch.zeros(3)
+
+    def fake_hop(*args):
+        return ("hop",)
+
+    def fake_eager(*args):
+        return ("eager",)
+
+    monkeypatch.setattr(flexsn_module, "_is_compiling", lambda: True)
+    monkeypatch.setattr(flexsn_module, "_flexsn_lowerable_scan", None)
+    monkeypatch.setattr(flexsn_module, "_flexsn_lowerable_while_loop_scan", None)
+    monkeypatch.setattr(flexsn_module, "_flexsn_hop_scan", fake_hop)
+    monkeypatch.setattr(flexsn_module, "_flexsn_eager_scan", fake_eager)
+    monkeypatch.setattr(flexsn_module, "_flexsn_dynamo_hop_available", lambda: False)
+
+    result = flexsn_module._run_hop_scan(None, 1, 1, 1, True, x, v)
+    assert result == ("eager",)
+
+    monkeypatch.setattr(flexsn_module, "_flexsn_dynamo_hop_available", lambda: True)
+    result = flexsn_module._run_hop_scan(None, 1, 1, 1, True, x, v)
+    assert result == ("hop",)
+
+
+def test_run_hop_scan_forwards_output_template_specs(monkeypatch):
+    x = torch.empty(0, 2)
+    v = torch.zeros(3)
+    specs = (((4,), torch.float64, torch.device("cpu")),)
+    captured = {}
+
+    def fake_eager(*args, output_template_specs=None):
+        captured["output_template_specs"] = output_template_specs
+        return ("eager",)
+
+    monkeypatch.setattr(flexsn_module, "_is_compiling", lambda: False)
+    monkeypatch.setattr(flexsn_module, "_flexsn_hop_scan", None)
+    monkeypatch.setattr(flexsn_module, "_flexsn_eager_scan", fake_eager)
+
+    result = flexsn_module._run_hop_scan(
+        None,
+        1,
+        1,
+        1,
+        True,
+        x,
+        v,
+        output_template_specs=specs,
+    )
+
+    assert result == ("eager",)
+    assert captured["output_template_specs"] is specs
+
+
+def test_run_hop_scan_forwards_output_template_specs_to_hop(monkeypatch):
+    x = torch.empty(0, 2)
+    v = torch.zeros(3)
+    specs = (((4,), torch.float64, torch.device("cpu")),)
+    captured = {}
+
+    def fake_hop(*args, output_template_specs=None):
+        captured["output_template_specs"] = output_template_specs
+        return ("hop",)
+
+    monkeypatch.setattr(flexsn_module, "_is_compiling", lambda: False)
+    monkeypatch.setattr(flexsn_module, "_flexsn_hop_scan", fake_hop)
+
+    result = flexsn_module._run_hop_scan(
+        None,
+        1,
+        1,
+        1,
+        True,
+        x,
+        v,
+        output_template_specs=specs,
+    )
+
+    assert result == ("hop",)
+    assert captured["output_template_specs"] is specs
 
 
 def test_lowerable_scan_matches_manual_loop(rng):
@@ -621,6 +1034,134 @@ def test_lowerable_scan_matches_manual_loop(rng):
 
     torch.testing.assert_close(s_seq, torch.stack(expected_s, dim=0))
     torch.testing.assert_close(v_seq, torch.stack(expected_v, dim=0))
+
+
+def test_lowerable_scan_return_order_with_unequal_outputs_and_states():
+    if not callable(lowerable_scan_available) or not lowerable_scan_available():
+        pytest.skip("PyTorch scan HOP is unavailable in this environment")
+
+    def core(x, v):
+        next_v = v + x
+        return x, x + 1, next_v
+
+    x = torch.arange(6, dtype=torch.float32).reshape(3, 2)
+    v0 = torch.zeros(2)
+
+    y0_seq, y1_seq, v_seq = lowerable_scan(core, 1, 1, 2, x, v0)
+    y0_final, y1_final, v_final = lowerable_scan_final_state(core, 1, 1, 2, x, v0)
+
+    torch.testing.assert_close(y0_seq, x)
+    torch.testing.assert_close(y1_seq, x + 1)
+    torch.testing.assert_close(v_seq, x.cumsum(dim=0))
+    torch.testing.assert_close(y0_final, x)
+    torch.testing.assert_close(y1_final, x + 1)
+    torch.testing.assert_close(v_final, x.sum(dim=0))
+
+
+def test_lowerable_scan_empty_sequence_returns_templates_without_scan_op():
+    if not callable(lowerable_scan_available) or not lowerable_scan_available():
+        pytest.skip("PyTorch scan HOP is unavailable in this environment")
+
+    calls = {"count": 0}
+
+    def core(x, v):
+        calls["count"] += 1
+        raise AssertionError("core should not run for an empty lowerable scan")
+
+    x = torch.empty(0, 2)
+    v0 = torch.zeros(3)
+    specs = (((4,), torch.float64),)
+
+    y_seq, v_seq = lowerable_scan(
+        core, 1, 1, 1, x, v0, output_template_specs=specs
+    )
+    y_final, v_final = lowerable_scan_final_state(
+        core, 1, 1, 1, x, v0, output_template_specs=specs
+    )
+
+    assert calls["count"] == 0
+    assert y_seq.shape == (0, 4)
+    assert y_seq.dtype == torch.float64
+    assert v_seq.shape == (0, 3)
+    assert y_final.shape == (0, 4)
+    assert y_final.dtype == torch.float64
+    torch.testing.assert_close(v_final, v0)
+    assert v_final is not v0
+
+
+def test_eager_scan_empty_sequence_uses_template_without_core_call():
+    calls = {"count": 0}
+
+    def core(x, v):
+        calls["count"] += 1
+        raise AssertionError("core should not run for an empty eager scan")
+
+    x = torch.empty(0, 2)
+    v0 = torch.zeros(3)
+    specs = (((4,), torch.float64),)
+
+    y_seq, v_seq = eager_scan(core, 1, 1, 1, x, v0, output_template_specs=specs)
+    y_final, v_final = eager_scan_final_state(
+        core, 1, 1, 1, x, v0, output_template_specs=specs
+    )
+
+    assert calls["count"] == 0
+    assert y_seq.shape == (0, 4)
+    assert y_seq.dtype == torch.float64
+    assert v_seq.shape == (0, 3)
+    assert y_final.shape == (0, 4)
+    assert y_final.dtype == torch.float64
+    torch.testing.assert_close(v_final, v0)
+    assert v_final is not v0
+
+
+def test_eager_scan_empty_state_only_does_not_require_output_template():
+    calls = {"count": 0}
+
+    def core(x, v):
+        calls["count"] += 1
+        raise AssertionError("core should not run for an empty eager scan")
+
+    x = torch.empty(0, 2)
+    v0 = torch.ones(3)
+
+    (v_seq,) = eager_scan(core, 1, 1, 0, x, v0)
+    (v_final,) = eager_scan_final_state(core, 1, 1, 0, x, v0)
+
+    assert calls["count"] == 0
+    assert v_seq.shape == (0, 3)
+    torch.testing.assert_close(v_final, v0)
+    assert v_final is not v0
+
+
+def test_inference_final_state_template_handles_zero_states(monkeypatch):
+    captured = {}
+
+    def fake_compile(kernel_str, kernel_name, verbose):
+        compile(kernel_str, kernel_name, "exec")
+        captured["kernel_str"] = kernel_str
+        return object()
+
+    monkeypatch.setattr(template_module, "compile_triton_code_str", fake_compile)
+    info = FlexSNInfo(
+        num_inputs=1,
+        num_outputs=1,
+        num_states=0,
+        fwd_core_args=["x"],
+        fwd_core_returns=["s"],
+        fwd_core_recipients=["s0"],
+        fwd_kernel_returns=["s0"],
+        num_fwd_kernel_returns=1,
+        c2k_return_mapping=[],
+    )
+
+    template_module.get_flexsn_inference_final_state_kernel(
+        "@triton.jit\ndef core_12345678(x0):\n    return x0",
+        "core_12345678",
+        info,
+    )
+
+    assert "\n    , # inputs" not in captured["kernel_str"]
 
 
 def test_lowerable_while_loop_matches_manual_loop(rng):
@@ -671,8 +1212,8 @@ def test_compile_fullgraph_lowerable_while_loop_matches_eager(rng):
     compiled_out = torch.compile(run_scan, fullgraph=True)(x_compiled, v0_compiled)
 
     assert len(compiled_out) == len(eager_out)
-    for compiled_tensor, eager_tensor in zip(compiled_out, eager_out):
-        torch.testing.assert_close(compiled_tensor, eager_tensor)
+    for i in range(len(eager_out)):
+        torch.testing.assert_close(compiled_out[i], eager_out[i])
 
 
 def test_compile_fullgraph_hop_backend_matches_eager_with_lowerable_while_loop(
@@ -698,13 +1239,15 @@ def test_compile_fullgraph_hop_backend_matches_eager_with_lowerable_while_loop(
             num_outputs=1,
             step_mode="m",
             backend="hop",
+            store_state_seqs=True,
             example_inputs=(torch.zeros(N), torch.zeros(N)),
         )
 
-    eager_out = make_neuron()(x_eager)
     monkeypatch.setenv("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP", "1")
-    compiled_fn = torch.compile(make_neuron(), fullgraph=True)
-    compiled_out = compiled_fn(x_compiled)
+    with torch.no_grad():
+        eager_out = make_neuron()(x_eager)
+        compiled_fn = torch.compile(make_neuron(), fullgraph=True)
+        compiled_out = compiled_fn(x_compiled)
 
     torch.testing.assert_close(compiled_out, eager_out)
 
@@ -740,6 +1283,99 @@ def test_hop_backend_store_state_seqs_false_matches_torch_backend(rng):
     torch.testing.assert_close(hop_neuron.states[0], torch_neuron.states[0])
 
 
+def test_hop_backend_zero_length_sequence_matches_torch_backend():
+    x = torch.randn(0, 8)
+
+    hop_neuron = FlexSN(
+        core=_differentiable_lif_core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="hop",
+        store_state_seqs=True,
+        example_inputs=(torch.zeros(8), torch.zeros(8)),
+        example_outputs=(torch.zeros(8),),
+    )
+    torch_neuron = FlexSN(
+        core=_differentiable_lif_core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+        store_state_seqs=True,
+        example_outputs=(torch.zeros(8),),
+    )
+
+    hop_out = hop_neuron(x)
+    torch_out = torch_neuron(x)
+
+    torch.testing.assert_close(hop_out, torch_out)
+    torch.testing.assert_close(hop_neuron.states[0], torch_neuron.states[0])
+
+
+def test_hop_backend_zero_length_sequence_uses_example_output_template():
+    x = torch.randn(0, 2)
+    bias = torch.zeros(3)
+    calls = {"count": 0}
+
+    def core_with_closure(x_step):
+        calls["count"] += 1
+        raise AssertionError("core should not run for an empty hop input")
+
+    hop_neuron = FlexSN(
+        core=core_with_closure,
+        num_inputs=1,
+        num_states=0,
+        num_outputs=1,
+        step_mode="m",
+        backend="hop",
+        store_state_seqs=False,
+        example_inputs=(torch.zeros(2),),
+        example_outputs=(bias,),
+    )
+
+    hop_out = hop_neuron(x)
+    assert calls["count"] == 0
+    assert hop_out.shape == (0, 3)
+
+
+def test_hop_backend_zero_length_sequence_delegates_to_hop_scan(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_run_hop_scan(
+        core,
+        num_inputs,
+        num_states,
+        num_outputs,
+        store_state_seqs,
+        *flat_args,
+        output_template_specs=None,
+    ):
+        calls["count"] += 1
+        assert flat_args[0].shape[0] == 0
+        assert output_template_specs is None
+        return (flat_args[0].new_empty((0, 5)),)
+
+    monkeypatch.setattr(flexsn_module, "_run_hop_scan", fake_run_hop_scan)
+    hop_neuron = FlexSN(
+        core=lambda x: (x.new_empty(5),),
+        num_inputs=1,
+        num_states=0,
+        num_outputs=1,
+        step_mode="m",
+        backend="hop",
+        store_state_seqs=False,
+        example_inputs=(torch.zeros(2),),
+    )
+
+    hop_out = hop_neuron(torch.empty(0, 2))
+
+    assert calls["count"] == 1
+    assert hop_out.shape == (0, 5)
+
+
 def test_compile_fullgraph_hop_store_state_seqs_false_matches_eager_with_lowerable_while_loop(
     rng, monkeypatch
 ):
@@ -767,14 +1403,16 @@ def test_compile_fullgraph_hop_store_state_seqs_false_matches_eager_with_lowerab
             example_inputs=(torch.zeros(N), torch.zeros(N)),
         )
 
-    eager_neuron = make_neuron()
-    eager_out = eager_neuron(x_eager)
     monkeypatch.setenv("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP", "1")
-    compiled_fn = torch.compile(make_neuron(), fullgraph=True)
-    compiled_out = compiled_fn(x_compiled)
+    with torch.no_grad():
+        eager_neuron = make_neuron()
+        eager_out = eager_neuron(x_eager)
+        compiled_neuron = make_neuron()
+        compiled_fn = torch.compile(compiled_neuron, fullgraph=True)
+        compiled_out = compiled_fn(x_compiled)
 
     torch.testing.assert_close(compiled_out, eager_out)
-    torch.testing.assert_close(compiled_fn._orig_mod.states[0], eager_neuron.states[0])
+    torch.testing.assert_close(compiled_neuron.states[0], eager_neuron.states[0])
 
 
 # -------------------------------------------------------------------------
@@ -958,6 +1596,8 @@ def test_aot_function_traces_fwd_bwd(rng):
 
 
 def test_compile_fullgraph_forward_matches_eager(rng):
+    if sys.platform == "win32":
+        pytest.skip("torch.compile fullgraph Inductor is not supported on Windows")
     T, N = 4, 8
     x_eager = torch.randn(T, N, generator=rng)
     x_compiled = x_eager.detach().clone()
@@ -976,6 +1616,8 @@ def test_compile_fullgraph_forward_matches_eager(rng):
 
 
 def test_compile_fullgraph_backward_matches_eager(rng):
+    if sys.platform == "win32":
+        pytest.skip("torch.compile fullgraph Inductor is not supported on Windows")
     T, N = 5, 8
     x_eager = torch.randn(T, N, generator=rng, requires_grad=True)
     x_compiled = x_eager.detach().clone().requires_grad_(True)
@@ -995,6 +1637,8 @@ def test_compile_fullgraph_backward_matches_eager(rng):
 
 
 def test_compile_fullgraph_backward_store_state_seqs_false_matches_eager(rng):
+    if sys.platform == "win32":
+        pytest.skip("torch.compile fullgraph Inductor is not supported on Windows")
     T, N = 5, 8
     x_eager = torch.randn(T, N, generator=rng, requires_grad=True)
     x_compiled = x_eager.detach().clone().requires_grad_(True)
@@ -1021,6 +1665,7 @@ def test_compile_fullgraph_backward_store_state_seqs_false_matches_eager(rng):
 def test_compile_fullgraph_hop_backend_matches_eager(rng):
     if sys.platform == "win32":
         pytest.skip("torch.compile is not supported on Windows")
+    _skip_if_dynamo_hop_unavailable()
 
     T, N = 4, 8
     x_eager = torch.randn(T, N, generator=rng)
@@ -1034,6 +1679,7 @@ def test_compile_fullgraph_hop_backend_matches_eager(rng):
             num_outputs=1,
             step_mode="m",
             backend="hop",
+            store_state_seqs=True,
             example_inputs=(torch.zeros(N), torch.zeros(N)),
         )
 
@@ -1044,9 +1690,63 @@ def test_compile_fullgraph_hop_backend_matches_eager(rng):
     torch.testing.assert_close(compiled_out, eager_out)
 
 
+def test_compile_fullgraph_hop_direct_zero_length_scan_uses_body_template():
+    if sys.platform == "win32":
+        pytest.skip("torch.compile is not supported on Windows")
+    _skip_if_dynamo_hop_unavailable()
+
+    def core(x_step, state):
+        return state + 1, state
+
+    x = torch.empty(0, 2)
+    state = torch.zeros(3)
+
+    @torch.compile(fullgraph=True)
+    def compiled_scan(x_seq, init_state):
+        return flex_sn_scan(core, 1, 1, 1, x_seq, init_state)
+
+    out, state_seq = compiled_scan(x, state)
+
+    assert out.shape == (0, 3)
+    assert state_seq.shape == (0, 3)
+    assert out.dtype == state.dtype
+
+
+def test_compile_fullgraph_hop_direct_accepts_output_template_specs():
+    if sys.platform == "win32":
+        pytest.skip("torch.compile is not supported on Windows")
+    _skip_if_dynamo_hop_unavailable()
+
+    def core(x_step, state):
+        return state + 1, state
+
+    x = torch.empty(0, 2)
+    state = torch.zeros(3)
+    specs = (((5,), torch.float64),)
+
+    @torch.compile(fullgraph=True)
+    def compiled_scan(x_seq, init_state):
+        return flex_sn_scan(
+            core,
+            1,
+            1,
+            1,
+            x_seq,
+            init_state,
+            output_template_specs=specs,
+        )
+
+    out, state_seq = compiled_scan(x, state)
+
+    assert out.shape == (0, 5)
+    assert out.dtype == torch.float64
+    assert state_seq.shape == (0, 3)
+
+
 def test_compile_fullgraph_hop_backend_matches_eager_with_closure(rng):
     if sys.platform == "win32":
         pytest.skip("torch.compile is not supported on Windows")
+    _skip_if_dynamo_hop_unavailable()
 
     T, N = 4, 8
     x_eager = torch.randn(T, N, generator=rng)
@@ -1064,6 +1764,7 @@ def test_compile_fullgraph_hop_backend_matches_eager_with_closure(rng):
             num_outputs=1,
             step_mode="m",
             backend="hop",
+            store_state_seqs=True,
             example_inputs=(torch.zeros(N), torch.zeros(N)),
         )
 
@@ -1078,6 +1779,8 @@ def test_compile_fuses_surrounding_linear_layers(rng):
     """Linear -> FlexSN -> Linear must compile under fullgraph=True.
     On GPU this is the case Inductor fuses into a single kernel stack;
     here we only validate correctness vs. eager."""
+    if sys.platform == "win32":
+        pytest.skip("torch.compile fullgraph Inductor is not supported on Windows")
     T, N = 4, 8
 
     class Net(torch.nn.Module):
@@ -1167,8 +1870,8 @@ def test_compile_spiking_vgg_hop_lowerable_while_loop_matches_eager(monkeypatch)
     def core(x, v):
         tau, v_th = 2.0, 1.0
         h = v + (x - v) / tau
-        s = (h >= v_th).to(h.dtype)
-        return s, h * (1.0 - s)
+        s = (h >= v_th).to(h.dtype).contiguous()
+        return s, (h * (1.0 - s)).contiguous()
 
     def make_flexsn(**kwargs):
         return FlexSN(
@@ -1186,21 +1889,27 @@ def test_compile_spiking_vgg_hop_lowerable_while_loop_matches_eager(monkeypatch)
     x_compiled = x_eager.detach().clone()
 
     torch.manual_seed(0)
-    model = spiking_vgg16_bn(
+    eager_model = spiking_vgg16_bn(
+        spiking_neuron=make_flexsn,
+        step_mode="m",
+    ).cuda().eval()
+    torch.manual_seed(0)
+    compiled_model = spiking_vgg16_bn(
         spiking_neuron=make_flexsn,
         step_mode="m",
     ).cuda().eval()
 
     from spikingjelly.activation_based import functional as sj_functional
-    sj_functional.set_step_mode(model, "m")
+    sj_functional.set_step_mode(eager_model, "m")
+    sj_functional.set_step_mode(compiled_model, "m")
 
     monkeypatch.setenv("SJ_ENABLE_EXPERIMENTAL_LOWERABLE_WHILE_LOOP", "1")
 
-    with torch.no_grad():
-        eager_out = model(x_eager)
-        sj_functional.reset_net(model)
-        compiled_model = torch.compile(model, fullgraph=True)
-        compiled_out = compiled_model(x_compiled)
+    with torch.backends.cudnn.flags(enabled=False):
+        with torch.no_grad():
+            eager_out = eager_model(x_eager)
+            compiled_model = torch.compile(compiled_model, fullgraph=True)
+            compiled_out = compiled_model(x_compiled)
 
     torch.testing.assert_close(compiled_out, eager_out, atol=1e-5, rtol=1e-4)
 

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -238,6 +238,19 @@ def test_scan_backends_reject_mismatched_example_output_template():
         )
 
 
+def test_scan_backends_reject_mismatched_example_output_template_without_example_inputs():
+    with pytest.raises(ValueError, match="example_outputs"):
+        FlexSN(
+            core=_lif_core,
+            num_inputs=1,
+            num_states=1,
+            num_outputs=1,
+            step_mode="m",
+            backend="inductor",
+            example_outputs=(torch.zeros(4),),
+        )
+
+
 def test_scan_backends_reject_mismatched_example_input_numel():
     with pytest.raises(ValueError, match="same number of elements"):
         FlexSN(

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -675,6 +675,16 @@ def test_flexsn_wrapper_backward_all_none_gradients_use_templates():
     torch.testing.assert_close(grad_v, torch.zeros_like(state_template))
 
 
+def test_flexsn_wrapper_backward_requires_input_templates_for_multi_input_core():
+    from spikingjelly.activation_based.triton_kernel.flexsn import wrapper
+
+    info = SimpleNamespace(num_inputs=2, num_states=0, num_outputs=1)
+    grad_output = torch.randn(3, 4)
+
+    with pytest.raises(ValueError, match="multiple input sequences"):
+        wrapper.flexsn_backward(None, info, grad_output)
+
+
 def test_inductor_final_state_warmup_args_use_example_shapes():
     info = SimpleNamespace(num_inputs=2, num_states=2)
     specs = (
@@ -1398,8 +1408,8 @@ def test_compile_fullgraph_lowerable_while_loop_matches_eager(rng):
     compiled_out = torch.compile(run_scan, fullgraph=True)(x_compiled, v0_compiled)
 
     assert len(compiled_out) == len(eager_out)
-    for i in range(len(eager_out)):
-        torch.testing.assert_close(compiled_out[i], eager_out[i])
+    for compiled_tensor, eager_tensor in zip(compiled_out, eager_out, strict=True):
+        torch.testing.assert_close(compiled_tensor, eager_tensor)
 
 
 def test_compile_fullgraph_hop_backend_matches_eager_with_lowerable_while_loop(

--- a/test/activation_based/test_fuse_conv_bn.py
+++ b/test/activation_based/test_fuse_conv_bn.py
@@ -1,0 +1,340 @@
+import copy
+
+import pytest
+import torch
+from torch import nn
+
+from spikingjelly.activation_based import functional, layer
+from spikingjelly.activation_based.functional.misc import _TrainConvBnWrapper
+
+
+class _StepBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = layer.Conv2d(
+            3, 8, kernel_size=3, stride=1, padding=1, bias=False, step_mode="m"
+        )
+        self.bn = layer.BatchNorm2d(8, step_mode="m")
+        self.tail = layer.Conv2d(
+            8, 8, kernel_size=3, stride=1, padding=1, bias=False, step_mode="m"
+        )
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.bn(x)
+        x = self.tail(x)
+        return x
+
+
+class _NativeStepBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn = nn.BatchNorm2d(8)
+        self.tail = nn.Conv2d(8, 8, kernel_size=3, stride=1, padding=1, bias=False)
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.bn(x)
+        x = self.tail(x)
+        return x
+
+
+class _NoRunningStatsBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn = nn.BatchNorm2d(8, track_running_stats=False)
+
+    def forward(self, x):
+        return self.bn(self.conv(x))
+
+
+class _SharedEvalConvBnBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn = nn.BatchNorm2d(8)
+
+    def forward(self, x):
+        a = self.bn(self.conv(x))
+        b = self.bn(self.conv(x))
+        return a + b
+
+
+class _SharedTrainConvBnBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn = nn.BatchNorm2d(8)
+
+    def forward(self, x):
+        a = self.bn(self.conv(x))
+        b = self.bn(self.conv(x))
+        return a + b
+
+
+class _SharedConvDifferentBnEvalBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(8)
+        self.bn2 = nn.BatchNorm2d(8)
+
+    def forward(self, x):
+        return self.bn1(self.conv(x)) + self.bn2(self.conv(x))
+
+
+class _SharedConvDifferentBnTrainBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(8)
+        self.bn2 = nn.BatchNorm2d(8)
+
+    def forward(self, x):
+        return self.bn1(self.conv(x)) + self.bn2(self.conv(x))
+
+
+class _PartialConvBnBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn = nn.BatchNorm2d(8)
+
+    def forward(self, x):
+        return self.bn(self.conv(x)) + self.conv(x)
+
+
+def test_fuse_conv_bn_eval_modules_matches_step_block():
+    torch.manual_seed(0)
+    model = _StepBlock().eval()
+    x = torch.randn(4, 2, 3, 16, 16)
+
+    with torch.no_grad():
+        y_ref = model(x)
+        fused = functional.fuse_conv_bn_eval_modules(copy.deepcopy(model))
+        y_fused = fused(x)
+
+    torch.testing.assert_close(y_fused, y_ref, atol=1e-5, rtol=1e-4)
+    assert not any(isinstance(m, layer.BatchNorm2d) for m in fused.modules())
+
+
+def test_fuse_conv_bn_eval_modules_matches_native_block():
+    torch.manual_seed(0)
+    model = _NativeStepBlock().eval()
+    x = torch.randn(2, 3, 16, 16)
+
+    with torch.no_grad():
+        y_ref = model(x)
+        fused = functional.fuse_conv_bn_eval_modules(copy.deepcopy(model))
+        y_fused = fused(x)
+
+    torch.testing.assert_close(y_fused, y_ref, atol=1e-5, rtol=1e-4)
+    assert not any(isinstance(m, nn.BatchNorm2d) for m in fused.modules())
+
+
+def test_fuse_conv_bn_eval_modules_rejects_missing_running_stats():
+    model = _NoRunningStatsBlock().eval()
+
+    with pytest.raises(ValueError, match="track running stats"):
+        functional.fuse_conv_bn_eval_modules(copy.deepcopy(model))
+
+
+def test_fuse_conv_bn_eval_modules_handles_shared_conv_bn_pairs():
+    torch.manual_seed(0)
+    model = _SharedEvalConvBnBlock().eval()
+    x = torch.randn(2, 3, 16, 16)
+
+    with torch.no_grad():
+        y_ref = model(x)
+        fused = functional.fuse_conv_bn_eval_modules(copy.deepcopy(model))
+        y_fused = fused(x)
+
+    torch.testing.assert_close(y_fused, y_ref, atol=1e-5, rtol=1e-4)
+    assert not any(isinstance(m, nn.BatchNorm2d) for m in fused.modules())
+
+
+def test_fuse_conv_bn_eval_modules_skips_shared_conv_with_different_bn():
+    torch.manual_seed(0)
+    model = _SharedConvDifferentBnEvalBlock().eval()
+    x = torch.randn(2, 3, 16, 16)
+
+    with torch.no_grad():
+        y_ref = model(x)
+        fused = functional.fuse_conv_bn_eval_modules(copy.deepcopy(model))
+        y_fused = fused(x)
+
+    torch.testing.assert_close(y_fused, y_ref, atol=1e-5, rtol=1e-4)
+    assert sum(isinstance(m, nn.BatchNorm2d) for m in fused.modules()) == 2
+
+
+def test_fuse_conv_bn_eval_modules_skips_partial_conv_bn_callsites():
+    torch.manual_seed(0)
+    model = _PartialConvBnBlock().eval()
+    x = torch.randn(2, 3, 16, 16)
+
+    with torch.no_grad():
+        y_ref = model(x)
+        fused = functional.fuse_conv_bn_eval_modules(copy.deepcopy(model))
+        y_fused = fused(x)
+
+    torch.testing.assert_close(y_fused, y_ref, atol=1e-5, rtol=1e-4)
+    assert any(isinstance(m, nn.BatchNorm2d) for m in fused.modules())
+
+
+def test_pack_conv_bn_train_modules_matches_step_block():
+    torch.manual_seed(0)
+    model = _StepBlock().train()
+    packed = functional.pack_conv_bn_train_modules(copy.deepcopy(model))
+    x = torch.randn(4, 2, 3, 16, 16, requires_grad=True)
+    x_packed = x.detach().clone().requires_grad_(True)
+
+    y_ref = model(x)
+    y_packed = packed(x_packed)
+    torch.testing.assert_close(y_packed, y_ref, atol=1e-5, rtol=1e-4)
+
+    loss_ref = y_ref.square().mean()
+    loss_packed = y_packed.square().mean()
+    loss_ref.backward()
+    loss_packed.backward()
+
+    torch.testing.assert_close(x_packed.grad, x.grad, atol=1e-5, rtol=1e-4)
+    torch.testing.assert_close(
+        packed.conv.conv.weight.grad, model.conv.weight.grad, atol=1e-5, rtol=1e-4
+    )
+    torch.testing.assert_close(
+        packed.conv.bn.weight.grad, model.bn.weight.grad, atol=1e-5, rtol=1e-4
+    )
+    assert any(isinstance(m, _TrainConvBnWrapper) for m in packed.modules())
+
+
+def test_pack_conv_bn_train_modules_matches_native_block():
+    torch.manual_seed(0)
+    model = _NativeStepBlock().train()
+    packed = functional.pack_conv_bn_train_modules(copy.deepcopy(model))
+    x = torch.randn(2, 3, 16, 16, requires_grad=True)
+    x_packed = x.detach().clone().requires_grad_(True)
+
+    y_ref = model(x)
+    y_packed = packed(x_packed)
+    torch.testing.assert_close(y_packed, y_ref, atol=1e-5, rtol=1e-4)
+
+    loss_ref = y_ref.square().mean()
+    loss_packed = y_packed.square().mean()
+    loss_ref.backward()
+    loss_packed.backward()
+
+    torch.testing.assert_close(x_packed.grad, x.grad, atol=1e-5, rtol=1e-4)
+    torch.testing.assert_close(
+        packed.conv.conv.weight.grad, model.conv.weight.grad, atol=1e-5, rtol=1e-4
+    )
+    torch.testing.assert_close(
+        packed.conv.bn.weight.grad, model.bn.weight.grad, atol=1e-5, rtol=1e-4
+    )
+    assert any(isinstance(m, _TrainConvBnWrapper) for m in packed.modules())
+
+
+def test_train_conv_bn_wrapper_packs_native_multistep_inputs():
+    torch.manual_seed(0)
+    model = _NativeStepBlock().train()
+    wrapped = _TrainConvBnWrapper(copy.deepcopy(model.conv), copy.deepcopy(model.bn)).train()
+    x = torch.randn(4, 2, 3, 16, 16, requires_grad=True)
+    x_packed = x.detach().clone().requires_grad_(True)
+
+    y_packed = wrapped(x_packed)
+
+    x_ref = x.flatten(0, 1)
+    y_ref = model.bn(model.conv(x_ref)).view_as(y_packed)
+    torch.testing.assert_close(y_packed, y_ref, atol=1e-5, rtol=1e-4)
+
+    loss_ref = y_ref.square().mean()
+    loss_packed = y_packed.square().mean()
+    loss_ref.backward()
+    loss_packed.backward()
+
+    torch.testing.assert_close(x_packed.grad, x.grad, atol=1e-5, rtol=1e-4)
+    torch.testing.assert_close(
+        wrapped.conv.weight.grad, model.conv.weight.grad, atol=1e-5, rtol=1e-4
+    )
+    torch.testing.assert_close(
+        wrapped.bn.weight.grad, model.bn.weight.grad, atol=1e-5, rtol=1e-4
+    )
+
+
+def test_train_conv_bn_wrapper_keeps_conv_hooks_active():
+    torch.manual_seed(0)
+    model = _StepBlock().train()
+    wrapped = _TrainConvBnWrapper(copy.deepcopy(model.conv), copy.deepcopy(model.bn)).train()
+    x = torch.randn(4, 2, 3, 16, 16)
+    hook_calls = []
+
+    def hook(module, args, output):
+        hook_calls.append((args[0].shape, output.shape))
+
+    handle = wrapped.conv.register_forward_hook(hook)
+    try:
+        wrapped(x)
+    finally:
+        handle.remove()
+
+    assert hook_calls == [((8, 3, 16, 16), (8, 8, 16, 16))]
+
+
+def test_pack_conv_bn_train_modules_handles_shared_conv_bn_pairs():
+    torch.manual_seed(0)
+    model = _SharedTrainConvBnBlock().train()
+    packed = functional.pack_conv_bn_train_modules(copy.deepcopy(model))
+    x = torch.randn(2, 3, 16, 16, requires_grad=True)
+    x_packed = x.detach().clone().requires_grad_(True)
+
+    y_ref = model(x)
+    y_packed = packed(x_packed)
+    torch.testing.assert_close(y_packed, y_ref, atol=1e-5, rtol=1e-4)
+
+    loss_ref = y_ref.square().mean()
+    loss_packed = y_packed.square().mean()
+    loss_ref.backward()
+    loss_packed.backward()
+
+    torch.testing.assert_close(x_packed.grad, x.grad, atol=1e-5, rtol=1e-4)
+
+
+def test_pack_conv_bn_train_modules_skips_shared_conv_with_different_bn():
+    torch.manual_seed(0)
+    model = _SharedConvDifferentBnTrainBlock().train()
+    packed = functional.pack_conv_bn_train_modules(copy.deepcopy(model))
+    x = torch.randn(2, 3, 16, 16, requires_grad=True)
+    x_packed = x.detach().clone().requires_grad_(True)
+
+    y_ref = model(x)
+    y_packed = packed(x_packed)
+    torch.testing.assert_close(y_packed, y_ref, atol=1e-5, rtol=1e-4)
+
+    loss_ref = y_ref.square().mean()
+    loss_packed = y_packed.square().mean()
+    loss_ref.backward()
+    loss_packed.backward()
+
+    torch.testing.assert_close(x_packed.grad, x.grad, atol=1e-5, rtol=1e-4)
+    assert not any(isinstance(m, _TrainConvBnWrapper) for m in packed.modules())
+
+
+def test_pack_conv_bn_train_modules_skips_partial_conv_bn_callsites():
+    torch.manual_seed(0)
+    model = _PartialConvBnBlock().train()
+    packed = functional.pack_conv_bn_train_modules(copy.deepcopy(model))
+    x = torch.randn(2, 3, 16, 16, requires_grad=True)
+    x_packed = x.detach().clone().requires_grad_(True)
+
+    y_ref = model(x)
+    y_packed = packed(x_packed)
+    torch.testing.assert_close(y_packed, y_ref, atol=1e-5, rtol=1e-4)
+
+    loss_ref = y_ref.square().mean()
+    loss_packed = y_packed.square().mean()
+    loss_ref.backward()
+    loss_packed.backward()
+
+    torch.testing.assert_close(x_packed.grad, x.grad, atol=1e-5, rtol=1e-4)
+    assert not any(isinstance(m, _TrainConvBnWrapper) for m in packed.modules())


### PR DESCRIPTION
## Summary
- create a clean FlexSN/HOP release branch from current `master`
- keep only the files relevant to FlexSN HOP and compile-training work
- carry over the validated FlexSN Inductor/HOP tests and Conv-BN fusion regression test
- harden optional HOP imports and skip Windows-only fullgraph Inductor tests that fail for platform reasons

## Validation
- `C:\Users\fw\anaconda3\envs\torch\python.exe -m pytest test\activation_based\test_flex_sn_inductor.py test\activation_based\test_fuse_conv_bn.py -q`
- `py_compile` on the touched FlexSN benchmark / kernel / test files

## Notes
- This PR supersedes #662 with the same core FlexSN scope but without the unrelated history that had accumulated on `feature/flexsn-hop`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conv–BatchNorm eval/train transforms, HOP/scan helpers, Dynamo HOP integration, and example-driven output templates with explicit empty-sequence (T==0) fast paths.

* **Performance**
  * Per-iteration CUDA benchmarking with optional reset hooks for consistent timing; deterministic compiled-kernel caching and reuse.

* **Bug Fixes**
  * Correct handling of zero-length sequences, final-state/gradient edge cases, and stricter dtype/device/template validation.

* **Refactor**
  * Simplified kernel/build and unified inference/training/backward flows; template-driven wrapper/trace plumbing.

* **Tests**
  * Expanded coverage for fusion, T==0 semantics, multi-backend and compilation/Dynamo behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->