### PR TITLE
Extend NeuroMC to support ANN and SGD

### DIFF
--- a/spikingjelly/activation_based/op_counter/neuromc/core.py
+++ b/spikingjelly/activation_based/op_counter/neuromc/core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 import warnings
 from collections import defaultdict
+from collections import deque
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, Callable
@@ -30,6 +31,11 @@ _ALLOWED_CORE_TYPES = {
     "bp_bn",
     "bp_grad_opt",
     "wg",
+    "ann_fe",
+    "ann_be",
+    "ann_we",
+    "ann_bn",
+    "ann_bn_bp",
 }
 
 _EXTRA_OP_COST_PJ = {
@@ -44,6 +50,9 @@ _MAC_COST_PJ = {
     "fp_soma": 0.548 + 0.548 * (1.0 / 16.0),
     "bp_grad": 0.548 + 0.812,
     "wg": 0.548 + 0.548 * (1.0 / 16.0),
+    "ann_fe": 0.548 + 0.812,
+    "ann_be": 0.548 + 0.812,
+    "ann_we": 0.548 + 0.812,
 }
 
 _IGNORED_OP_PREFIXES = (
@@ -194,28 +203,9 @@ class _Fragment:
     b_type: int = 0
     t_type: int = 0
     source: str = "trace"
-
-
-def _fragment_signature(fragment: _Fragment) -> tuple[Any, ...]:
-    return (
-        fragment.op_name,
-        fragment.source,
-        fragment.stage,
-        fragment.phase,
-        fragment.core_type,
-        fragment.process_key,
-        tuple(sorted(fragment.loop_dims.items())),
-        fragment.input_precision_bits,
-        fragment.weight_precision_bits,
-        fragment.output_precision_bits,
-        fragment.input_numel,
-        fragment.weight_numel,
-        fragment.output_numel,
-        fragment.mac_count,
-        fragment.conv_type,
-        fragment.b_type,
-        fragment.t_type,
-    )
+    optimizer_has_momentum: bool = False
+    optimizer_has_weight_decay: bool = False
+    optimizer_has_momentum_buffer: bool = False
 
 
 def _module_overlap_signature(fragment: _Fragment) -> tuple[Any, ...]:
@@ -302,6 +292,34 @@ def _is_spike_like(x: Any) -> bool:
     if isinstance(x, _TraceTensor):
         return x.is_spike
     return _is_spike(x)
+
+
+def _shape_tuple(x: Any) -> tuple[int, ...]:
+    if isinstance(x, (_TraceTensor, torch.Tensor)):
+        return tuple(int(v) for v in x.shape)
+    return ()
+
+
+def _forward_core_type(is_spike_input: bool) -> str:
+    return "fp_soma" if is_spike_input else "ann_fe"
+
+
+def _grad_input_core_type(is_spike_input: bool) -> str:
+    return "bp_grad" if is_spike_input else "ann_be"
+
+
+def _weight_grad_core_type(is_spike_input: bool) -> str:
+    return "wg" if is_spike_input else "ann_we"
+
+
+def _optimizer_param_count(fragment: _Fragment) -> int:
+    return fragment.loop_dims["K"] + (
+        fragment.loop_dims["FX"] * fragment.loop_dims["FY"] * fragment.loop_dims["C"]
+    )
+
+
+def _optimizer_count_key(fragment: _Fragment) -> str:
+    return "KT" if fragment.loop_dims["K"] > 0 else "FYFXKC"
 
 
 def _resolve_loss_fn(loss_fn: Callable | None):
@@ -466,6 +484,11 @@ class NeuroMCEnergyProfiler:
             return "unlabeled"
         return self._stage_stack[-1]
 
+    def _bn_core_type(self, phase: str, is_spike_input: bool) -> str:
+        if is_spike_input:
+            return "fp_bn" if phase == "forward" else "bp_bn"
+        return "ann_bn" if phase == "forward" else "ann_bn_bp"
+
     def _stage_phase(self, stage: str | None = None) -> str:
         name = stage or self._current_stage()
         lowered = name.lower()
@@ -524,6 +547,7 @@ class NeuroMCEnergyProfiler:
             )
         elif isinstance(module, (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d)):
             x = args[0]
+            module._neuromc_last_input = x
             self._fragments.append(
                 self._make_bn_forward_fragment(stage, module, x, out)
             )
@@ -589,11 +613,7 @@ class NeuroMCEnergyProfiler:
         self, stage: str, module: nn.Module, x, out
     ) -> _Fragment:
         b_type, t_type = self._stage_position(stage)
-        if not _is_spike(x):
-            raise ValueError(
-                "Exact NeuroMC runtime only supports spike/binary forward inputs "
-                f"for {module.__class__.__name__}; got ANN-like dense activations."
-            )
+        is_spike_input = _is_spike(x)
         t, b, _, _ = _tensor_layout(x, module)
         _, _, _, out_spatial = _tensor_layout(out, module)
         spatial = out_spatial if len(out_spatial) > 0 else (1, 1)
@@ -620,10 +640,10 @@ class NeuroMCEnergyProfiler:
             stage=stage,
             phase="forward",
             op_name="conv.forward",
-            core_type="fp_soma",
+            core_type=_forward_core_type(is_spike_input),
             process_key="with_nothing",
             loop_dims=loop_dims,
-            input_precision_bits=1,
+            input_precision_bits=1 if is_spike_input else 16,
             weight_precision_bits=16,
             output_precision_bits=16,
             input_numel=_tensor_numel(x),
@@ -639,11 +659,7 @@ class NeuroMCEnergyProfiler:
         self, stage: str, module: nn.Linear, x, out
     ) -> _Fragment:
         b_type, t_type = self._stage_position(stage)
-        if not _is_spike(x):
-            raise ValueError(
-                "Exact NeuroMC runtime only supports spike/binary forward inputs "
-                f"for {module.__class__.__name__}; got ANN-like dense activations."
-            )
+        is_spike_input = _is_spike(x)
         t, batch, _, _ = _tensor_layout(x, module)
         loop_dims = self._make_loop_dims(
             batch_size=batch,
@@ -659,10 +675,10 @@ class NeuroMCEnergyProfiler:
             stage=stage,
             phase="forward",
             op_name="linear.forward",
-            core_type="fp_soma",
+            core_type=_forward_core_type(is_spike_input),
             process_key="with_nothing",
             loop_dims=loop_dims,
-            input_precision_bits=1,
+            input_precision_bits=1 if is_spike_input else 16,
             weight_precision_bits=16,
             output_precision_bits=16,
             input_numel=_tensor_numel(x),
@@ -677,6 +693,7 @@ class NeuroMCEnergyProfiler:
     def _make_bn_forward_fragment(
         self, stage: str, module: nn.Module | None, x, out
     ) -> _Fragment:
+        is_spike_input = _is_spike(x)
         t, batch, c, spatial = _tensor_layout(x, module)
         spatial_prod = max(_prod(spatial), 1) if spatial else 1
         loop_dims = self._make_loop_dims(
@@ -693,7 +710,7 @@ class NeuroMCEnergyProfiler:
             stage=stage,
             phase="forward",
             op_name="bn.forward",
-            core_type="fp_bn",
+            core_type=self._bn_core_type("forward", is_spike_input),
             process_key="with_bn",
             loop_dims=loop_dims,
             input_precision_bits=16,
@@ -751,6 +768,7 @@ class NeuroMCEnergyProfiler:
         grad_out = (
             grad_output[0] if isinstance(grad_output, (tuple, list)) else grad_output
         )
+        is_spike_input = _is_spike(getattr(module, "_neuromc_last_input", None))
         t, batch, _, spatial = _tensor_layout(grad_out, module)
         spatial = spatial if len(spatial) > 0 else (1, 1)
         if len(spatial) == 1:
@@ -784,7 +802,7 @@ class NeuroMCEnergyProfiler:
                     stage=stage,
                     phase="backward",
                     op_name="conv.backward.grad_input",
-                    core_type="bp_grad",
+                    core_type=_grad_input_core_type(is_spike_input),
                     process_key="with_nothing",
                     loop_dims=base_loop,
                     input_precision_bits=16,
@@ -803,12 +821,10 @@ class NeuroMCEnergyProfiler:
                     stage=stage,
                     phase="backward",
                     op_name="conv.backward.grad_weight",
-                    core_type="wg",
+                    core_type=_weight_grad_core_type(is_spike_input),
                     process_key="with_nothing",
                     loop_dims=base_loop,
-                    input_precision_bits=1
-                    if _is_spike(getattr(module, "_neuromc_last_input", None))
-                    else 16,
+                    input_precision_bits=1 if is_spike_input else 16,
                     weight_precision_bits=16,
                     output_precision_bits=16,
                     input_numel=_tensor_numel(
@@ -826,6 +842,7 @@ class NeuroMCEnergyProfiler:
         grad_out = (
             grad_output[0] if isinstance(grad_output, (tuple, list)) else grad_output
         )
+        is_spike_input = _is_spike(getattr(module, "_neuromc_last_input", None))
         t, batch, _, _ = _tensor_layout(grad_out, module)
         loop_dims = self._make_loop_dims(
             batch_size=batch,
@@ -849,7 +866,7 @@ class NeuroMCEnergyProfiler:
                     stage=stage,
                     phase="backward",
                     op_name="linear.backward.grad_input",
-                    core_type="bp_grad",
+                    core_type=_grad_input_core_type(is_spike_input),
                     process_key="with_nothing",
                     loop_dims=loop_dims,
                     input_precision_bits=16,
@@ -868,12 +885,10 @@ class NeuroMCEnergyProfiler:
                     stage=stage,
                     phase="backward",
                     op_name="linear.backward.grad_weight",
-                    core_type="wg",
+                    core_type=_weight_grad_core_type(is_spike_input),
                     process_key="with_nothing",
                     loop_dims=loop_dims,
-                    input_precision_bits=1
-                    if _is_spike(getattr(module, "_neuromc_last_input", None))
-                    else 16,
+                    input_precision_bits=1 if is_spike_input else 16,
                     weight_precision_bits=16,
                     output_precision_bits=16,
                     input_numel=_tensor_numel(
@@ -888,6 +903,7 @@ class NeuroMCEnergyProfiler:
         return fragments
 
     def _make_bn_backward_fragment(self, stage, module, grad_input, grad_output):
+        is_spike_input = _is_spike(getattr(module, "_neuromc_last_input", None))
         grad_out = (
             grad_output[0] if isinstance(grad_output, (tuple, list)) else grad_output
         )
@@ -913,7 +929,7 @@ class NeuroMCEnergyProfiler:
             stage=stage,
             phase="backward",
             op_name="bn.backward",
-            core_type="bp_bn",
+            core_type=self._bn_core_type("backward", is_spike_input),
             process_key="with_bn",
             loop_dims=loop_dims,
             input_precision_bits=16,
@@ -1006,6 +1022,9 @@ class NeuroMCEnergyProfiler:
         self, *, supplemental_only: bool = False
     ) -> list[_Fragment]:
         fragments: list[_Fragment] = []
+        gemm_forward_is_spike: dict[
+            tuple[str, tuple[int, ...], tuple[int, ...]], deque[bool]
+        ] = defaultdict(deque)
         supplemental_ops = {
             "aten.convolution.default",
             "aten.addmm.default",
@@ -1029,11 +1048,7 @@ class NeuroMCEnergyProfiler:
                         "Exact NeuroMC runtime does not support multi-step or 3D "
                         "Conv trace fallback yet."
                     )
-                if not _is_spike_like(x):
-                    raise ValueError(
-                        "Exact NeuroMC runtime only supports spike/binary forward inputs "
-                        "for Conv-like ops; got ANN-like dense activations."
-                    )
+                is_spike_input = _is_spike_like(x)
                 spatial = tuple(out.shape[2:]) if out.ndim > 2 else (1, 1)
                 if len(spatial) > 2:
                     raise ValueError(
@@ -1062,10 +1077,10 @@ class NeuroMCEnergyProfiler:
                         stage=event.stage,
                         phase=event.phase,
                         op_name=op,
-                        core_type="fp_soma",
+                        core_type=_forward_core_type(is_spike_input),
                         process_key="with_nothing",
                         loop_dims=loop_dims,
-                        input_precision_bits=1,
+                        input_precision_bits=1 if is_spike_input else 16,
                         weight_precision_bits=16,
                         output_precision_bits=16,
                         input_numel=_tensor_numel(x),
@@ -1081,11 +1096,10 @@ class NeuroMCEnergyProfiler:
                 y = event.args[-1]
                 out = event.out
                 if event.phase == "forward":
-                    if not _is_spike_like(x):
-                        raise ValueError(
-                            "Exact NeuroMC runtime only supports spike/binary forward inputs "
-                            "for GEMM-like ops; got ANN-like dense activations."
-                        )
+                    is_spike_input = _is_spike_like(x)
+                    gemm_forward_is_spike[
+                        (op, _shape_tuple(x), _shape_tuple(out))
+                    ].append(is_spike_input)
                     batch = (
                         int(x.shape[0]) if x.ndim == 2 else int(x.shape[0] * x.shape[1])
                     )
@@ -1105,10 +1119,10 @@ class NeuroMCEnergyProfiler:
                             stage=event.stage,
                             phase=event.phase,
                             op_name=op,
-                            core_type="fp_soma",
+                            core_type=_forward_core_type(is_spike_input),
                             process_key="with_nothing",
                             loop_dims=loop_dims,
-                            input_precision_bits=1,
+                            input_precision_bits=1 if is_spike_input else 16,
                             weight_precision_bits=16,
                             output_precision_bits=16,
                             input_numel=_tensor_numel(x),
@@ -1122,6 +1136,7 @@ class NeuroMCEnergyProfiler:
                 else:
                     kind = self._gemm_backward_fragment_kind(x, y, out)
                     if kind == "wg":
+                        is_spike_input = _is_spike_like(x)
                         if x.ndim == 2:
                             batch = int(x.shape[-1])
                             c = int(x.shape[0])
@@ -1144,10 +1159,10 @@ class NeuroMCEnergyProfiler:
                                 stage=event.stage,
                                 phase=event.phase,
                                 op_name=op,
-                                core_type="wg",
+                                core_type=_weight_grad_core_type(is_spike_input),
                                 process_key="with_nothing",
                                 loop_dims=loop_dims,
-                                input_precision_bits=1 if _is_spike_like(x) else 16,
+                                input_precision_bits=1 if is_spike_input else 16,
                                 weight_precision_bits=16,
                                 output_precision_bits=16,
                                 input_numel=_tensor_numel(x),
@@ -1159,6 +1174,24 @@ class NeuroMCEnergyProfiler:
                             )
                         )
                     else:
+                        forward_key = (op, _shape_tuple(out), _shape_tuple(x))
+                        is_spike_input = False
+                        if gemm_forward_is_spike[forward_key]:
+                            is_spike_input = gemm_forward_is_spike[forward_key].pop()
+                        elif op == "aten.addmm.default":
+                            alt_key = ("aten.mm.default", _shape_tuple(out), _shape_tuple(x))
+                            if gemm_forward_is_spike[alt_key]:
+                                is_spike_input = gemm_forward_is_spike[alt_key].pop()
+                        elif op == "aten.mm.default":
+                            alt_key = (
+                                "aten.addmm.default",
+                                _shape_tuple(out),
+                                _shape_tuple(x),
+                            )
+                            if gemm_forward_is_spike[alt_key]:
+                                is_spike_input = gemm_forward_is_spike[alt_key].pop()
+                        # Missing forward provenance should bias toward the denser,
+                        # more expensive path instead of undercounting energy.
                         batch = (
                             int(x.shape[0])
                             if x.ndim == 2
@@ -1180,7 +1213,7 @@ class NeuroMCEnergyProfiler:
                                 stage=event.stage,
                                 phase=event.phase,
                                 op_name=op,
-                                core_type="bp_grad",
+                                core_type=_grad_input_core_type(is_spike_input),
                                 process_key="with_nothing",
                                 loop_dims=loop_dims,
                                 input_precision_bits=16,
@@ -1269,9 +1302,23 @@ class NeuroMCEnergyProfiler:
                     counts["add"] = 0
                     counts["mul"] = 0
         elif fragment.process_key == "with_opt":
-            counts["add"] += 8 * kt + 4 * fyfxkc
-            counts["mul"] += 22 * kt + 11 * fyfxkc
-            counts["sqrt"] += 2 * kt + fyfxkc
+            if fragment.op_name in {"adam", "adamw"}:
+                counts["add"] += 8 * kt + 4 * fyfxkc
+                counts["mul"] += 22 * kt + 11 * fyfxkc
+                counts["sqrt"] += 2 * kt + fyfxkc
+            elif fragment.op_name == "sgd":
+                total_params = _optimizer_param_count(fragment)
+                counts["add"] += total_params
+                counts["mul"] += total_params
+                if fragment.optimizer_has_weight_decay:
+                    counts["add"] += total_params
+                    counts["mul"] += total_params
+                if (
+                    fragment.optimizer_has_momentum
+                    and fragment.optimizer_has_momentum_buffer
+                ):
+                    counts["add"] += total_params
+                    counts["mul"] += total_params
         return counts
 
     def _memory_energy_per_element(
@@ -1315,7 +1362,8 @@ class NeuroMCEnergyProfiler:
         totals = defaultdict(lambda: defaultdict(int))
         energy = defaultdict(lambda: defaultdict(float))
         if (
-            fragment.core_type not in {"fp_soma", "bp_grad", "wg"}
+            fragment.core_type
+            not in {"fp_soma", "bp_grad", "wg", "ann_fe", "ann_be", "ann_we"}
             or fragment.mac_count == 0
         ):
             return totals, energy
@@ -1328,7 +1376,14 @@ class NeuroMCEnergyProfiler:
                 cfg["sram_fp_conv_in_w"],
                 cfg["sram_fp_conv_out_xi"],
             )
-        elif fragment.core_type == "bp_grad":
+        elif fragment.core_type == "ann_fe":
+            reg_i1, reg_i2, reg_o = cfg["reg_16b"], cfg["reg_16b"], cfg["reg_16b"]
+            sram_i1, sram_i2, sram_o = (
+                cfg["sram_fp_conv_in_w"],
+                cfg["sram_fp_conv_in_w"],
+                cfg["sram_fp_conv_out_xi"],
+            )
+        elif fragment.core_type in {"bp_grad", "ann_be"}:
             reg_i1, reg_i2, reg_o = cfg["reg_16b"], cfg["reg_16b"], cfg["reg_16b"]
             sram_i1, sram_i2, sram_o = (
                 cfg["sram_bp_conv_in_du"],
@@ -1336,12 +1391,24 @@ class NeuroMCEnergyProfiler:
                 cfg["sram_bp_conv_out_res"],
             )
         else:
-            reg_i1, reg_i2, reg_o = cfg["reg_1b"], cfg["reg_16b"], cfg["reg_16b"]
-            sram_i1, sram_i2, sram_o = (
-                cfg["sram_wg_conv_in_s"],
-                cfg["sram_wg_conv_in_du"],
-                cfg["sram_wg_conv_out_dw"],
-            )
+            if fragment.core_type == "ann_we":
+                reg_i1, reg_i2, reg_o = (
+                    cfg["reg_16b"],
+                    cfg["reg_16b"],
+                    cfg["reg_16b"],
+                )
+                sram_i1, sram_i2, sram_o = (
+                    cfg["sram_wg_conv_in_du"],
+                    cfg["sram_wg_conv_in_du"],
+                    cfg["sram_wg_conv_out_dw"],
+                )
+            else:
+                reg_i1, reg_i2, reg_o = cfg["reg_1b"], cfg["reg_16b"], cfg["reg_16b"]
+                sram_i1, sram_i2, sram_o = (
+                    cfg["sram_wg_conv_in_s"],
+                    cfg["sram_wg_conv_in_du"],
+                    cfg["sram_wg_conv_out_dw"],
+                )
 
         i1_bits = fragment.input_numel * fragment.input_precision_bits
         i2_bits = fragment.weight_numel * fragment.weight_precision_bits
@@ -1421,6 +1488,64 @@ class NeuroMCEnergyProfiler:
 
         cfg = self.memory_config.memory_instances
         ld = fragment.loop_dims
+        if fragment.process_key == "with_opt" and fragment.op_name == "sgd":
+            total_params = _optimizer_param_count(fragment)
+            total_bits = total_params * 32
+            sram_spec = cfg["sram_6MB"]
+            self._accumulate_memory(
+                totals,
+                energy,
+                "sram",
+                "rh2l",
+                total_bits,
+                sram_spec,
+                32,
+                True,
+            )
+            self._accumulate_memory(
+                totals,
+                energy,
+                "sram",
+                "rh2l",
+                total_bits,
+                sram_spec,
+                32,
+                True,
+            )
+            self._accumulate_memory(
+                totals,
+                energy,
+                "sram",
+                "wl2h",
+                total_bits,
+                sram_spec,
+                32,
+                False,
+            )
+            if fragment.optimizer_has_momentum and fragment.optimizer_has_momentum_buffer:
+                self._accumulate_memory(
+                    totals,
+                    energy,
+                    "sram",
+                    "rh2l",
+                    total_bits,
+                    sram_spec,
+                    32,
+                    True,
+                )
+            if fragment.optimizer_has_momentum:
+                self._accumulate_memory(
+                    totals,
+                    energy,
+                    "sram",
+                    "wl2h",
+                    total_bits,
+                    sram_spec,
+                    32,
+                    False,
+                )
+            return totals, energy
+
         scalar_counts = {
             "OYOXKBT": ld["OY"] * ld["OX"] * ld["K"] * ld["B"] * ld["T"],
             "KT": ld["K"] if fragment.process_key == "with_opt" else ld["K"] * ld["T"],
@@ -1473,29 +1598,30 @@ class NeuroMCEnergyProfiler:
                 "bp_bn_du_l_pre2": ("OYOXCBT", 16, "reg_16b", "sram_2MB"),
             }
         elif fragment.process_key == "with_opt":
-            variables = {
-                "opt_y": ("KT", 32, "reg_32b", "sram_6MB"),
-                "opt_b": ("KT", 32, "reg_32b", "sram_6MB"),
-                "opt_w": ("FYFXKC", 32, "reg_32b", "sram_6MB"),
-                "opt_dy": ("KT", 32, "reg_32b", "sram_6MB"),
-                "opt_db": ("KT", 32, "reg_32b", "sram_6MB"),
-                "opt_dw": ("FYFXKC", 32, "reg_32b", "sram_6MB"),
-                "opt_v_y": ("KT", 32, "reg_32b", "sram_6MB"),
-                "opt_v_b": ("KT", 32, "reg_32b", "sram_6MB"),
-                "opt_v_w": ("FYFXKC", 32, "reg_32b", "sram_6MB"),
-                "opt_s_y": ("KT", 32, "reg_32b", "sram_6MB"),
-                "opt_s_b": ("KT", 32, "reg_32b", "sram_6MB"),
-                "opt_s_w": ("FYFXKC", 32, "reg_32b", "sram_6MB"),
-                "opt_vbc_y": ("KT", 32, "reg_32b", "sram_6MB"),
-                "opt_vbc_b": ("KT", 32, "reg_32b", "sram_6MB"),
-                "opt_vbc_w": ("FYFXKC", 32, "reg_32b", "sram_6MB"),
-                "opt_sbc_y": ("KT", 32, "reg_32b", "sram_6MB"),
-                "opt_sbc_b": ("KT", 32, "reg_32b", "sram_6MB"),
-                "opt_sbc_w": ("FYFXKC", 32, "reg_32b", "sram_6MB"),
-                "opt_y_updated": ("KT", 32, "reg_32b", "sram_6MB"),
-                "opt_b_updated": ("KT", 32, "reg_32b", "sram_6MB"),
-                "opt_w_updated": ("FYFXKC", 32, "reg_32b", "sram_6MB"),
-            }
+            if fragment.op_name in {"adam", "adamw"}:
+                variables = {
+                    "opt_y": ("KT", 32, "reg_32b", "sram_6MB"),
+                    "opt_b": ("KT", 32, "reg_32b", "sram_6MB"),
+                    "opt_w": ("FYFXKC", 32, "reg_32b", "sram_6MB"),
+                    "opt_dy": ("KT", 32, "reg_32b", "sram_6MB"),
+                    "opt_db": ("KT", 32, "reg_32b", "sram_6MB"),
+                    "opt_dw": ("FYFXKC", 32, "reg_32b", "sram_6MB"),
+                    "opt_v_y": ("KT", 32, "reg_32b", "sram_6MB"),
+                    "opt_v_b": ("KT", 32, "reg_32b", "sram_6MB"),
+                    "opt_v_w": ("FYFXKC", 32, "reg_32b", "sram_6MB"),
+                    "opt_s_y": ("KT", 32, "reg_32b", "sram_6MB"),
+                    "opt_s_b": ("KT", 32, "reg_32b", "sram_6MB"),
+                    "opt_s_w": ("FYFXKC", 32, "reg_32b", "sram_6MB"),
+                    "opt_vbc_y": ("KT", 32, "reg_32b", "sram_6MB"),
+                    "opt_vbc_b": ("KT", 32, "reg_32b", "sram_6MB"),
+                    "opt_vbc_w": ("FYFXKC", 32, "reg_32b", "sram_6MB"),
+                    "opt_sbc_y": ("KT", 32, "reg_32b", "sram_6MB"),
+                    "opt_sbc_b": ("KT", 32, "reg_32b", "sram_6MB"),
+                    "opt_sbc_w": ("FYFXKC", 32, "reg_32b", "sram_6MB"),
+                    "opt_y_updated": ("KT", 32, "reg_32b", "sram_6MB"),
+                    "opt_b_updated": ("KT", 32, "reg_32b", "sram_6MB"),
+                    "opt_w_updated": ("FYFXKC", 32, "reg_32b", "sram_6MB"),
+                }
 
         for _, (count_key, bits_per_elem, reg_name, sram_name) in variables.items():
             total_bits = scalar_counts[count_key] * bits_per_elem
@@ -1522,24 +1648,34 @@ class NeuroMCEnergyProfiler:
             )
         return totals, energy
 
-    def _optimizer_fragment(self, stage: str) -> _Fragment:
-        if self._optimizer is None:
-            raise RuntimeError("Optimizer stage requires a bound optimizer.")
-        if not isinstance(self._optimizer, (torch.optim.Adam, torch.optim.AdamW)):
+    def _validate_sgd_group(self, group: dict[str, Any]) -> None:
+        if group.get("nesterov", False):
             raise ValueError(
-                "Exact NeuroMC optimizer modeling only supports Adam/AdamW; "
-                f"got {type(self._optimizer).__name__}."
+                "Exact NeuroMC SGD modeling currently supports only "
+                "nesterov=False."
             )
-        kt = 0
-        fyfxkc = 0
-        for group in self._optimizer.param_groups:
-            for p in group["params"]:
-                if p.grad is None:
-                    continue
-                if p.ndim <= 1:
-                    kt += int(p.numel())
-                else:
-                    fyfxkc += int(p.numel())
+        if float(group.get("dampening", 0.0)) != 0.0:
+            raise ValueError(
+                "Exact NeuroMC SGD modeling currently supports only "
+                "dampening=0."
+            )
+        if group.get("maximize", False):
+            raise ValueError(
+                "Exact NeuroMC SGD modeling currently supports only "
+                "maximize=False."
+            )
+
+    def _make_optimizer_fragment(
+        self,
+        *,
+        stage: str,
+        op_name: str,
+        kt: int,
+        fyfxkc: int,
+        optimizer_has_momentum: bool = False,
+        optimizer_has_weight_decay: bool = False,
+        optimizer_has_momentum_buffer: bool = False,
+    ) -> _Fragment:
         loop_dims = self._make_loop_dims(
             batch_size=1,
             channels_in=1,
@@ -1556,7 +1692,7 @@ class NeuroMCEnergyProfiler:
         return _Fragment(
             stage=stage,
             phase="optimizer",
-            op_name=type(self._optimizer).__name__.lower(),
+            op_name=op_name,
             core_type="bp_grad_opt",
             process_key="with_opt",
             loop_dims=loop_dims,
@@ -1568,7 +1704,89 @@ class NeuroMCEnergyProfiler:
             output_numel=kt + fyfxkc,
             mac_count=0,
             source="optimizer",
+            optimizer_has_momentum=optimizer_has_momentum,
+            optimizer_has_weight_decay=optimizer_has_weight_decay,
+            optimizer_has_momentum_buffer=optimizer_has_momentum_buffer,
         )
+
+    def _optimizer_fragments(self, stage: str) -> list[_Fragment]:
+        if self._optimizer is None:
+            raise RuntimeError("Optimizer stage requires a bound optimizer.")
+        if isinstance(self._optimizer, (torch.optim.Adam, torch.optim.AdamW)):
+            kt = 0
+            fyfxkc = 0
+            for group in self._optimizer.param_groups:
+                for p in group["params"]:
+                    if p.grad is None:
+                        continue
+                    if p.ndim <= 1:
+                        kt += int(p.numel())
+                    else:
+                        fyfxkc += int(p.numel())
+            return [
+                self._make_optimizer_fragment(
+                    stage=stage,
+                    op_name=type(self._optimizer).__name__.lower(),
+                    kt=kt,
+                    fyfxkc=fyfxkc,
+                )
+            ]
+        if isinstance(self._optimizer, torch.optim.SGD):
+            buckets: dict[tuple[bool, bool, bool, str], int] = defaultdict(int)
+            for group in self._optimizer.param_groups:
+                self._validate_sgd_group(group)
+                has_momentum = float(group.get("momentum", 0.0)) > 0.0
+                has_weight_decay = float(group.get("weight_decay", 0.0)) > 0.0
+                for p in group["params"]:
+                    if p.grad is None:
+                        continue
+                    bucket_name = "kt" if p.ndim <= 1 else "fyfxkc"
+                    has_momentum_buffer = (
+                        has_momentum and "momentum_buffer" in self._optimizer.state[p]
+                    )
+                    buckets[
+                        (
+                            has_momentum,
+                            has_weight_decay,
+                            has_momentum_buffer,
+                            bucket_name,
+                        )
+                    ] += int(p.numel())
+            fragments = []
+            for (
+                has_momentum,
+                has_weight_decay,
+                has_momentum_buffer,
+                bucket_name,
+            ), count in buckets.items():
+                if count <= 0:
+                    continue
+                fragments.append(
+                    self._make_optimizer_fragment(
+                        stage=stage,
+                        op_name="sgd",
+                        kt=count if bucket_name == "kt" else 0,
+                        fyfxkc=count if bucket_name == "fyfxkc" else 0,
+                        optimizer_has_momentum=has_momentum,
+                        optimizer_has_weight_decay=has_weight_decay,
+                        optimizer_has_momentum_buffer=has_momentum_buffer,
+                    )
+                )
+            return fragments
+        raise ValueError(
+            "Exact NeuroMC optimizer modeling only supports Adam/AdamW and "
+            "common SGD (nesterov=False, dampening=0, maximize=False); "
+            f"got {type(self._optimizer).__name__}."
+        )
+
+    def _optimizer_fragment(self, stage: str) -> _Fragment:
+        fragments = self._optimizer_fragments(stage)
+        if len(fragments) != 1:
+            raise RuntimeError(
+                "Optimizer expands to multiple NeuroMC fragments; use "
+                "_optimizer_fragments() instead."
+            )
+        return fragments[0]
 
     def get_report(self) -> NeuroMCRuntimeEnergyReport:
         fragments = list(self._fragments)
@@ -1681,11 +1899,17 @@ class NeuroMCEnergyProfiler:
                     "op_name": fragment.op_name,
                     "core_type": fragment.core_type,
                     "process_key": fragment.process_key,
+                    "input_precision_bits": fragment.input_precision_bits,
+                    "weight_precision_bits": fragment.weight_precision_bits,
+                    "output_precision_bits": fragment.output_precision_bits,
                     "loop_dims": dict(fragment.loop_dims),
                     "b_type": fragment.b_type,
                     "t_type": fragment.t_type,
                     "mac_count": fragment.mac_count,
                     "source": fragment.source,
+                    "optimizer_has_momentum": fragment.optimizer_has_momentum,
+                    "optimizer_has_weight_decay": fragment.optimizer_has_weight_decay,
+                    "optimizer_has_momentum_buffer": fragment.optimizer_has_momentum_buffer,
                 }
             )
 
@@ -1758,7 +1982,7 @@ class NeuroMCEnergyProfiler:
         }
 
     def record_optimizer_step(self, stage: str = "optimizer") -> None:
-        self._fragments.append(self._optimizer_fragment(stage))
+        self._fragments.extend(self._optimizer_fragments(stage))
 
 
 def estimate_neuromc_runtime_energy(

--- a/spikingjelly/activation_based/op_counter/neuromc/core.py
+++ b/spikingjelly/activation_based/op_counter/neuromc/core.py
@@ -318,10 +318,6 @@ def _optimizer_param_count(fragment: _Fragment) -> int:
     )
 
 
-def _optimizer_count_key(fragment: _Fragment) -> str:
-    return "KT" if fragment.loop_dims["K"] > 0 else "FYFXKC"
-
-
 def _resolve_loss_fn(loss_fn: Callable | None):
     if loss_fn is None:
         return None
@@ -693,7 +689,7 @@ class NeuroMCEnergyProfiler:
     def _make_bn_forward_fragment(
         self, stage: str, module: nn.Module | None, x, out
     ) -> _Fragment:
-        is_spike_input = _is_spike(x)
+        is_spike_input = _is_spike_like(x)
         t, batch, c, spatial = _tensor_layout(x, module)
         spatial_prod = max(_prod(spatial), 1) if spatial else 1
         loop_dims = self._make_loop_dims(
@@ -1176,20 +1172,23 @@ class NeuroMCEnergyProfiler:
                     else:
                         forward_key = (op, _shape_tuple(out), _shape_tuple(x))
                         is_spike_input = False
-                        if gemm_forward_is_spike[forward_key]:
-                            is_spike_input = gemm_forward_is_spike[forward_key].pop()
+                        forward_queue = gemm_forward_is_spike.get(forward_key)
+                        if forward_queue:
+                            is_spike_input = forward_queue.pop()
                         elif op == "aten.addmm.default":
                             alt_key = ("aten.mm.default", _shape_tuple(out), _shape_tuple(x))
-                            if gemm_forward_is_spike[alt_key]:
-                                is_spike_input = gemm_forward_is_spike[alt_key].pop()
+                            alt_queue = gemm_forward_is_spike.get(alt_key)
+                            if alt_queue:
+                                is_spike_input = alt_queue.pop()
                         elif op == "aten.mm.default":
                             alt_key = (
                                 "aten.addmm.default",
                                 _shape_tuple(out),
                                 _shape_tuple(x),
                             )
-                            if gemm_forward_is_spike[alt_key]:
-                                is_spike_input = gemm_forward_is_spike[alt_key].pop()
+                            alt_queue = gemm_forward_is_spike.get(alt_key)
+                            if alt_queue:
+                                is_spike_input = alt_queue.pop()
                         # Missing forward provenance should bias toward the denser,
                         # more expensive path instead of undercounting energy.
                         batch = (

--- a/test/activation_based/test_op_counter_neuromc_runtime.py
+++ b/test/activation_based/test_op_counter_neuromc_runtime.py
@@ -170,7 +170,7 @@ def test_neuromc_exact_online_learning_optimizer_step_each_time_step():
     with op_counter.NeuroMCEnergyProfiler() as profiler:
         profiler.bind_model(model)
         profiler.bind_optimizer(optimizer)
-        for t, (x, target) in enumerate(zip(xs, targets)):
+        for t, (x, target) in enumerate(zip(xs, targets, strict=True)):
             with profiler.stage(f"t{t}_forward"):
                 out = model(x)
             with profiler.suspend():

--- a/test/activation_based/test_op_counter_neuromc_runtime.py
+++ b/test/activation_based/test_op_counter_neuromc_runtime.py
@@ -55,7 +55,7 @@ def test_neuromc_exact_batchnorm_supports_bn_breakdown():
 
     report = op_counter.estimate_neuromc_runtime_energy(model, x)
 
-    assert report.energy_by_core_type["fp_bn"] > 0.0
+    assert report.energy_by_core_type["ann_bn"] > 0.0
     assert report.energy_by_process_key["with_bn"] > 0.0
     assert report.counts_by_process_key["with_bn"]["sqrt"] > 0
 
@@ -81,6 +81,23 @@ def test_neuromc_exact_training_uses_bp_wg_and_optimizer():
     assert sum(report.energy_by_stage.values()) == pytest.approx(report.energy_total_pj)
 
 
+def _optimizer_fragment_totals(profiler, fragments):
+    total_add = 0
+    total_mul = 0
+    total_sqrt = 0
+    total_rh2l = 0
+    total_wl2h = 0
+    for fragment in fragments:
+        counts = profiler._extra_counts(fragment)
+        bits, _ = profiler._extra_memory_for_fragment(fragment)
+        total_add += counts["add"]
+        total_mul += counts["mul"]
+        total_sqrt += counts["sqrt"]
+        total_rh2l += bits["sram"].get("rh2l", 0)
+        total_wl2h += bits["sram"].get("wl2h", 0)
+    return total_add, total_mul, total_sqrt, total_rh2l, total_wl2h
+
+
 def test_neuromc_exact_repeated_forward_reuses_weights():
     model = nn.Linear(16, 8, bias=False)
     x = (torch.rand(4, 16) > 0.75).float()
@@ -97,17 +114,129 @@ def test_neuromc_exact_repeated_forward_reuses_weights():
     assert any(item["t_type"] == 1 for item in report.mapping_summary)
 
 
-def test_neuromc_exact_sgd_optimizer_is_rejected():
+def test_neuromc_exact_plain_sgd_optimizer_is_supported():
     model = nn.Linear(4, 2)
     optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
     loss_fn = nn.MSELoss()
     x = (torch.rand(2, 4) > 0.5).float()
     target = torch.randn(2, 2)
 
-    with pytest.raises(ValueError, match="Adam/AdamW"):
-        op_counter.estimate_neuromc_runtime_energy(
-            model, x, target=target, loss_fn=loss_fn, optimizer=optimizer
-        )
+    report = op_counter.estimate_neuromc_runtime_energy(
+        model, x, target=target, loss_fn=loss_fn, optimizer=optimizer
+    )
+
+    assert report.energy_by_stage["optimizer"] > 0.0
+    assert report.energy_by_core_type["bp_grad_opt"] > 0.0
+    assert report.energy_by_process_key["with_opt"] > 0.0
+    assert any(
+        item["source"] == "optimizer"
+        and item["op_name"] == "sgd"
+        and item["optimizer_has_momentum"] is False
+        and item["optimizer_has_weight_decay"] is False
+        for item in report.mapping_summary
+    )
+
+
+def test_neuromc_exact_sgd_with_momentum_and_weight_decay_is_supported():
+    model = nn.Linear(4, 2)
+    optimizer = torch.optim.SGD(
+        model.parameters(), lr=0.1, momentum=0.9, weight_decay=0.01
+    )
+    loss_fn = nn.MSELoss()
+    x = (torch.rand(2, 4) > 0.5).float()
+    target = torch.randn(2, 2)
+
+    report = op_counter.estimate_neuromc_runtime_energy(
+        model, x, target=target, loss_fn=loss_fn, optimizer=optimizer
+    )
+
+    assert report.energy_by_stage["optimizer"] > 0.0
+    assert any(
+        item["source"] == "optimizer"
+        and item["op_name"] == "sgd"
+        and item["optimizer_has_momentum"] is True
+        and item["optimizer_has_weight_decay"] is True
+        for item in report.mapping_summary
+    )
+
+
+def test_neuromc_exact_online_learning_optimizer_step_each_time_step():
+    model = nn.Linear(4, 2)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
+    loss_fn = nn.MSELoss()
+    xs = [torch.randn(3, 4), torch.randn(3, 4)]
+    targets = [torch.randn(3, 2), torch.randn(3, 2)]
+
+    with op_counter.NeuroMCEnergyProfiler() as profiler:
+        profiler.bind_model(model)
+        profiler.bind_optimizer(optimizer)
+        for t, (x, target) in enumerate(zip(xs, targets)):
+            with profiler.stage(f"t{t}_forward"):
+                out = model(x)
+            with profiler.suspend():
+                loss = loss_fn(out, target)
+            with profiler.stage(f"t{t}_backward"):
+                loss.backward()
+            with profiler.stage(f"t{t}_optimizer"):
+                profiler.record_optimizer_step(f"t{t}_optimizer")
+                with profiler.suspend():
+                    optimizer.step()
+                    optimizer.zero_grad(set_to_none=True)
+        report = profiler.get_report()
+
+    optimizer_items = [
+        item for item in report.mapping_summary if item["source"] == "optimizer"
+    ]
+    assert report.energy_by_stage["t0_optimizer"] > 0.0
+    assert report.energy_by_stage["t1_optimizer"] > 0.0
+    assert {item["stage"] for item in optimizer_items} == {
+        "t0_optimizer",
+        "t1_optimizer",
+    }
+    assert any(
+        item["stage"] == "t0_optimizer"
+        and item["op_name"] == "sgd"
+        and item["optimizer_has_momentum"] is True
+        and item["optimizer_has_momentum_buffer"] is False
+        for item in optimizer_items
+    )
+    assert any(
+        item["stage"] == "t1_optimizer"
+        and item["op_name"] == "sgd"
+        and item["optimizer_has_momentum"] is True
+        and item["optimizer_has_momentum_buffer"] is True
+        for item in optimizer_items
+    )
+
+
+def test_neuromc_exact_sgd_optimizer_rejects_nesterov():
+    model = nn.Linear(4, 2)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9, nesterov=True)
+    profiler = op_counter.NeuroMCEnergyProfiler()
+    profiler.bind_optimizer(optimizer)
+
+    with pytest.raises(ValueError, match="nesterov=False"):
+        profiler._optimizer_fragments("optimizer")
+
+
+def test_neuromc_exact_sgd_optimizer_rejects_dampening():
+    model = nn.Linear(4, 2)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9, dampening=0.1)
+    profiler = op_counter.NeuroMCEnergyProfiler()
+    profiler.bind_optimizer(optimizer)
+
+    with pytest.raises(ValueError, match="dampening=0"):
+        profiler._optimizer_fragments("optimizer")
+
+
+def test_neuromc_exact_sgd_optimizer_rejects_maximize():
+    model = nn.Linear(4, 2)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1, maximize=True)
+    profiler = op_counter.NeuroMCEnergyProfiler()
+    profiler.bind_optimizer(optimizer)
+
+    with pytest.raises(ValueError, match="maximize=False"):
+        profiler._optimizer_fragments("optimizer")
 
 
 def test_neuromc_exact_unsupported_op_raises():
@@ -175,6 +304,56 @@ def test_neuromc_exact_functional_mm_backward_has_wg_fragment():
     assert report.energy_by_core_type.get("wg", 0.0) > 0.0
 
 
+def test_neuromc_exact_dense_functional_mm_backward_uses_ann_paths():
+    class FunctionalMM(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.randn(3, 5))
+
+        def forward(self, x):
+            return torch.mm(x, self.weight)
+
+    model = FunctionalMM()
+    x = torch.randn(4, 3, requires_grad=True)
+    target = torch.randn(4, 5)
+    loss_fn = nn.MSELoss()
+
+    report = op_counter.estimate_neuromc_runtime_energy(
+        model, x, target=target, loss_fn=loss_fn
+    )
+
+    assert report.energy_by_core_type.get("ann_be", 0.0) > 0.0
+    assert report.energy_by_core_type.get("ann_we", 0.0) > 0.0
+
+
+def test_neuromc_exact_same_shape_functional_mm_backward_keeps_spike_and_ann_labels():
+    class DualFunctionalMM(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight_dense = nn.Parameter(torch.randn(3, 5))
+            self.weight_spike = nn.Parameter(torch.randn(3, 5))
+
+        def forward(self, x_dense, x_spike):
+            return torch.mm(x_dense, self.weight_dense) + torch.mm(
+                x_spike, self.weight_spike
+            )
+
+    model = DualFunctionalMM()
+    x_dense = torch.randn(4, 3, requires_grad=True)
+    x_spike = (torch.rand(4, 3) > 0.7).float().requires_grad_()
+    target = torch.randn(4, 5)
+    loss_fn = nn.MSELoss()
+
+    report = op_counter.estimate_neuromc_runtime_energy(
+        model, (x_dense, x_spike), target=target, loss_fn=loss_fn
+    )
+
+    assert report.energy_by_core_type.get("ann_be", 0.0) > 0.0
+    assert report.energy_by_core_type.get("bp_grad", 0.0) > 0.0
+    assert report.energy_by_core_type.get("ann_we", 0.0) > 0.0
+    assert report.energy_by_core_type.get("wg", 0.0) > 0.0
+
+
 def test_neuromc_exact_mixed_hook_and_functional_mm_counts_both_paths():
     class MixedModel(nn.Module):
         def __init__(self):
@@ -217,6 +396,202 @@ def test_neuromc_exact_mixed_hook_and_functional_addmm_counts_both_paths():
     assert any(item["op_name"] == "linear.forward" for item in report.mapping_summary)
     assert any(
         item["op_name"] == "aten.addmm.default" for item in report.mapping_summary
+    )
+
+
+def test_neuromc_exact_dense_linear_uses_ann_forward_path():
+    model = nn.Linear(8, 4, bias=False)
+    x = torch.randn(3, 8)
+
+    report = op_counter.estimate_neuromc_runtime_energy(model, x)
+
+    assert report.energy_by_core_type["ann_fe"] > 0.0
+    assert report.energy_base_memory_pj > 0.0
+    assert any(
+        item["op_name"] == "linear.forward"
+        and item["core_type"] == "ann_fe"
+        and item["input_precision_bits"] == 16
+        for item in report.mapping_summary
+    )
+
+
+def test_neuromc_exact_dense_conv2d_uses_ann_forward_path():
+    model = nn.Conv2d(2, 3, kernel_size=3, padding=1, bias=False)
+    x = torch.randn(4, 2, 5, 5)
+
+    report = op_counter.estimate_neuromc_runtime_energy(model, x)
+
+    assert report.energy_by_core_type["ann_fe"] > 0.0
+    assert report.energy_base_memory_pj > 0.0
+    assert any(
+        item["op_name"] == "conv.forward"
+        and item["core_type"] == "ann_fe"
+        and item["input_precision_bits"] == 16
+        for item in report.mapping_summary
+    )
+
+
+def test_neuromc_exact_dense_training_uses_ann_backward_paths():
+    model = nn.Linear(8, 4, bias=False)
+    x = torch.randn(3, 8, requires_grad=True)
+    target = torch.randn(3, 4)
+    loss_fn = nn.MSELoss()
+
+    report = op_counter.estimate_neuromc_runtime_energy(
+        model, x, target=target, loss_fn=loss_fn
+    )
+
+    assert report.energy_by_core_type["ann_fe"] > 0.0
+    assert report.energy_by_core_type["ann_be"] > 0.0
+    assert report.energy_by_core_type["ann_we"] > 0.0
+
+
+def test_neuromc_exact_dense_conv2d_backward_uses_ann_paths():
+    model = nn.Conv2d(2, 3, kernel_size=3, padding=1, bias=False)
+    x = torch.randn(3, 2, 5, 5)
+    grad_in = torch.randn_like(x)
+    grad_out = torch.randn(3, 3, 5, 5)
+    profiler = op_counter.NeuroMCEnergyProfiler()
+
+    model._neuromc_last_input = x
+    fragments = profiler._make_conv_backward_fragments(
+        "backward", model, (grad_in,), (grad_out,)
+    )
+
+    assert {fragment.core_type for fragment in fragments} == {"ann_be", "ann_we"}
+    assert all(fragment.input_precision_bits == 16 for fragment in fragments)
+
+
+def test_neuromc_exact_dense_weight_grad_costs_more_than_spike_weight_grad():
+    torch.manual_seed(0)
+    model_spike = nn.Linear(8, 4, bias=False)
+    x_spike = (torch.rand(3, 8) > 0.6).float().requires_grad_()
+    target_spike = torch.randn(3, 4)
+    loss_fn = nn.MSELoss()
+    spike_report = op_counter.estimate_neuromc_runtime_energy(
+        model_spike, x_spike, target=target_spike, loss_fn=loss_fn
+    )
+
+    model_dense = nn.Linear(8, 4, bias=False)
+    x_dense = torch.randn(3, 8, requires_grad=True)
+    target_dense = torch.randn(3, 4)
+    dense_report = op_counter.estimate_neuromc_runtime_energy(
+        model_dense, x_dense, target=target_dense, loss_fn=loss_fn
+    )
+
+    assert spike_report.energy_by_core_type["wg"] > 0.0
+    assert dense_report.energy_by_core_type["ann_we"] > 0.0
+    assert (
+        dense_report.energy_by_core_type["ann_we"]
+        > spike_report.energy_by_core_type["wg"]
+    )
+
+
+def test_neuromc_exact_dense_batchnorm_training_uses_ann_bn_labels():
+    model = nn.Sequential(nn.Linear(8, 8), nn.BatchNorm1d(8))
+    x = torch.randn(4, 8, requires_grad=True)
+    target = torch.randn(4, 8)
+    loss_fn = nn.MSELoss()
+
+    report = op_counter.estimate_neuromc_runtime_energy(
+        model, x, target=target, loss_fn=loss_fn
+    )
+
+    assert report.energy_by_core_type["ann_bn"] > 0.0
+    assert report.energy_by_core_type["ann_bn_bp"] > 0.0
+    assert report.energy_by_process_key["with_bn"] > 0.0
+
+
+def test_neuromc_exact_dense_batchnorm2d_forward_uses_ann_bn_label():
+    model = nn.Sequential(nn.Conv2d(2, 4, kernel_size=3, padding=1), nn.BatchNorm2d(4))
+    x = torch.randn(2, 2, 5, 5)
+
+    report = op_counter.estimate_neuromc_runtime_energy(model, x)
+
+    assert report.energy_by_core_type["ann_bn"] > 0.0
+    assert any(
+        item["op_name"] == "bn.forward" and item["core_type"] == "ann_bn"
+        for item in report.mapping_summary
+    )
+
+
+def test_neuromc_exact_mixed_model_dense_bn_keeps_ann_label_before_spike_node():
+    model = nn.Sequential(nn.Linear(8, 8), nn.BatchNorm1d(8), neuron.IFNode())
+    x = torch.randn(3, 8)
+
+    report = op_counter.estimate_neuromc_runtime_energy(model, x)
+
+    assert report.energy_by_core_type["ann_bn"] > 0.0
+    assert not any(
+        item["op_name"] == "bn.forward" and item["core_type"] == "fp_bn"
+        for item in report.mapping_summary
+    )
+
+
+def test_neuromc_exact_mixed_model_reports_ann_and_snn_paths():
+    model = nn.Sequential(nn.Linear(8, 8), neuron.IFNode(), nn.Linear(8, 4))
+    x = torch.randn(3, 8)
+
+    report = op_counter.estimate_neuromc_runtime_energy(model, x)
+
+    assert report.energy_by_core_type["ann_fe"] > 0.0
+    assert report.energy_by_core_type["fp_soma"] > 0.0
+    assert any(
+        item["op_name"] == "linear.forward" and item["core_type"] == "ann_fe"
+        for item in report.mapping_summary
+    )
+    assert any(
+        item["op_name"] == "linear.forward" and item["core_type"] == "fp_soma"
+        for item in report.mapping_summary
+    )
+
+
+def test_neuromc_exact_dense_mixed_hook_and_functional_mm_use_ann_path():
+    class MixedModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(4, 4, bias=False)
+            self.weight = nn.Parameter(torch.randn(4, 3))
+
+        def forward(self, x):
+            return self.linear(x)[:, :3] + torch.mm(x, self.weight)
+
+    model = MixedModel()
+    x = torch.randn(5, 4)
+
+    report = op_counter.estimate_neuromc_runtime_energy(model, x)
+
+    expected_mac = 5 * 4 * 4 + 5 * 4 * 3
+    assert report.primitive_counts["totals"]["mac"] == expected_mac
+    assert report.counts_by_core_type["ann_fe"]["mac"] == expected_mac
+    assert any(
+        item["op_name"] == "aten.mm.default" and item["core_type"] == "ann_fe"
+        for item in report.mapping_summary
+    )
+
+
+def test_neuromc_exact_dense_mixed_hook_and_functional_addmm_use_ann_path():
+    class MixedModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(4, 4, bias=False)
+            self.bias = nn.Parameter(torch.randn(3))
+            self.weight = nn.Parameter(torch.randn(4, 3))
+
+        def forward(self, x):
+            return self.linear(x)[:, :3] + torch.addmm(self.bias, x, self.weight)
+
+    model = MixedModel()
+    x = torch.randn(5, 4)
+
+    report = op_counter.estimate_neuromc_runtime_energy(model, x)
+
+    expected_mac = 5 * 4 * 4 + 5 * 4 * 3
+    assert report.primitive_counts["totals"]["mac"] == expected_mac
+    assert report.counts_by_core_type["ann_fe"]["mac"] == expected_mac
+    assert any(
+        item["op_name"] == "aten.addmm.default" and item["core_type"] == "ann_fe"
+        for item in report.mapping_summary
     )
 
 
@@ -385,11 +760,12 @@ def test_neuromc_bind_model_rejects_rebinding_different_model():
         profiler.bind_model(model2)
 
 
-def test_neuromc_exact_ann_forward_input_is_rejected():
+def test_neuromc_exact_ann_forward_input_is_supported():
     model = nn.Linear(8, 4, bias=False)
     x = torch.randn(3, 8)
-    with pytest.raises(ValueError, match="ANN-like dense activations"):
-        op_counter.estimate_neuromc_runtime_energy(model, x)
+    report = op_counter.estimate_neuromc_runtime_energy(model, x)
+    assert report.energy_total_pj > 0.0
+    assert report.energy_by_core_type["ann_fe"] > 0.0
 
 
 def test_neuromc_exact_memory_config_api():
@@ -435,6 +811,154 @@ def test_neuromc_exact_optimizer_counts_mixed_parameter_shapes():
     assert bits["sram"]["wl2h"] == (14 * 3 + 7 * 6) * 32
 
 
+def test_neuromc_exact_sgd_optimizer_counts_plain_step():
+    model = nn.Linear(2, 3, bias=True)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    profiler = op_counter.NeuroMCEnergyProfiler()
+    profiler.bind_optimizer(optimizer)
+
+    model.weight.grad = torch.ones_like(model.weight)
+    model.bias.grad = torch.ones_like(model.bias)
+
+    fragments = profiler._optimizer_fragments("optimizer")
+    add, mul, sqrt, rh2l, wl2h = _optimizer_fragment_totals(profiler, fragments)
+
+    total_params = model.weight.numel() + model.bias.numel()
+    assert add == total_params
+    assert mul == total_params
+    assert sqrt == 0
+    assert rh2l == total_params * 2 * 32
+    assert wl2h == total_params * 32
+
+
+def test_neuromc_exact_sgd_optimizer_counts_weight_decay_only_step():
+    model = nn.Linear(2, 3, bias=True)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1, weight_decay=0.01)
+    profiler = op_counter.NeuroMCEnergyProfiler()
+    profiler.bind_optimizer(optimizer)
+
+    model.weight.grad = torch.ones_like(model.weight)
+    model.bias.grad = torch.ones_like(model.bias)
+
+    fragments = profiler._optimizer_fragments("optimizer")
+    add, mul, sqrt, rh2l, wl2h = _optimizer_fragment_totals(profiler, fragments)
+
+    total_params = model.weight.numel() + model.bias.numel()
+    assert add == total_params * 2
+    assert mul == total_params * 2
+    assert sqrt == 0
+    assert rh2l == total_params * 2 * 32
+    assert wl2h == total_params * 32
+
+
+def test_neuromc_exact_sgd_optimizer_counts_momentum_first_step():
+    model = nn.Linear(2, 3, bias=True)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
+    profiler = op_counter.NeuroMCEnergyProfiler()
+    profiler.bind_optimizer(optimizer)
+
+    model.weight.grad = torch.ones_like(model.weight)
+    model.bias.grad = torch.ones_like(model.bias)
+
+    fragments = profiler._optimizer_fragments("optimizer")
+    add, mul, sqrt, rh2l, wl2h = _optimizer_fragment_totals(profiler, fragments)
+
+    total_params = model.weight.numel() + model.bias.numel()
+    assert add == total_params
+    assert mul == total_params
+    assert sqrt == 0
+    assert rh2l == total_params * 2 * 32
+    assert wl2h == total_params * 2 * 32
+    assert any(
+        fragment.op_name == "sgd"
+        and fragment.optimizer_has_momentum
+        and not fragment.optimizer_has_momentum_buffer
+        for fragment in fragments
+    )
+
+
+def test_neuromc_exact_sgd_optimizer_counts_momentum_with_existing_buffer():
+    model = nn.Linear(2, 3, bias=True)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
+    profiler = op_counter.NeuroMCEnergyProfiler()
+    profiler.bind_optimizer(optimizer)
+
+    for param in model.parameters():
+        optimizer.state[param]["momentum_buffer"] = torch.ones_like(param)
+        param.grad = torch.ones_like(param)
+
+    fragments = profiler._optimizer_fragments("optimizer")
+    add, mul, sqrt, rh2l, wl2h = _optimizer_fragment_totals(profiler, fragments)
+
+    total_params = model.weight.numel() + model.bias.numel()
+    assert add == total_params * 2
+    assert mul == total_params * 2
+    assert sqrt == 0
+    assert rh2l == total_params * 3 * 32
+    assert wl2h == total_params * 2 * 32
+    assert all(
+        fragment.optimizer_has_momentum_buffer
+        for fragment in fragments
+        if fragment.op_name == "sgd"
+    )
+
+
+def test_neuromc_exact_sgd_optimizer_counts_momentum_and_weight_decay():
+    model = nn.Linear(2, 3, bias=True)
+    optimizer = torch.optim.SGD(
+        model.parameters(), lr=0.1, momentum=0.9, weight_decay=0.01
+    )
+    profiler = op_counter.NeuroMCEnergyProfiler()
+    profiler.bind_optimizer(optimizer)
+
+    for param in model.parameters():
+        optimizer.state[param]["momentum_buffer"] = torch.ones_like(param)
+        param.grad = torch.ones_like(param)
+
+    fragments = profiler._optimizer_fragments("optimizer")
+    add, mul, sqrt, rh2l, wl2h = _optimizer_fragment_totals(profiler, fragments)
+
+    total_params = model.weight.numel() + model.bias.numel()
+    assert add == total_params * 3
+    assert mul == total_params * 3
+    assert sqrt == 0
+    assert rh2l == total_params * 3 * 32
+    assert wl2h == total_params * 2 * 32
+
+
+def test_neuromc_exact_sgd_optimizer_counts_mixed_param_groups():
+    model = nn.Linear(2, 3, bias=True)
+    optimizer = torch.optim.SGD(
+        [
+            {"params": [model.bias], "lr": 0.1},
+            {
+                "params": [model.weight],
+                "lr": 0.1,
+                "momentum": 0.9,
+                "weight_decay": 0.01,
+            },
+        ]
+    )
+    profiler = op_counter.NeuroMCEnergyProfiler()
+    profiler.bind_optimizer(optimizer)
+
+    model.bias.grad = torch.ones_like(model.bias)
+    model.weight.grad = torch.ones_like(model.weight)
+    optimizer.state[model.weight]["momentum_buffer"] = torch.ones_like(model.weight)
+
+    fragments = profiler._optimizer_fragments("optimizer")
+    add, mul, sqrt, rh2l, wl2h = _optimizer_fragment_totals(profiler, fragments)
+
+    bias_numel = model.bias.numel()
+    weight_numel = model.weight.numel()
+    assert add == bias_numel + weight_numel * 3
+    assert mul == bias_numel + weight_numel * 3
+    assert sqrt == 0
+    assert rh2l == (bias_numel * 2 + weight_numel * 3) * 32
+    assert wl2h == (bias_numel + weight_numel * 2) * 32
+    assert len(fragments) == 2
+
+
 def test_neuromc_memory_residency_legacy_memory_config_alias():
     cfg = op_counter.MemoryHierarchyConfig.neuromc_like_v1()
     with pytest.deprecated_call():
@@ -451,9 +975,7 @@ def test_neuromc_memory_residency_legacy_memory_config_positional_alias():
 
 def test_neuromc_like_v1_legacy_memory_model_is_ignored():
     with pytest.deprecated_call():
-        cfg = op_counter.MemoryHierarchyConfig.neuromc_like_v1(
-            memory_model="weighted"
-        )
+        cfg = op_counter.MemoryHierarchyConfig.neuromc_like_v1(memory_model="weighted")
     cfg.validate()
 
 


### PR DESCRIPTION
## Summary
- Extend `neuromc` runtime energy statistics to be compatible with ANN, SNN, and hybrid models for forward/backward fragments.
- Add a dedicated ANN `core_type`, routing counting between `1-bit spike` and `16-bit dense` based on actual input activation type.
- Cover precise modeling of `BatchNorm`, functional GEMM fallback, and `SGD` (supporting `momentum` / `weight_decay`).
- Increase coverage of online learning scenarios, verifying that statistics can be properly accumulated at each time step when performing an immediate `optimizer step`.

## Testing
- Add and update `neuromc` runtime tests to cover ANN forward/backward, BN, functional fallback, diverse SGD configurations, and mixed model scenarios.
- Increase online learning integration tests, verifying the statistical behavior of `forward/backward/optimizer.step()` at each time step.
- Regression tests pass: `test_op_counter_neuromc_runtime.py` fully passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ANN core types to NeuroMC energy/runtime estimation and broader ANN/SNN mixed-model support
  * Added detailed SGD optimizer modeling (momentum, weight decay, per-time-step/online steps)

* **Improvements**
  * More accurate routing between spike and dense activations for forward/backward paths
  * Extended memory and compute modeling including optimizer SRAM accounting

* **Tests**
  * Expanded test coverage verifying ANN/SNN routing, BatchNorm behavior, dense-layer paths, and SGD fragment accounting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangwei123456/spikingjelly/pull/677)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->