### PR TITLE
Add a compute-only MAC/AC energy estimator with Horowitz presets

### DIFF
--- a/docs/source/APIs/spikingjelly.activation_based.op_counter.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.op_counter.rst
@@ -43,6 +43,14 @@ MAC / AC / SynOp Counters
    :undoc-members:
    :show-inheritance:
 
+Compute-Only Energy Estimator
++++++++++++++++++++++++++++++
+
+.. automodule:: spikingjelly.activation_based.op_counter.compute_energy
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 NeuroMC Energy Profiler
 +++++++++++++++++++++++++++
 

--- a/spikingjelly/activation_based/functional/misc.py
+++ b/spikingjelly/activation_based/functional/misc.py
@@ -242,7 +242,7 @@ def kaiming_normal_conv_linear_weight(net: nn.Module):
 
     * **中文**
 
-    使用kaiming normal初始化 ``net` `中的所有 :class:`torch.nn._ConvNd` 和 :class:`torch.nn.Linear` 的权重（不包括偏置项）。
+    使用kaiming normal初始化 ``net`` 中的所有 :class:`torch.nn._ConvNd` 和 :class:`torch.nn.Linear` 的权重（不包括偏置项）。
     参见 :class:`torch.nn.init.kaiming_normal_`。
 
     :param net: 任何属于 ``nn.Module`` 子类的网络

--- a/spikingjelly/activation_based/op_counter/__init__.py
+++ b/spikingjelly/activation_based/op_counter/__init__.py
@@ -7,6 +7,7 @@ from .neuron_state import *
 from .ac import *
 from .synop import *
 from .mac import *
+from .compute_energy import *
 from .neuromc import *
 from .spikesim import *
 from .analytical_energy import *

--- a/spikingjelly/activation_based/op_counter/_sparse_memory.py
+++ b/spikingjelly/activation_based/op_counter/_sparse_memory.py
@@ -18,11 +18,24 @@ __all__ = [
 
 def active_element_count(x: torch.Tensor) -> int:
     r"""
+    **API Language:**
+    :ref:`中文 <active_element_count-cn>` | :ref:`English <active_element_count-en>`
+
+    ----
+
+    .. _active_element_count-cn:
+
+    * **中文**
+
     :param x: 输入张量
     :type x: torch.Tensor
 
     :return: ``x`` 中非零元素的个数
     :rtype: int
+
+    ----
+
+    .. _active_element_count-en:
 
     * **English**
 
@@ -37,11 +50,24 @@ def active_element_count(x: torch.Tensor) -> int:
 
 def dense_bytes(x: torch.Tensor) -> int:
     r"""
+    **API Language:**
+    :ref:`中文 <dense_bytes-cn>` | :ref:`English <dense_bytes-en>`
+
+    ----
+
+    .. _dense_bytes-cn:
+
+    * **中文**
+
     :param x: 输入张量
     :type x: torch.Tensor
 
     :return: ``x`` 以密集格式存储所需的字节数，即 ``numel * element_size``
     :rtype: int
+
+    ----
+
+    .. _dense_bytes-en:
 
     * **English**
 
@@ -56,11 +82,24 @@ def dense_bytes(x: torch.Tensor) -> int:
 
 def sparse_bytes(x: torch.Tensor) -> int:
     r"""
+    **API Language:**
+    :ref:`中文 <sparse_bytes-cn>` | :ref:`English <sparse_bytes-en>`
+
+    ----
+
+    .. _sparse_bytes-cn:
+
+    * **中文**
+
     :param x: 输入张量
     :type x: torch.Tensor
 
     :return: ``x`` 以稀疏格式存储所需的字节数，即 ``active_elements * element_size``
     :rtype: int
+
+    ----
+
+    .. _sparse_bytes-en:
 
     * **English**
 
@@ -77,6 +116,15 @@ def is_sparse_access_tensor(
     x: torch.Tensor, *, zero_ratio_threshold: float = 0.5
 ) -> bool:
     r"""
+    **API Language:**
+    :ref:`中文 <is_sparse_access_tensor-cn>` | :ref:`English <is_sparse_access_tensor-en>`
+
+    ----
+
+    .. _is_sparse_access_tensor-cn:
+
+    * **中文**
+
     :param x: 输入张量
     :type x: torch.Tensor
 
@@ -86,6 +134,10 @@ def is_sparse_access_tensor(
 
     :return: 当 ``x`` 为零值比例高于 ``zero_ratio_threshold`` 的二元脉冲张量或稠密张量时返回 ``True``
     :rtype: bool
+
+    ----
+
+    .. _is_sparse_access_tensor-en:
 
     * **English**
 
@@ -113,11 +165,24 @@ def is_sparse_access_tensor(
 
 def dense_bytes_tree(tree: Any) -> int:
     r"""
+    **API Language:**
+    :ref:`中文 <dense_bytes_tree-cn>` | :ref:`English <dense_bytes_tree-en>`
+
+    ----
+
+    .. _dense_bytes_tree-cn:
+
+    * **中文**
+
     :param tree: 可能包含张量的嵌套容器（tuple / list / dict）
     :type tree: Any
 
     :return: 容器中所有张量的密集字节数之和
     :rtype: int
+
+    ----
+
+    .. _dense_bytes_tree-en:
 
     * **English**
 
@@ -138,6 +203,15 @@ def dense_bytes_tree(tree: Any) -> int:
 
 def sparse_bytes_tree(tree: Any, *, zero_ratio_threshold: float = 0.5) -> int:
     r"""
+    **API Language:**
+    :ref:`中文 <sparse_bytes_tree-cn>` | :ref:`English <sparse_bytes_tree-en>`
+
+    ----
+
+    .. _sparse_bytes_tree-cn:
+
+    * **中文**
+
     :param tree: 可能包含张量的嵌套容器（tuple / list / dict）
     :type tree: Any
 
@@ -147,6 +221,10 @@ def sparse_bytes_tree(tree: Any, *, zero_ratio_threshold: float = 0.5) -> int:
 
     :return: 容器中所有张量的稀疏字节数之和。对于稀疏张量，仅计算非零元素对应的字节数
     :rtype: int
+
+    ----
+
+    .. _sparse_bytes_tree-en:
 
     * **English**
 

--- a/spikingjelly/activation_based/op_counter/compute_energy.py
+++ b/spikingjelly/activation_based/op_counter/compute_energy.py
@@ -124,6 +124,9 @@ class ComputeEnergyConfig:
     Configuration for the compute-only MAC/AC energy profiler.
 
     The default ``cost_config`` matches ``ComputeEnergyCostConfig.fp32()``.
+    ``strict`` only applies to profiler-level validation added by this wrapper.
+    The internal ``DispatchCounterMode`` is intentionally kept non-strict because
+    it composes multiple specialized counters with non-identical rule coverage.
     """
 
     strict: bool = False
@@ -230,7 +233,7 @@ class ComputeEnergyProfiler:
                 self.synop_counter,
                 self.flop_counter,
             ],
-            strict=self.config.strict,
+            strict=False,
             verbose=self.config.verbose,
         )
 

--- a/spikingjelly/activation_based/op_counter/compute_energy.py
+++ b/spikingjelly/activation_based/op_counter/compute_energy.py
@@ -276,9 +276,8 @@ class ComputeEnergyProfiler:
     def get_total(self) -> float:
         return self.get_report().energy_total_pj
 
-    def get_counts(self) -> dict[str, Any]:
-        report = self.get_report()
-        return {"counts": report.counts}
+    def get_counts(self) -> dict[str, int]:
+        return self.get_report().counts
 
 
 def estimate_compute_energy(

--- a/spikingjelly/activation_based/op_counter/compute_energy.py
+++ b/spikingjelly/activation_based/op_counter/compute_energy.py
@@ -222,6 +222,7 @@ class ComputeEnergyProfiler:
     def __init__(self, *, config: ComputeEnergyConfig | None = None):
         self.config = copy.deepcopy(config or ComputeEnergyConfig())
         ignore_modules = list(self.config.extra_ignore_modules or [])
+        self._warnings: list[str] = []
         self.mac_counter = MACCounter(extra_ignore_modules=ignore_modules)
         self.ac_counter = ACCounter(extra_ignore_modules=ignore_modules)
         self.synop_counter = SynOpCounter(extra_ignore_modules=ignore_modules)
@@ -238,6 +239,7 @@ class ComputeEnergyProfiler:
         )
 
     def __enter__(self):
+        self._warnings.clear()
         self.mac_counter.reset()
         self.ac_counter.reset()
         self.synop_counter.reset()
@@ -253,7 +255,18 @@ class ComputeEnergyProfiler:
         ac = self.ac_counter.get_total()
         synop = self.synop_counter.get_total()
         flop = self.flop_counter.get_total()
+        total_count = mac + ac + synop + flop
         cost = self.config.cost_config
+
+        warnings_list = list(self._warnings)
+        if total_count == 0:
+            message = (
+                "ComputeEnergyProfiler recorded zero MAC/AC/SynOp/FLOP counts. "
+                "The model may not contain supported operators for this estimator."
+            )
+            if self.config.strict:
+                raise RuntimeError(message)
+            warnings_list.append(message)
 
         energy_mac_pj = mac * cost.e_mac_pj
         energy_ac_pj = ac * cost.e_ac_pj
@@ -273,7 +286,7 @@ class ComputeEnergyProfiler:
                 "synop": synop,
                 "flop": flop,
             },
-            warnings=[],
+            warnings=warnings_list,
         )
 
     def get_total(self) -> float:

--- a/spikingjelly/activation_based/op_counter/compute_energy.py
+++ b/spikingjelly/activation_based/op_counter/compute_energy.py
@@ -131,7 +131,7 @@ class ComputeEnergyConfig:
     cost_config: ComputeEnergyCostConfig = field(
         default_factory=ComputeEnergyCostConfig
     )
-    extra_ignore_modules: list[nn.Module] | None = None
+    extra_ignore_modules: list[type[nn.Module]] | None = None
 
 
 @dataclass
@@ -246,10 +246,10 @@ class ComputeEnergyProfiler:
         return self._dispatch_mode.__exit__(exc_type, exc, tb)
 
     def get_report(self) -> ComputeEnergyReport:
-        mac = int(self.mac_counter.get_total())
-        ac = int(self.ac_counter.get_total())
-        synop = int(self.synop_counter.get_total())
-        flop = int(self.flop_counter.get_total())
+        mac = self.mac_counter.get_total()
+        ac = self.ac_counter.get_total()
+        synop = self.synop_counter.get_total()
+        flop = self.flop_counter.get_total()
         cost = self.config.cost_config
 
         energy_mac_pj = mac * cost.e_mac_pj

--- a/spikingjelly/activation_based/op_counter/compute_energy.py
+++ b/spikingjelly/activation_based/op_counter/compute_energy.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch.nn as nn
+
+from .ac import ACCounter
+from .base import DispatchCounterMode
+from .flop import FlopCounter
+from .mac import MACCounter
+from .synop import SynOpCounter
+
+__all__ = [
+    "ComputeEnergyCostConfig",
+    "ComputeEnergyConfig",
+    "ComputeEnergyProfiler",
+    "ComputeEnergyReport",
+    "estimate_compute_energy",
+]
+
+
+def _call_model(model: nn.Module, inputs):
+    if isinstance(inputs, (tuple, list)):
+        return model(*inputs)
+    return model(inputs)
+
+
+@dataclass
+class ComputeEnergyCostConfig:
+    r"""
+    **API Language:**
+    :ref:`中文 <ComputeEnergyCostConfig-cn>` |
+    :ref:`English <ComputeEnergyCostConfig-en>`
+
+    ----
+
+    .. _ComputeEnergyCostConfig-cn:
+
+    * **中文**
+
+    仅计算 MAC/AC 的 compute-only 能耗模型成本配置。
+
+    默认值采用 SNN 文献中常见的 Horowitz 2014 口径：45nm、32-bit 浮点
+    ``E_MAC = 4.6 pJ``，``E_AC = 0.9 pJ``。
+
+    这是一个 cost-table-driven 的归一化模型。默认不会自动根据运行时
+    ``dtype`` 推断成本；如需切换口径，请显式使用 ``fp32()``, ``fp16()``,
+    ``int8()`` 等 preset。
+
+    ----
+
+    .. _ComputeEnergyCostConfig-en:
+
+    * **English**
+
+    Cost configuration for the compute-only MAC/AC energy model.
+
+    Defaults follow the widely used Horowitz 2014 reference costs for 45nm,
+    32-bit floating-point arithmetic: ``E_MAC = 4.6 pJ`` and
+    ``E_AC = 0.9 pJ``.
+
+    This is a normalized, cost-table-driven model. It does not automatically
+    infer energy costs from runtime ``dtype``; use explicit presets such as
+    ``fp32()``, ``fp16()``, or ``int8()`` when a different comparison regime is
+    desired.
+    """
+
+    e_mac_pj: float = 4.6
+    e_ac_pj: float = 0.9
+
+    @classmethod
+    def fp32(cls) -> "ComputeEnergyCostConfig":
+        r"""
+        Return the Horowitz 2014 45nm FP32 preset.
+        """
+        return cls(e_mac_pj=4.6, e_ac_pj=0.9)
+
+    @classmethod
+    def fp16(cls) -> "ComputeEnergyCostConfig":
+        r"""
+        Return the Horowitz 2014 45nm FP16 preset.
+
+        Uses ``FMult16 = 1.1 pJ`` and ``FAdd16 = 0.4 pJ``, so
+        ``E_MAC = 1.5 pJ`` and ``E_AC = 0.4 pJ``.
+        """
+        return cls(e_mac_pj=1.5, e_ac_pj=0.4)
+
+    @classmethod
+    def int8(cls) -> "ComputeEnergyCostConfig":
+        r"""
+        Return the Horowitz 2014 45nm INT8 preset.
+
+        Uses ``Mult8 = 0.2 pJ`` and ``Add8 = 0.03 pJ``, so
+        ``E_MAC = 0.23 pJ`` and ``E_AC = 0.03 pJ``.
+        """
+        return cls(e_mac_pj=0.23, e_ac_pj=0.03)
+
+
+@dataclass
+class ComputeEnergyConfig:
+    r"""
+    **API Language:**
+    :ref:`中文 <ComputeEnergyConfig-cn>` |
+    :ref:`English <ComputeEnergyConfig-en>`
+
+    ----
+
+    .. _ComputeEnergyConfig-cn:
+
+    * **中文**
+
+    控制 compute-only MAC/AC 能耗分析器行为的配置。
+
+    默认 ``cost_config`` 使用 ``ComputeEnergyCostConfig.fp32()`` 对应的口径。
+
+    ----
+
+    .. _ComputeEnergyConfig-en:
+
+    * **English**
+
+    Configuration for the compute-only MAC/AC energy profiler.
+
+    The default ``cost_config`` matches ``ComputeEnergyCostConfig.fp32()``.
+    """
+
+    strict: bool = False
+    verbose: bool = False
+    cost_config: ComputeEnergyCostConfig = field(
+        default_factory=ComputeEnergyCostConfig
+    )
+    extra_ignore_modules: list[nn.Module] | None = None
+
+
+@dataclass
+class ComputeEnergyReport:
+    r"""
+    **API Language:**
+    :ref:`中文 <ComputeEnergyReport-cn>` |
+    :ref:`English <ComputeEnergyReport-en>`
+
+    ----
+
+    .. _ComputeEnergyReport-cn:
+
+    * **中文**
+
+    compute-only MAC/AC 能耗报告。
+
+    该模型只考虑计算能耗，不包含访存、寻址、状态驻留等开销。主结果
+    ``energy_total_pj`` 由 ``MAC`` 和 ``AC`` 两部分组成。
+
+    ``SynOps`` 与 ``FLOPs`` 作为辅助统计返回，便于与现有 SNN/ANN 文献对齐，
+    但不参与主能耗计算。
+
+    该估计器面向“统一比较口径”，而不是对真实 kernel、混合精度累加路径或
+    特定硬件微架构做精确建模。
+
+    ----
+
+    .. _ComputeEnergyReport-en:
+
+    * **English**
+
+    Report for the compute-only MAC/AC energy model.
+
+    This model only accounts for arithmetic compute energy, excluding memory,
+    addressing, and state residency costs. The main result ``energy_total_pj``
+    consists of ``MAC`` and ``AC`` contributions only.
+
+    ``SynOps`` and ``FLOPs`` are returned as auxiliary counts for alignment
+    with existing SNN/ANN literature, but they do not contribute to the primary
+    energy estimate.
+
+    The estimator is intended as a normalized comparison regime rather than an
+    exact model of real kernels, mixed-precision accumulation paths, or a
+    specific hardware microarchitecture.
+    """
+
+    energy_total_pj: float
+    energy_mac_pj: float
+    energy_ac_pj: float
+    breakdown_pj: dict[str, float]
+    counts: dict[str, int]
+    warnings: list[str]
+
+
+class ComputeEnergyProfiler:
+    r"""
+    **API Language:**
+    :ref:`中文 <ComputeEnergyProfiler-cn>` |
+    :ref:`English <ComputeEnergyProfiler-en>`
+
+    ----
+
+    .. _ComputeEnergyProfiler-cn:
+
+    * **中文**
+
+    基于 public counter 组装的 compute-only MAC/AC 能耗分析器。
+
+    用法与其他能耗分析器一致：以 context manager 方式包住一次真实前向传播，
+    然后调用 ``get_report()``。
+
+    ----
+
+    .. _ComputeEnergyProfiler-en:
+
+    * **English**
+
+    Compute-only MAC/AC energy profiler composed from public counters.
+
+    Use it like the other energy profilers: wrap one real forward pass in the
+    context manager and call ``get_report()`` afterwards.
+    """
+
+    def __init__(self, *, config: ComputeEnergyConfig | None = None):
+        self.config = copy.deepcopy(config or ComputeEnergyConfig())
+        ignore_modules = list(self.config.extra_ignore_modules or [])
+        self.mac_counter = MACCounter(extra_ignore_modules=ignore_modules)
+        self.ac_counter = ACCounter(extra_ignore_modules=ignore_modules)
+        self.synop_counter = SynOpCounter(extra_ignore_modules=ignore_modules)
+        self.flop_counter = FlopCounter(extra_ignore_modules=ignore_modules)
+        self._dispatch_mode = DispatchCounterMode(
+            [
+                self.mac_counter,
+                self.ac_counter,
+                self.synop_counter,
+                self.flop_counter,
+            ],
+            strict=self.config.strict,
+            verbose=self.config.verbose,
+        )
+
+    def __enter__(self):
+        self.mac_counter.reset()
+        self.ac_counter.reset()
+        self.synop_counter.reset()
+        self.flop_counter.reset()
+        self._dispatch_mode.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return self._dispatch_mode.__exit__(exc_type, exc, tb)
+
+    def get_report(self) -> ComputeEnergyReport:
+        mac = int(self.mac_counter.get_total())
+        ac = int(self.ac_counter.get_total())
+        synop = int(self.synop_counter.get_total())
+        flop = int(self.flop_counter.get_total())
+        cost = self.config.cost_config
+
+        energy_mac_pj = mac * cost.e_mac_pj
+        energy_ac_pj = ac * cost.e_ac_pj
+        total_pj = energy_mac_pj + energy_ac_pj
+
+        return ComputeEnergyReport(
+            energy_total_pj=total_pj,
+            energy_mac_pj=energy_mac_pj,
+            energy_ac_pj=energy_ac_pj,
+            breakdown_pj={
+                "mac_pj": energy_mac_pj,
+                "ac_pj": energy_ac_pj,
+            },
+            counts={
+                "mac": mac,
+                "ac": ac,
+                "synop": synop,
+                "flop": flop,
+            },
+            warnings=[],
+        )
+
+    def get_total(self) -> float:
+        return self.get_report().energy_total_pj
+
+    def get_counts(self) -> dict[str, Any]:
+        report = self.get_report()
+        return {"counts": report.counts}
+
+
+def estimate_compute_energy(
+    model: nn.Module,
+    inputs,
+    *,
+    config: ComputeEnergyConfig | None = None,
+) -> ComputeEnergyReport:
+    r"""
+    **API Language:**
+    :ref:`中文 <estimate_compute_energy-cn>` |
+    :ref:`English <estimate_compute_energy-en>`
+
+    ----
+
+    .. _estimate_compute_energy-cn:
+
+    * **中文**
+
+    compute-only MAC/AC 能耗估计的便捷入口。该函数执行一次真实前向传播，
+    并返回总能耗与 MAC/AC 计数。
+
+    默认使用 Horowitz 2014 的 FP32 成本口径；若需要 FP16 或 INT8 比较，
+    请显式传入对应 preset。
+
+    :param model: 待统计模型
+    :param inputs: 模型输入；若为 tuple/list 则按 ``model(*inputs)`` 调用
+    :param config: compute-only 能耗配置
+
+    ----
+
+    .. _estimate_compute_energy-en:
+
+    * **English**
+
+    Convenience entry for compute-only MAC/AC energy estimation.
+    It runs one real forward pass and returns the energy report.
+
+    The default comparison regime is Horowitz 2014 FP32. For FP16 or INT8
+    comparisons, pass an explicit preset cost configuration.
+
+    :param model: model to profile
+    :param inputs: model input; tuple/list will be passed as ``model(*inputs)``
+    :param config: compute-only energy configuration
+    """
+    profiler = ComputeEnergyProfiler(config=config)
+    with profiler:
+        _ = _call_model(model, inputs)
+    return profiler.get_report()

--- a/spikingjelly/activation_based/op_counter/compute_energy.py
+++ b/spikingjelly/activation_based/op_counter/compute_energy.py
@@ -255,13 +255,18 @@ class ComputeEnergyProfiler:
         ac = self.ac_counter.get_total()
         synop = self.synop_counter.get_total()
         flop = self.flop_counter.get_total()
-        total_count = mac + ac + synop + flop
         cost = self.config.cost_config
 
         warnings_list = list(self._warnings)
-        if total_count == 0:
+        matched_supported_ops = (
+            len(self.mac_counter.get_counts().get("Global", {}))
+            + len(self.ac_counter.get_counts().get("Global", {}))
+            + len(self.synop_counter.get_counts().get("Global", {}))
+            + len(self.flop_counter.get_counts().get("Global", {}))
+        )
+        if matched_supported_ops == 0:
             message = (
-                "ComputeEnergyProfiler recorded zero MAC/AC/SynOp/FLOP counts. "
+                "ComputeEnergyProfiler did not match any supported operators. "
                 "The model may not contain supported operators for this estimator."
             )
             if self.config.strict:

--- a/spikingjelly/activation_based/op_counter/compute_energy.py
+++ b/spikingjelly/activation_based/op_counter/compute_energy.py
@@ -24,6 +24,8 @@ __all__ = [
 def _call_model(model: nn.Module, inputs):
     if isinstance(inputs, (tuple, list)):
         return model(*inputs)
+    if isinstance(inputs, dict):
+        return model(**inputs)
     return model(inputs)
 
 
@@ -222,7 +224,6 @@ class ComputeEnergyProfiler:
     def __init__(self, *, config: ComputeEnergyConfig | None = None):
         self.config = copy.deepcopy(config or ComputeEnergyConfig())
         ignore_modules = list(self.config.extra_ignore_modules or [])
-        self._warnings: list[str] = []
         self.mac_counter = MACCounter(extra_ignore_modules=ignore_modules)
         self.ac_counter = ACCounter(extra_ignore_modules=ignore_modules)
         self.synop_counter = SynOpCounter(extra_ignore_modules=ignore_modules)
@@ -239,7 +240,6 @@ class ComputeEnergyProfiler:
         )
 
     def __enter__(self):
-        self._warnings.clear()
         self.mac_counter.reset()
         self.ac_counter.reset()
         self.synop_counter.reset()
@@ -257,7 +257,7 @@ class ComputeEnergyProfiler:
         flop = self.flop_counter.get_total()
         cost = self.config.cost_config
 
-        warnings_list = list(self._warnings)
+        warnings_list: list[str] = []
         matched_supported_ops = (
             len(self.mac_counter.get_counts().get("Global", {}))
             + len(self.ac_counter.get_counts().get("Global", {}))

--- a/spikingjelly/activation_based/op_counter/memory_residency.py
+++ b/spikingjelly/activation_based/op_counter/memory_residency.py
@@ -552,7 +552,7 @@ class MemoryResidencyCounter(BaseCounter):
         config: Any | None = None,
         capacity_bits: dict[str, float] | None = None,
         extra_rules: dict[Any, Callable] | None = None,
-        extra_ignore_modules: list[nn.Module] | None = None,
+        extra_ignore_modules: list[type[nn.Module]] | None = None,
     ):
         r"""
         **API Language:**
@@ -578,8 +578,8 @@ class MemoryResidencyCounter(BaseCounter):
             键为 aten 操作，值为 ``(args, kwargs, out) -> (read_tensors, write_tensors)`` 形式的函数
         :type extra_rules: Optional[dict[Any, Callable]]
 
-        :param extra_ignore_modules: 需要忽略的模块列表，这些模块中的访存不会被计入
-        :type extra_ignore_modules: Optional[list[nn.Module]]
+        :param extra_ignore_modules: 需要忽略的模块类型列表，这些模块中的访存不会被计入
+        :type extra_ignore_modules: Optional[list[type[nn.Module]]]
 
         ----
 
@@ -601,9 +601,9 @@ class MemoryResidencyCounter(BaseCounter):
             are callables with signature ``(args, kwargs, out) -> (read_tensors, write_tensors)``
         :type extra_rules: Optional[dict[Any, Callable]]
 
-        :param extra_ignore_modules: list of modules to ignore. Memory accesses
+        :param extra_ignore_modules: list of module classes to ignore. Memory accesses
             within these modules will not be counted
-        :type extra_ignore_modules: Optional[list[nn.Module]]
+        :type extra_ignore_modules: Optional[list[type[nn.Module]]]
         """
         super().__init__()
         self.rules = dict(_RESIDENCY_ACCESS_RULES)

--- a/spikingjelly/activation_based/op_counter/memory_residency.py
+++ b/spikingjelly/activation_based/op_counter/memory_residency.py
@@ -513,6 +513,39 @@ class MemoryResidencySimulator:
 
 
 class MemoryResidencyCounter(BaseCounter):
+    r"""
+    **API Language:**
+    :ref:`中文 <MemoryResidencyCounter-cn>` |
+    :ref:`English <MemoryResidencyCounter-en>`
+
+    ----
+
+    .. _MemoryResidencyCounter-cn:
+
+    * **中文**
+
+    内存驻留计数器，用于追踪 SNN 推理过程中张量在各存储层级（register、SRAM、DRAM）之间的驻留和移动。
+
+    该计数器使用 :class:`MemoryResidencySimulator` 模拟缓存行为，并结合 LRU
+    淘汰策略管理寄存器与 SRAM 层级。它可与
+    :class:`DispatchCounterMode <spikingjelly.activation_based.op_counter.base.DispatchCounterMode>`
+    配合使用来自动追踪每个 aten 操作的内存访问模式。
+
+    ----
+
+    .. _MemoryResidencyCounter-en:
+
+    * **English**
+
+    Memory residency counter that tracks tensor residency and movement across
+    memory hierarchy levels (register, SRAM, DRAM) during SNN inference.
+
+    It uses :class:`MemoryResidencySimulator` to model cache behavior with LRU
+    eviction policy at register and SRAM levels. It is designed to be used with
+    :class:`DispatchCounterMode <spikingjelly.activation_based.op_counter.base.DispatchCounterMode>`
+    to automatically track memory access patterns of each aten operation.
+    """
+
     def __init__(
         self,
         *,
@@ -521,6 +554,57 @@ class MemoryResidencyCounter(BaseCounter):
         extra_rules: dict[Any, Callable] | None = None,
         extra_ignore_modules: list[nn.Module] | None = None,
     ):
+        r"""
+        **API Language:**
+        :ref:`中文 <MemoryResidencyCounter.__init__-cn>` |
+        :ref:`English <MemoryResidencyCounter.__init__-en>`
+
+        ----
+
+        .. _MemoryResidencyCounter.__init__-cn:
+
+        * **中文**
+
+        初始化内存驻留计数器。
+
+        :param config: 可选配置对象（需具有 ``capacity_bits`` 属性）
+        :type config: Optional[Any]
+
+        :param capacity_bits: 各层级的容量（以比特为单位），包含 ``reg``、``sram``、``dram`` 三个键。
+            若未提供则使用默认容量
+        :type capacity_bits: Optional[dict[str, float]]
+
+        :param extra_rules: 额外的内存访问规则，用于注册自定义 aten 操作的访存模式。
+            键为 aten 操作，值为 ``(args, kwargs, out) -> (read_tensors, write_tensors)`` 形式的函数
+        :type extra_rules: Optional[dict[Any, Callable]]
+
+        :param extra_ignore_modules: 需要忽略的模块列表，这些模块中的访存不会被计入
+        :type extra_ignore_modules: Optional[list[nn.Module]]
+
+        ----
+
+        .. _MemoryResidencyCounter.__init__-en:
+
+        * **English**
+
+        Initialize the memory residency counter.
+
+        :param config: optional config object (must have ``capacity_bits`` attribute)
+        :type config: Optional[Any]
+
+        :param capacity_bits: capacity for each level in bits, with keys ``reg``,
+            ``sram``, and ``dram``. If not provided, default capacities are used
+        :type capacity_bits: Optional[dict[str, float]]
+
+        :param extra_rules: additional memory access rules for registering access
+            patterns of custom aten operations. Keys are aten operations, values
+            are callables with signature ``(args, kwargs, out) -> (read_tensors, write_tensors)``
+        :type extra_rules: Optional[dict[Any, Callable]]
+
+        :param extra_ignore_modules: list of modules to ignore. Memory accesses
+            within these modules will not be counted
+        :type extra_ignore_modules: Optional[list[nn.Module]]
+        """
         super().__init__()
         self.rules = dict(_RESIDENCY_ACCESS_RULES)
         if extra_rules is not None:
@@ -544,6 +628,33 @@ class MemoryResidencyCounter(BaseCounter):
         )
 
     def reset(self):
+        r"""
+        **API Language:**
+        :ref:`中文 <MemoryResidencyCounter.reset-cn>` |
+        :ref:`English <MemoryResidencyCounter.reset-en>`
+
+        ----
+
+        .. _MemoryResidencyCounter.reset-cn:
+
+        * **中文**
+
+        重置计数器和模拟器的所有记录状态。
+
+        :return: None
+        :rtype: None
+
+        ----
+
+        .. _MemoryResidencyCounter.reset-en:
+
+        * **English**
+
+        Reset all recorded states of the counter and the underlying simulator.
+
+        :return: None
+        :rtype: None
+        """
         self.records.clear()
         self.level_records.clear()
         self.level_rw_records.clear()
@@ -563,6 +674,60 @@ class MemoryResidencyCounter(BaseCounter):
         active_modules: set[nn.Module] | None = None,
         parent_names: set[str] | None = None,
     ) -> int:
+        r"""
+        **API Language:**
+        :ref:`中文 <MemoryResidencyCounter.count-cn>` |
+        :ref:`English <MemoryResidencyCounter.count-en>`
+
+        ----
+
+        .. _MemoryResidencyCounter.count-cn:
+
+        * **中文**
+
+        根据注册的访存规则计算一次 aten 操作的内存访问计数，并驱动
+        :class:`MemoryResidencySimulator` 更新缓存状态。
+
+        :param func: 待计算的 aten 操作
+        :type func: Any
+        :param args: func 的位置参数
+        :type args: tuple
+        :param kwargs: func 的关键字参数
+        :type kwargs: dict
+        :param out: func 的输出
+        :type out: Any
+        :param active_modules: 当前活跃模块集合
+        :type active_modules: Optional[set[nn.Module]]
+        :param parent_names: 当前活跃父模块名称集合
+        :type parent_names: Optional[set[str]]
+        :return: 该操作的总访问字节数
+        :rtype: int
+
+        ----
+
+        .. _MemoryResidencyCounter.count-en:
+
+        * **English**
+
+        Compute the memory access count for an aten operation according to
+        registered access rules, and drive the :class:`MemoryResidencySimulator`
+        to update cache states.
+
+        :param func: the aten operation to be calculated
+        :type func: Any
+        :param args: positional arguments of func
+        :type args: tuple
+        :param kwargs: keyword arguments of func
+        :type kwargs: dict
+        :param out: output of func
+        :type out: Any
+        :param active_modules: currently active module instances
+        :type active_modules: Optional[set[nn.Module]]
+        :param parent_names: names of currently active parent modules
+        :type parent_names: Optional[set[str]]
+        :return: total access bytes of this operation
+        :rtype: int
+        """
         rule = self.rules.get(func)
         if rule is None:
             return 0
@@ -610,19 +775,157 @@ class MemoryResidencyCounter(BaseCounter):
         return total_bits
 
     def get_level_bits(self) -> dict[str, int]:
+        r"""
+        **API Language:**
+        :ref:`中文 <MemoryResidencyCounter.get_level_bits-cn>` |
+        :ref:`English <MemoryResidencyCounter.get_level_bits-en>`
+
+        ----
+
+        .. _MemoryResidencyCounter.get_level_bits-cn:
+
+        * **中文**
+
+        :return: 各层级的总访问比特数
+        :rtype: dict[str, int]
+
+        ----
+
+        .. _MemoryResidencyCounter.get_level_bits-en:
+
+        * **English**
+
+        :return: total access bits per memory level
+        :rtype: dict[str, int]
+        """
         return dict(self.level_records)
 
     def get_level_rw_bits(self) -> dict[str, dict[str, int]]:
+        r"""
+        **API Language:**
+        :ref:`中文 <MemoryResidencyCounter.get_level_rw_bits-cn>` |
+        :ref:`English <MemoryResidencyCounter.get_level_rw_bits-en>`
+
+        ----
+
+        .. _MemoryResidencyCounter.get_level_rw_bits-cn:
+
+        * **中文**
+
+        :return: 各层级的读写比特数详情
+        :rtype: dict[str, dict[str, int]]
+
+        ----
+
+        .. _MemoryResidencyCounter.get_level_rw_bits-en:
+
+        * **English**
+
+        :return: per-level read/write bit breakdown
+        :rtype: dict[str, dict[str, int]]
+        """
         return {k: dict(v) for k, v in self.level_rw_records.items()}
 
     def get_op_level_bits(self) -> dict[str, dict[str, int]]:
+        r"""
+        **API Language:**
+        :ref:`中文 <MemoryResidencyCounter.get_op_level_bits-cn>` |
+        :ref:`English <MemoryResidencyCounter.get_op_level_bits-en>`
+
+        ----
+
+        .. _MemoryResidencyCounter.get_op_level_bits-cn:
+
+        * **中文**
+
+        :return: 按操作聚合的各层级访问比特数
+        :rtype: dict[str, dict[str, int]]
+
+        ----
+
+        .. _MemoryResidencyCounter.get_op_level_bits-en:
+
+        * **English**
+
+        :return: per-operation level access bits
+        :rtype: dict[str, dict[str, int]]
+        """
         return {k: dict(v) for k, v in self.op_level_records.items()}
 
     def get_stage_level_bits(self) -> dict[str, dict[str, int]]:
+        r"""
+        **API Language:**
+        :ref:`中文 <MemoryResidencyCounter.get_stage_level_bits-cn>` |
+        :ref:`English <MemoryResidencyCounter.get_stage_level_bits-en>`
+
+        ----
+
+        .. _MemoryResidencyCounter.get_stage_level_bits-cn:
+
+        * **中文**
+
+        :return: 按阶段（forward/backward/optimizer）聚合的各层级访问比特数
+        :rtype: dict[str, dict[str, int]]
+
+        ----
+
+        .. _MemoryResidencyCounter.get_stage_level_bits-en:
+
+        * **English**
+
+        :return: per-stage level access bits
+        :rtype: dict[str, dict[str, int]]
+        """
         return {k: dict(v) for k, v in self.stage_level_records.items()}
 
     def get_move_bits_by_edge(self) -> dict[str, int]:
+        r"""
+        **API Language:**
+        :ref:`中文 <MemoryResidencyCounter.get_move_bits_by_edge-cn>` |
+        :ref:`English <MemoryResidencyCounter.get_move_bits_by_edge-en>`
+
+        ----
+
+        .. _MemoryResidencyCounter.get_move_bits_by_edge-cn:
+
+        * **中文**
+
+        :return: 按层级间移动边聚合的数据移动比特数
+        :rtype: dict[str, int]
+
+        ----
+
+        .. _MemoryResidencyCounter.get_move_bits_by_edge-en:
+
+        * **English**
+
+        :return: data movement bits aggregated by inter-level edges
+        :rtype: dict[str, int]
+        """
         return self.simulator.get_move_bits_by_edge()
 
     def get_move_bits_by_op(self) -> dict[str, dict[str, int]]:
+        r"""
+        **API Language:**
+        :ref:`中文 <MemoryResidencyCounter.get_move_bits_by_op-cn>` |
+        :ref:`English <MemoryResidencyCounter.get_move_bits_by_op-en>`
+
+        ----
+
+        .. _MemoryResidencyCounter.get_move_bits_by_op-cn:
+
+        * **中文**
+
+        :return: 按操作聚合的层级间数据移动比特数
+        :rtype: dict[str, dict[str, int]]
+
+        ----
+
+        .. _MemoryResidencyCounter.get_move_bits_by_op-en:
+
+        * **English**
+
+        :return: per-operation inter-level data movement bits
+        :rtype: dict[str, dict[str, int]]
+        """
         return self.simulator.get_move_bits_by_op()

--- a/spikingjelly/activation_based/op_counter/neuromc/config.py
+++ b/spikingjelly/activation_based/op_counter/neuromc/config.py
@@ -18,7 +18,9 @@ class MemoryInstanceSpec:
 
 
 _MEMORY_INSTANCES = {
-    "reg_1b": MemoryInstanceSpec("reg_1b", 1, 1, 1, 1, 0.00901 / 7.1 * 2, 0.00901 / 7.1 * 2),
+    "reg_1b": MemoryInstanceSpec(
+        "reg_1b", 1, 1, 1, 1, 0.00901 / 7.1 * 2, 0.00901 / 7.1 * 2
+    ),
     "reg_16b": MemoryInstanceSpec(
         "reg_16b", 16, 16, 16, 16, 0.14416 / 7.1 * 2, 0.14416 / 7.1 * 2
     ),

--- a/spikingjelly/activation_based/op_counter/neuromc/core.py
+++ b/spikingjelly/activation_based/op_counter/neuromc/core.py
@@ -1176,7 +1176,11 @@ class NeuroMCEnergyProfiler:
                         if forward_queue:
                             is_spike_input = forward_queue.pop()
                         elif op == "aten.addmm.default":
-                            alt_key = ("aten.mm.default", _shape_tuple(out), _shape_tuple(x))
+                            alt_key = (
+                                "aten.mm.default",
+                                _shape_tuple(out),
+                                _shape_tuple(x),
+                            )
                             alt_queue = gemm_forward_is_spike.get(alt_key)
                             if alt_queue:
                                 is_spike_input = alt_queue.pop()
@@ -1521,7 +1525,10 @@ class NeuroMCEnergyProfiler:
                 32,
                 False,
             )
-            if fragment.optimizer_has_momentum and fragment.optimizer_has_momentum_buffer:
+            if (
+                fragment.optimizer_has_momentum
+                and fragment.optimizer_has_momentum_buffer
+            ):
                 self._accumulate_memory(
                     totals,
                     energy,
@@ -1650,18 +1657,15 @@ class NeuroMCEnergyProfiler:
     def _validate_sgd_group(self, group: dict[str, Any]) -> None:
         if group.get("nesterov", False):
             raise ValueError(
-                "Exact NeuroMC SGD modeling currently supports only "
-                "nesterov=False."
+                "Exact NeuroMC SGD modeling currently supports only nesterov=False."
             )
         if float(group.get("dampening", 0.0)) != 0.0:
             raise ValueError(
-                "Exact NeuroMC SGD modeling currently supports only "
-                "dampening=0."
+                "Exact NeuroMC SGD modeling currently supports only dampening=0."
             )
         if group.get("maximize", False):
             raise ValueError(
-                "Exact NeuroMC SGD modeling currently supports only "
-                "maximize=False."
+                "Exact NeuroMC SGD modeling currently supports only maximize=False."
             )
 
     def _make_optimizer_fragment(

--- a/spikingjelly/activation_based/op_counter/neuron_state.py
+++ b/spikingjelly/activation_based/op_counter/neuron_state.py
@@ -245,6 +245,69 @@ class NeuronStateCounter(BaseCounter):
         active_modules: set[nn.Module] | None = None,
         parent_names: set[str] | None = None,
     ) -> int:
+        r"""
+        **API Language:**
+        :ref:`中文 <NeuronStateCounter.count-cn>` |
+        :ref:`English <NeuronStateCounter.count-en>`
+
+        ----
+
+        .. _NeuronStateCounter.count-cn:
+
+        * **中文**
+
+        统计一次aten操作对神经元内部状态的影响。
+
+        该函数会判断当前操作是否涉及 ``BaseNode`` 子类的内部状态张量，
+        并根据操作类型（加法、乘法、比较、非线性、选择等）记录对应的
+        细粒度状态统计。如果启用了稀疏内存估计，还会根据输入张量的
+        稀疏度调整计数方式。
+
+        :param func: 待计算的 aten 操作
+        :type func: Any
+        :param args: func 的位置参数
+        :type args: tuple
+        :param kwargs: func 的关键字参数
+        :type kwargs: dict
+        :param out: func 的输出
+        :type out: Any
+        :param active_modules: 当前活跃模块集合
+        :type active_modules: Optional[set[nn.Module]]
+        :param parent_names: 当前活跃父模块名称集合
+        :type parent_names: Optional[set[str]]
+        :return: 所有状态相关操作数之和（非零计数的总和）
+        :rtype: int
+
+        ----
+
+        .. _NeuronStateCounter.count-en:
+
+        * **English**
+
+        Count the impact of an aten operation on the internal state of neurons.
+
+        This function checks whether the current operation involves internal
+        state tensors of ``BaseNode`` subclasses, and records fine-grained
+        state metrics according to the operation type (addition, multiplication,
+        comparison, nonlinear, selection, etc.). When sparse memory estimation
+        is enabled, the counting is adjusted based on the sparsity of input
+        tensors.
+
+        :param func: the aten operation to be calculated
+        :type func: Any
+        :param args: positional arguments of func
+        :type args: tuple
+        :param kwargs: keyword arguments of func
+        :type kwargs: dict
+        :param out: output of func
+        :type out: Any
+        :param active_modules: currently active module instances
+        :type active_modules: Optional[set[nn.Module]]
+        :param parent_names: names of currently active parent modules
+        :type parent_names: Optional[set[str]]
+        :return: total count of all state-related operations
+        :rtype: int
+        """
         active_modules = set() if active_modules is None else active_modules
         active_base_nodes = [m for m in active_modules if isinstance(m, BaseNode)]
         if not active_base_nodes:

--- a/spikingjelly/activation_based/rnn.py
+++ b/spikingjelly/activation_based/rnn.py
@@ -10,6 +10,54 @@ from spikingjelly.activation_based import surrogate
 def directional_rnn_cell_forward(
     cell: nn.Module, x: torch.Tensor, states: torch.Tensor
 ):
+    r"""
+    **API Language:**
+    :ref:`中文 <directional_rnn_cell_forward-cn>` | :ref:`English <directional_rnn_cell_forward-en>`
+
+    ----
+
+    .. _directional_rnn_cell_forward-cn:
+
+    * **中文**
+
+    计算单个RNN cell沿着时间维度的循环并输出结果和cell的最终状态。
+
+    :param cell: RNN cell
+    :type cell: nn.Module
+    :param x: ``shape = [T, batch_size, input_size]`` 的输入
+    :type x: torch.Tensor
+    :param states: RNN cell的起始状态。
+        若RNN cell只有单个隐藏状态，则 ``shape = [batch_size, hidden_size]`` ；
+        否则 ``shape = [states_num, batch_size, hidden_size]``
+    :type states: torch.Tensor
+    :return: (output, ss)
+        output: torch.Tensor
+            ``shape = [T, batch_size, hidden_size]`` 的输出
+        ss: torch.Tensor
+            ``shape`` 与 ``states`` 相同，cell在 ``T-1`` 时刻的状态
+
+    ----
+
+    .. _directional_rnn_cell_forward-en:
+
+    * **English**
+
+    Compute the temporal loop of a single RNN cell along the time dimension, returning the output and the final state of the cell.
+
+    :param cell: the RNN cell
+    :type cell: nn.Module
+    :param x: input with ``shape = [T, batch_size, input_size]``
+    :type x: torch.Tensor
+    :param states: initial state of the RNN cell.
+        If the RNN cell has a single hidden state, ``shape = [batch_size, hidden_size]``;
+        otherwise ``shape = [states_num, batch_size, hidden_size]``
+    :type states: torch.Tensor
+    :return: (output, ss)
+        output: torch.Tensor
+            ``shape = [T, batch_size, hidden_size]``
+        ss: torch.Tensor
+            ``shape`` is the same as ``states``. The state of the cell at ``T-1``
+    """
     T = x.shape[0]
     ss = states
 
@@ -324,7 +372,7 @@ class SpikingRNNBase(nn.Module):
         :type dropout_p: float
         :param invariant_dropout_mask: If ``False``，use the naive `Dropout`；If ``True``，use the dropout in SNN that
             `mask` doesn't change in different time steps, see :class:`~spikingjelly.activation_based.layer.Dropout` for more
-            information. Defaule: ``False``
+            information. Default: ``False``
         :type invariant_dropout_mask: bool
         :param bidirectional: If ``True``, becomes a bidirectional LSTM. Default: ``False``
         :type bidirectional: bool
@@ -977,7 +1025,7 @@ class SpikingLSTM(SpikingRNNBase):
         :type dropout_p: float
         :param invariant_dropout_mask: If ``False``，use the naive `Dropout`；If ``True``，use the dropout in SNN that
             `mask` doesn't change in different time steps, see :class:`~spikingjelly.activation_based.layer.Dropout` for more
-            information. Defaule: ``False``
+            information. Default: ``False``
         :type invariant_dropout_mask: bool
         :param bidirectional: If ``True``, becomes a bidirectional LSTM. Default: ``False``
         :type bidirectional: bool

--- a/spikingjelly/activation_based/rnn.py
+++ b/spikingjelly/activation_based/rnn.py
@@ -32,6 +32,17 @@ def bidirectional_rnn_cell_forward(
     states_reverse: torch.Tensor,
 ):
     """
+    **API Language:**
+    :ref:`中文 <bidirectional_rnn_cell_forward-cn>` | :ref:`English <bidirectional_rnn_cell_forward-en>`
+
+    ----
+
+    .. _bidirectional_rnn_cell_forward-cn:
+
+    * **中文**
+
+    计算单个正向和反向RNN cell沿着时间维度的循环并输出结果和两个cell的最终状态。
+
     :param cell: 正向RNN cell，输入是正向序列
     :type cell: nn.Module
     :param cell_reverse: 反向的RNN cell，输入是反向序列
@@ -56,7 +67,37 @@ def bidirectional_rnn_cell_forward(
         ss_r: torch.Tensor
             ``shape`` 与 ``states_reverse`` 相同，反向cell在 ``0`` 时刻的状态
 
-    计算单个正向和反向RNN cell沿着时间维度的循环并输出结果和两个cell的最终状态。
+    ----
+
+    .. _bidirectional_rnn_cell_forward-en:
+
+    * **English**
+
+    Compute the temporal loop of a forward and a reverse RNN cell along the time dimension, returning the output and the final states of both cells.
+
+    :param cell: forward RNN cell that takes the forward sequence as input
+    :type cell: nn.Module
+    :param cell_reverse: reverse RNN cell that takes the reverse sequence as input
+    :type cell_reverse: nn.Module
+    :param x: input with ``shape = [T, batch_size, input_size]``
+    :type x: torch.Tensor
+    :param states: initial state of the forward RNN cell.
+        If the RNN cell has a single hidden state, ``shape = [batch_size, hidden_size]``;
+        otherwise ``shape = [states_num, batch_size, hidden_size]``
+    :type states: torch.Tensor
+    :param states_reverse: initial state of the reverse RNN cell.
+        If the RNN cell has a single hidden state, ``shape = [batch_size, hidden_size]``;
+        otherwise ``shape = [states_num, batch_size, hidden_size]``
+    :type states_reverse: torch.Tensor
+    :return: y, ss, ss_r
+
+        y: torch.Tensor
+            ``shape = [T, batch_size, 2 * hidden_size]``. ``y[t]`` is the concatenation of
+            the forward cell's output at ``t`` and the reverse cell's output at ``T - t - 1``
+        ss: torch.Tensor
+            ``shape`` is the same as ``states``. The state of the forward cell at ``T-1``
+        ss_r: torch.Tensor
+            ``shape`` is the same as ``states_reverse``. The state of the reverse cell at ``0``
     """
     T = x.shape[0]
     ss = states

--- a/spikingjelly/datasets/speechcommands.py
+++ b/spikingjelly/datasets/speechcommands.py
@@ -96,25 +96,25 @@ class SpeechCommands(Dataset):
         :type root: str
 
         :param silence_cnt: Silence数据的数量
-        :type silence_cnt: int, optional
+        :type silence_cnt: Optional[int]
 
         :param silence_size: Silence数据的尺寸
-        :type silence_size: int, optional
+        :type silence_size: Optional[int]
 
         :param transform: A function/transform that takes in a raw audio
-        :type transform: Callable, optional
+        :type transform: Optional[Callable]
 
         :param url: 数据集版本，默认为v0.02
-        :type url: str, optional
+        :type url: Optional[str]
 
         :param split: 数据集划分，可以是 ``"train", "test", "val"``，默认为 ``"train"``
-        :type split: str, optional
+        :type split: Optional[str]
 
         :param folder_in_archive: 解压后的目录名称，默认为 ``"SpeechCommands"``
-        :type folder_in_archive: str, optional
+        :type folder_in_archive: Optional[str]
 
         :param download: 是否下载数据，默认为False
-        :type download: bool, optional
+        :type download: Optional[bool]
 
         ----
 

--- a/spikingjelly/datasets/speechcommands.py
+++ b/spikingjelly/datasets/speechcommands.py
@@ -101,7 +101,7 @@ class SpeechCommands(Dataset):
         :param silence_size: Silence数据的尺寸
         :type silence_size: Optional[int]
 
-        :param transform: A function/transform that takes in a raw audio
+        :param transform: 对原始音频的变换/处理函数，输入为原始音频波形，输出为变换后的音频
         :type transform: Optional[Callable]
 
         :param url: 数据集版本，默认为v0.02

--- a/test/activation_based/test_op_counter_compute_energy.py
+++ b/test/activation_based/test_op_counter_compute_energy.py
@@ -1,0 +1,111 @@
+import pytest
+import torch
+import torch.nn as nn
+
+from spikingjelly.activation_based import op_counter
+
+
+def test_compute_energy_uses_mac_and_ac_as_authoritative_total():
+    class AddModel(nn.Module):
+        def forward(self, x, y):
+            return x + y
+
+    model = AddModel()
+    x = torch.ones(2, 3)
+    y = torch.ones(2, 3)
+
+    report = op_counter.estimate_compute_energy(model, (x, y))
+
+    assert report.counts["mac"] == 0
+    assert report.counts["ac"] == 12
+    assert report.energy_mac_pj == pytest.approx(0.0)
+    assert report.energy_ac_pj == pytest.approx(12 * 0.9)
+    assert report.energy_total_pj == pytest.approx(
+        report.energy_mac_pj + report.energy_ac_pj
+    )
+
+
+def test_compute_energy_spike_linear_counts_synop_as_auxiliary_only():
+    model = nn.Linear(4, 3, bias=False)
+    x = torch.tensor([[1.0, 0.0, 1.0, 0.0]])
+
+    report = op_counter.estimate_compute_energy(model, x)
+
+    assert report.counts["synop"] == 6
+    assert report.counts["ac"] == 6
+    assert report.counts["mac"] == 0
+    assert report.energy_total_pj == pytest.approx(6 * 0.9)
+
+
+def test_compute_energy_dense_linear_counts_mac():
+    model = nn.Linear(4, 3, bias=False)
+    x = torch.full((2, 4), 0.5)
+
+    report = op_counter.estimate_compute_energy(model, x)
+
+    assert report.counts["mac"] == 24
+    assert report.counts["ac"] == 0
+    assert report.energy_total_pj == pytest.approx(24 * 4.6)
+
+
+def test_compute_energy_profiler_matches_convenience_function():
+    model = nn.Linear(4, 2, bias=False)
+    x = torch.tensor([[1.0, 0.0, 1.0, 0.0]])
+
+    profiler = op_counter.ComputeEnergyProfiler()
+    with profiler:
+        _ = model(x)
+
+    report_ctx = profiler.get_report()
+    report_fn = op_counter.estimate_compute_energy(model, x)
+
+    assert report_ctx.energy_total_pj == pytest.approx(report_fn.energy_total_pj)
+    assert report_ctx.counts == report_fn.counts
+
+
+def test_compute_energy_custom_cost_config_is_applied():
+    model = nn.Linear(4, 2, bias=False)
+    x = torch.tensor([[1.0, 0.0, 1.0, 0.0]])
+    cfg = op_counter.ComputeEnergyConfig(
+        cost_config=op_counter.ComputeEnergyCostConfig(e_mac_pj=10.0, e_ac_pj=2.0)
+    )
+
+    report = op_counter.estimate_compute_energy(model, x, config=cfg)
+
+    assert report.counts["ac"] == 4
+    assert report.energy_total_pj == pytest.approx(8.0)
+
+
+def test_compute_energy_cost_config_presets_match_horowitz_reference_table():
+    fp32 = op_counter.ComputeEnergyCostConfig.fp32()
+    fp16 = op_counter.ComputeEnergyCostConfig.fp16()
+    int8 = op_counter.ComputeEnergyCostConfig.int8()
+
+    assert fp32.e_mac_pj == pytest.approx(4.6)
+    assert fp32.e_ac_pj == pytest.approx(0.9)
+    assert fp16.e_mac_pj == pytest.approx(1.5)
+    assert fp16.e_ac_pj == pytest.approx(0.4)
+    assert int8.e_mac_pj == pytest.approx(0.23)
+    assert int8.e_ac_pj == pytest.approx(0.03)
+
+
+def test_compute_energy_default_cost_config_matches_fp32_preset():
+    cfg = op_counter.ComputeEnergyConfig()
+    fp32 = op_counter.ComputeEnergyCostConfig.fp32()
+
+    assert cfg.cost_config.e_mac_pj == pytest.approx(fp32.e_mac_pj)
+    assert cfg.cost_config.e_ac_pj == pytest.approx(fp32.e_ac_pj)
+
+
+def test_compute_energy_fp16_preset_changes_only_comparison_regime():
+    model = nn.Linear(4, 2, bias=False)
+    x = torch.tensor([[1.0, 0.0, 1.0, 0.0]])
+    cfg = op_counter.ComputeEnergyConfig(
+        cost_config=op_counter.ComputeEnergyCostConfig.fp16()
+    )
+
+    report = op_counter.estimate_compute_energy(model, x, config=cfg)
+
+    assert report.counts["ac"] == 4
+    assert report.counts["mac"] == 0
+    assert report.energy_total_pj == pytest.approx(4 * 0.4)

--- a/test/activation_based/test_op_counter_compute_energy.py
+++ b/test/activation_based/test_op_counter_compute_energy.py
@@ -109,3 +109,22 @@ def test_compute_energy_fp16_preset_changes_only_comparison_regime():
     assert report.counts["ac"] == 4
     assert report.counts["mac"] == 0
     assert report.energy_total_pj == pytest.approx(4 * 0.4)
+
+
+def test_compute_energy_warns_when_no_supported_ops_are_profiled():
+    model = nn.ReLU()
+    x = torch.ones(2, 3)
+
+    report = op_counter.estimate_compute_energy(model, x)
+
+    assert report.energy_total_pj == pytest.approx(0.0)
+    assert any("zero MAC/AC/SynOp/FLOP counts" in msg for msg in report.warnings)
+
+
+def test_compute_energy_strict_raises_when_no_supported_ops_are_profiled():
+    model = nn.ReLU()
+    x = torch.ones(2, 3)
+    cfg = op_counter.ComputeEnergyConfig(strict=True)
+
+    with pytest.raises(RuntimeError, match="zero MAC/AC/SynOp/FLOP counts"):
+        op_counter.estimate_compute_energy(model, x, config=cfg)

--- a/test/activation_based/test_op_counter_compute_energy.py
+++ b/test/activation_based/test_op_counter_compute_energy.py
@@ -142,3 +142,20 @@ def test_compute_energy_strict_allows_zero_work_when_supported_op_matches():
     assert report.counts["synop"] == 0
     assert report.counts["flop"] == 0
     assert report.warnings == []
+
+
+def test_compute_energy_supports_dict_inputs_for_keyword_only_models():
+    class KeywordOnlyAdd(nn.Module):
+        def forward(self, *, x, y):
+            return x + y
+
+    model = KeywordOnlyAdd()
+    inputs = {
+        "x": torch.ones(2, 3),
+        "y": torch.ones(2, 3),
+    }
+
+    report = op_counter.estimate_compute_energy(model, inputs)
+
+    assert report.counts["mac"] == 0
+    assert report.counts["ac"] == 12

--- a/test/activation_based/test_op_counter_compute_energy.py
+++ b/test/activation_based/test_op_counter_compute_energy.py
@@ -118,7 +118,7 @@ def test_compute_energy_warns_when_no_supported_ops_are_profiled():
     report = op_counter.estimate_compute_energy(model, x)
 
     assert report.energy_total_pj == pytest.approx(0.0)
-    assert any("zero MAC/AC/SynOp/FLOP counts" in msg for msg in report.warnings)
+    assert any("did not match any supported operators" in msg for msg in report.warnings)
 
 
 def test_compute_energy_strict_raises_when_no_supported_ops_are_profiled():
@@ -126,5 +126,19 @@ def test_compute_energy_strict_raises_when_no_supported_ops_are_profiled():
     x = torch.ones(2, 3)
     cfg = op_counter.ComputeEnergyConfig(strict=True)
 
-    with pytest.raises(RuntimeError, match="zero MAC/AC/SynOp/FLOP counts"):
+    with pytest.raises(RuntimeError, match="did not match any supported operators"):
         op_counter.estimate_compute_energy(model, x, config=cfg)
+
+
+def test_compute_energy_strict_allows_zero_work_when_supported_op_matches():
+    model = nn.Linear(4, 3, bias=False)
+    x = torch.empty(0, 4)
+    cfg = op_counter.ComputeEnergyConfig(strict=True)
+
+    report = op_counter.estimate_compute_energy(model, x, config=cfg)
+
+    assert report.counts["mac"] == 0
+    assert report.counts["ac"] == 0
+    assert report.counts["synop"] == 0
+    assert report.counts["flop"] == 0
+    assert report.warnings == []

--- a/test/activation_based/test_op_counter_snn_energy.py
+++ b/test/activation_based/test_op_counter_snn_energy.py
@@ -71,8 +71,12 @@ def test_lemaire_energy_sparse_linear_memory_is_lower_than_dense():
     dense_report = op_counter.estimate_lemaire_energy(model, dense_x)
     sparse_report = op_counter.estimate_lemaire_energy(model, sparse_x)
 
-    assert sparse_report.breakdown_pj["inout_pj"] < dense_report.breakdown_pj["inout_pj"]
-    assert sparse_report.breakdown_pj["params_pj"] < dense_report.breakdown_pj["params_pj"]
+    assert (
+        sparse_report.breakdown_pj["inout_pj"] < dense_report.breakdown_pj["inout_pj"]
+    )
+    assert (
+        sparse_report.breakdown_pj["params_pj"] < dense_report.breakdown_pj["params_pj"]
+    )
     assert sparse_report.total_pj < dense_report.total_pj
 
 
@@ -85,7 +89,9 @@ def test_lemaire_energy_non_binary_sparse_linear_memory_is_lower_than_dense():
     dense_report = op_counter.estimate_lemaire_energy(model, dense_x)
     sparse_report = op_counter.estimate_lemaire_energy(model, sparse_x)
 
-    assert sparse_report.breakdown_pj["inout_pj"] < dense_report.breakdown_pj["inout_pj"]
+    assert (
+        sparse_report.breakdown_pj["inout_pj"] < dense_report.breakdown_pj["inout_pj"]
+    )
 
 
 def test_lemaire_energy_sparse_zero_ratio_below_threshold_stays_dense():
@@ -114,8 +120,12 @@ def test_lemaire_energy_sparse_conv_memory_is_lower_than_dense():
     dense_report = op_counter.estimate_lemaire_energy(model, dense_x)
     sparse_report = op_counter.estimate_lemaire_energy(model, sparse_x)
 
-    assert sparse_report.breakdown_pj["inout_pj"] < dense_report.breakdown_pj["inout_pj"]
-    assert sparse_report.breakdown_pj["params_pj"] < dense_report.breakdown_pj["params_pj"]
+    assert (
+        sparse_report.breakdown_pj["inout_pj"] < dense_report.breakdown_pj["inout_pj"]
+    )
+    assert (
+        sparse_report.breakdown_pj["params_pj"] < dense_report.breakdown_pj["params_pj"]
+    )
 
 
 def test_lemaire_energy_conv_transpose_sparse_input_falls_back_with_warning():
@@ -195,7 +205,10 @@ def test_lemaire_addressing_counter_linear_counts_dense_and_binary():
         _ = model(spike_x)
     spike_counts = counter.get_metric_counts()["Global"]
     assert spike_counts["mac_addr"] == 0
-    assert spike_counts["acc_addr"] == int(spike_x.count_nonzero().item()) * model.out_features
+    assert (
+        spike_counts["acc_addr"]
+        == int(spike_x.count_nonzero().item()) * model.out_features
+    )
 
 
 def test_lemaire_addressing_counter_conv_counts_dense_binary_and_grouped():


### PR DESCRIPTION
## Summary
- Add a compute-only MAC/AC energy profiler with both context-manager and convenience function APIs.
- Reuse existing `MACCounter`, `ACCounter`, `SynOpCounter`, and `FlopCounter` to expose normalized compute-energy estimates.
- Add Horowitz-style FP32/FP16/INT8 cost presets and keep FP32 as the default comparison regime.
- Update op_counter exports and API docs to surface the new estimator.
- Include unit tests covering the new profiler, presets, and default-cost behavior.

## Testing
- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a compute-only energy estimator with configurable cost presets, a profiler, and a convenience API that returns structured energy reports.

* **Documentation**
  * Added a "Compute‑Only Energy Estimator" API doc section and expanded bilingual (Chinese/English) API docstrings across counters and utilities; fixed typos and parameter annotations.

* **Tests**
  * Added tests covering estimation behavior, presets, reporting consistency, input forms, and strict vs. warning modes.

* **Chores**
  * Made the energy estimator available at the package level and adjusted a counter initializer type annotation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangwei123456/spikingjelly/pull/681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->