### PR TITLE
Fix IndentationError and NameError introduced by 7182fb1

### DIFF
--- a/spikingjelly/activation_based/cuda_kernel/neuron_kernel/integrate_and_fire.py
+++ b/spikingjelly/activation_based/cuda_kernel/neuron_kernel/integrate_and_fire.py
@@ -58,7 +58,7 @@ def create_fptt_kernel(hard_reset: bool, dtype: str):
     :return: CUDA kernel object with generated code
     :rtype: CKernel1D
     """
-        kernel_name = f"IFNode_fptt_{'hard' if hard_reset else 'soft'}Reset_{dtype}"
+    kernel_name = f"IFNode_fptt_{'hard' if hard_reset else 'soft'}Reset_{dtype}"
 
     if dtype == "fp32":
         code = rf"""
@@ -221,7 +221,7 @@ def create_bptt_kernel(
     :return: CUDA kernel object with generated code
     :rtype: CKernel1D
     """
-        kernel_name = f"IFNode_bptt_{'hard' if hard_reset else 'soft'}Reset_{'detachReset' if detach_reset else ''}_{dtype}"
+    kernel_name = f"IFNode_bptt_{'hard' if hard_reset else 'soft'}Reset_{'detachReset' if detach_reset else ''}_{dtype}"
 
     code_grad_s_to_h = sg_cuda_code_fun(x="over_th", y="grad_s_to_h", dtype=dtype)
 

--- a/spikingjelly/activation_based/cuda_kernel/neuron_kernel/izhikevich.py
+++ b/spikingjelly/activation_based/cuda_kernel/neuron_kernel/izhikevich.py
@@ -54,7 +54,7 @@ def create_fptt_kernel(hard_reset: bool, dtype: str):
     :return: CUDA kernel object with generated code
     :rtype: CKernel1D
     """
-        kernel_name = f"IzhikevichNode_fptt_{'hard' if hard_reset else 'soft'}Reset_{dtype}"
+    kernel_name = f"IzhikevichNode_fptt_{'hard' if hard_reset else 'soft'}Reset_{dtype}"
 
     if dtype == "fp32":
         code = rf"""
@@ -174,7 +174,7 @@ def create_bptt_kernel(
     :return: CUDA kernel object with generated code
     :rtype: CKernel1D
     """
-        kernel_name = f"IzhikevichNode_bptt_{'hard' if hard_reset else 'soft'}Reset_{'detachReset' if detach_reset else ''}_{dtype}"
+    kernel_name = f"IzhikevichNode_bptt_{'hard' if hard_reset else 'soft'}Reset_{'detachReset' if detach_reset else ''}_{dtype}"
 
     code_grad_s_to_h = sg_cuda_code_fun(x="over_th", y="grad_s_to_h", dtype=dtype)
 

--- a/spikingjelly/activation_based/cuda_kernel/neuron_kernel/lif.py
+++ b/spikingjelly/activation_based/cuda_kernel/neuron_kernel/lif.py
@@ -60,7 +60,7 @@ def create_fptt_kernel(
     :return: CUDA kernel object with generated code
     :rtype: CKernel1D
     """
-        kernel_name = f"{kernel_name_prefix}_fptt_decayInput{decay_input}_{'hard' if hard_reset else 'soft'}Reset_{dtype}"
+    kernel_name = f"{kernel_name_prefix}_fptt_decayInput{decay_input}_{'hard' if hard_reset else 'soft'}Reset_{dtype}"
 
     if dtype == "fp32":
         code = rf"""
@@ -262,7 +262,7 @@ def create_bptt_kernel(
     :return: CUDA kernel object with generated code
     :rtype: CKernel1D
     """
-        kernel_name = f"LIFNode_bptt_decayInput{decay_input}_{'hard' if hard_reset else 'soft'}Reset_{'detachReset' if detach_reset else ''}_{dtype}"
+    kernel_name = f"LIFNode_bptt_decayInput{decay_input}_{'hard' if hard_reset else 'soft'}Reset_{'detachReset' if detach_reset else ''}_{dtype}"
 
     code_grad_s_to_h = sg_cuda_code_fun(x="over_th", y="grad_s_to_h", dtype=dtype)
 

--- a/spikingjelly/activation_based/cuda_kernel/neuron_kernel/plif.py
+++ b/spikingjelly/activation_based/cuda_kernel/neuron_kernel/plif.py
@@ -55,7 +55,7 @@ def create_fptt_kernel(decay_input: bool, hard_reset: bool, dtype: str):
     :return: CUDA kernel object with generated code
     :rtype: CKernel1D
     """
-        return lif_create_fptt_kernel(
+    return lif_create_fptt_kernel(
         decay_input, hard_reset, dtype, kernel_name_prefix="ParametricLIFNode"
     )
 
@@ -109,7 +109,7 @@ def create_bptt_kernel(
     :return: CUDA kernel object with generated code
     :rtype: CKernel1D
     """
-        kernel_name = f"ParametricLIFNode_bptt_decayInput{decay_input}_{'hard' if hard_reset else 'soft'}Reset_{'detachReset' if detach_reset else ''}_{dtype}"
+    kernel_name = f"ParametricLIFNode_bptt_decayInput{decay_input}_{'hard' if hard_reset else 'soft'}Reset_{'detachReset' if detach_reset else ''}_{dtype}"
 
     code_grad_s_to_h = sg_cuda_code_fun(x="over_th", y="grad_s_to_h", dtype=dtype)
 

--- a/spikingjelly/activation_based/cuda_kernel/neuron_kernel/qif.py
+++ b/spikingjelly/activation_based/cuda_kernel/neuron_kernel/qif.py
@@ -55,7 +55,7 @@ def create_fptt_kernel(hard_reset: bool, dtype: str):
     :return: CUDA kernel object with generated code
     :rtype: CKernel1D
     """
-        kernel_name = f"QIFNode_fptt_{'hard' if hard_reset else 'soft'}Reset_{dtype}"
+    kernel_name = f"QIFNode_fptt_{'hard' if hard_reset else 'soft'}Reset_{dtype}"
 
     if dtype == "fp32":
         code = rf"""
@@ -227,7 +227,7 @@ def create_bptt_kernel(
     :return: CUDA kernel object with generated code
     :rtype: CKernel1D
     """
-        kernel_name = f"QIFNode_bptt_{'hard' if hard_reset else 'soft'}Reset_{'detachReset' if detach_reset else ''}_{dtype}"
+    kernel_name = f"QIFNode_bptt_{'hard' if hard_reset else 'soft'}Reset_{'detachReset' if detach_reset else ''}_{dtype}"
 
     code_grad_s_to_h = sg_cuda_code_fun(x="over_th", y="grad_s_to_h", dtype=dtype)
 

--- a/spikingjelly/activation_based/neuron/base_node.py
+++ b/spikingjelly/activation_based/neuron/base_node.py
@@ -1,4 +1,4 @@
-import logging
+from abc import abstractmethod
 from typing import Optional
 
 import torch


### PR DESCRIPTION
Fixes `IndentationError` in `activation_based.cuda_kernel.neuron_kernel` and `NameError` in `activation_based.neuron.base_node` introduced by 7182fb154d2c807dfe35c938d36e3ee65d7c0530.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Corrected indentation and whitespace alignment for kernel name variable assignments across multiple CUDA neuron kernel creation functions to maintain consistent code formatting and readability standards.

* **Chores**
  * Updated module imports in neuron base classes to add proper support for abstract method decorators while removing previously unused logging dependencies from the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangwei123456/spikingjelly/pull/684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->