### PR TITLE
Add initial FP8 precision tooling

### DIFF
--- a/spikingjelly/activation_based/op_counter/neuromc/core.py
+++ b/spikingjelly/activation_based/op_counter/neuromc/core.py
@@ -218,6 +218,18 @@ class NeuroMCRuntimeEnergyReport:
     :return: None
     :rtype: None
     """
+    energy_total_pj: float
+    energy_compute_pj: float
+    energy_memory_pj: float
+    energy_by_stage: dict[str, float]
+    energy_by_op: dict[str, float]
+    primitive_counts: dict[str, Any]
+    memory_bits_by_level: dict[str, Any]
+    warnings: list[str]
+    energy_mac_pj: float
+    energy_base_memory_pj: float
+    energy_extra_memory_pj: float
+    energy_extra_compute_pj: float
     energy_by_core_type: dict[str, float]
     energy_by_process_key: dict[str, float]
     energy_by_memory_level_dir: dict[str, dict[str, float]]

--- a/spikingjelly/activation_based/precision/__init__.py
+++ b/spikingjelly/activation_based/precision/__init__.py
@@ -1,9 +1,10 @@
+import importlib.util
+
 from .api import PrecisionArtifacts, prepare_model_for_precision, save_precision_reports
 from .capability import build_capability_report, validate_capability
 from .config import PrecisionConfig
 from .convert import ConversionReport, analyze_convertible_modules, convert_model_for_precision
 from .float8_base import Float8LinearStepModule, wrap_float8_linear_module
-from .float8_torchao import Float8TorchAOPolicy
 from .policy import BF16Policy, FP16Policy, FP32Policy, PrecisionPolicy
 from .runtime import resolve_precision_policy
 
@@ -19,10 +20,14 @@ __all__ = [
     "convert_model_for_precision",
     "Float8LinearStepModule",
     "wrap_float8_linear_module",
-    "Float8TorchAOPolicy",
     "PrecisionPolicy",
     "FP32Policy",
     "FP16Policy",
     "BF16Policy",
     "resolve_precision_policy",
 ]
+
+if importlib.util.find_spec("torchao") is not None:
+    from .float8_torchao import Float8TorchAOPolicy
+
+    __all__.append("Float8TorchAOPolicy")

--- a/spikingjelly/activation_based/precision/__init__.py
+++ b/spikingjelly/activation_based/precision/__init__.py
@@ -1,0 +1,28 @@
+from .api import PrecisionArtifacts, prepare_model_for_precision, save_precision_reports
+from .capability import build_capability_report, validate_capability
+from .config import PrecisionConfig
+from .convert import ConversionReport, analyze_convertible_modules, convert_model_for_precision
+from .float8_base import Float8LinearStepModule, wrap_float8_linear_module
+from .float8_torchao import Float8TorchAOPolicy
+from .policy import BF16Policy, FP16Policy, FP32Policy, PrecisionPolicy
+from .runtime import resolve_precision_policy
+
+__all__ = [
+    "PrecisionArtifacts",
+    "PrecisionConfig",
+    "prepare_model_for_precision",
+    "save_precision_reports",
+    "build_capability_report",
+    "validate_capability",
+    "ConversionReport",
+    "analyze_convertible_modules",
+    "convert_model_for_precision",
+    "Float8LinearStepModule",
+    "wrap_float8_linear_module",
+    "Float8TorchAOPolicy",
+    "PrecisionPolicy",
+    "FP32Policy",
+    "FP16Policy",
+    "BF16Policy",
+    "resolve_precision_policy",
+]

--- a/spikingjelly/activation_based/precision/__init__.py
+++ b/spikingjelly/activation_based/precision/__init__.py
@@ -3,7 +3,11 @@ import importlib.util
 from .api import PrecisionArtifacts, prepare_model_for_precision, save_precision_reports
 from .capability import build_capability_report, validate_capability
 from .config import PrecisionConfig
-from .convert import ConversionReport, analyze_convertible_modules, convert_model_for_precision
+from .convert import (
+    ConversionReport,
+    analyze_convertible_modules,
+    convert_model_for_precision,
+)
 from .float8_base import Float8LinearStepModule, wrap_float8_linear_module
 from .policy import BF16Policy, FP16Policy, FP32Policy, PrecisionPolicy
 from .runtime import resolve_precision_policy

--- a/spikingjelly/activation_based/precision/api.py
+++ b/spikingjelly/activation_based/precision/api.py
@@ -73,7 +73,7 @@ def prepare_model_for_precision(
     policy = resolve_precision_policy(requested)
     policy.check_capability(model, device)
     prepared_model = policy.prepare_model(model)
-    effective = requested
+    effective = requested  # Fallback resolution is intentionally deferred for now.
     scaler = policy.create_grad_scaler()
     return PrecisionArtifacts(
         requested_config=requested,

--- a/spikingjelly/activation_based/precision/api.py
+++ b/spikingjelly/activation_based/precision/api.py
@@ -32,6 +32,8 @@ class PrecisionArtifacts:
         parameters: Iterable[torch.nn.Parameter] | None = None,
         step_optimizer: bool = True,
     ) -> float | None:
+        if clip_grad_norm is not None and parameters is None:
+            parameters = self.model.parameters()
         if self.scaler is None:
             loss.backward()
             grad_norm = None

--- a/spikingjelly/activation_based/precision/api.py
+++ b/spikingjelly/activation_based/precision/api.py
@@ -36,10 +36,6 @@ class PrecisionArtifacts:
             loss.backward()
             grad_norm = None
             if clip_grad_norm is not None:
-                if not step_optimizer:
-                    raise ValueError(
-                        "clip_grad_norm with step_optimizer=False is not supported."
-                    )
                 if parameters is None:
                     raise ValueError("parameters must be provided when clip_grad_norm is set.")
                 grad_norm = torch.nn.utils.clip_grad_norm_(parameters, clip_grad_norm)
@@ -52,7 +48,7 @@ class PrecisionArtifacts:
         if clip_grad_norm is not None:
             if not step_optimizer:
                 raise ValueError(
-                    "clip_grad_norm with step_optimizer=False is not supported."
+                    "clip_grad_norm with step_optimizer=False is not supported when a grad scaler is active."
                 )
             if parameters is None:
                 raise ValueError("parameters must be provided when clip_grad_norm is set.")

--- a/spikingjelly/activation_based/precision/api.py
+++ b/spikingjelly/activation_based/precision/api.py
@@ -73,6 +73,13 @@ def prepare_model_for_precision(
     device: torch.device | str,
     config: PrecisionConfig | str | dict | Any,
 ) -> PrecisionArtifacts:
+    """Prepare a model for the requested precision mode.
+
+    Note:
+        This may replace modules in the model. Call it before constructing the
+        optimizer so the optimizer does not keep references to stale
+        parameters.
+    """
     device = torch.device(device)
     requested = PrecisionConfig.from_any(config, default_device=str(device))
     policy = resolve_precision_policy(requested)

--- a/spikingjelly/activation_based/precision/api.py
+++ b/spikingjelly/activation_based/precision/api.py
@@ -30,26 +30,37 @@ class PrecisionArtifacts:
         optimizer: torch.optim.Optimizer,
         clip_grad_norm: float | None = None,
         parameters: Iterable[torch.nn.Parameter] | None = None,
+        step_optimizer: bool = True,
     ) -> float | None:
         if self.scaler is None:
             loss.backward()
             grad_norm = None
             if clip_grad_norm is not None:
+                if not step_optimizer:
+                    raise ValueError(
+                        "clip_grad_norm with step_optimizer=False is not supported."
+                    )
                 if parameters is None:
                     raise ValueError("parameters must be provided when clip_grad_norm is set.")
                 grad_norm = torch.nn.utils.clip_grad_norm_(parameters, clip_grad_norm)
-            optimizer.step()
+            if step_optimizer:
+                optimizer.step()
             return None if grad_norm is None else float(grad_norm)
 
         self.scaler.scale(loss).backward()
-        self.scaler.unscale_(optimizer)
         grad_norm = None
         if clip_grad_norm is not None:
+            if not step_optimizer:
+                raise ValueError(
+                    "clip_grad_norm with step_optimizer=False is not supported."
+                )
             if parameters is None:
                 raise ValueError("parameters must be provided when clip_grad_norm is set.")
+            self.scaler.unscale_(optimizer)
             grad_norm = torch.nn.utils.clip_grad_norm_(parameters, clip_grad_norm)
-        self.scaler.step(optimizer)
-        self.scaler.update()
+        if step_optimizer:
+            self.scaler.step(optimizer)
+            self.scaler.update()
         return None if grad_norm is None else float(grad_norm)
 
     def describe(self) -> dict[str, Any]:

--- a/spikingjelly/activation_based/precision/api.py
+++ b/spikingjelly/activation_based/precision/api.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+import os
+from contextlib import AbstractContextManager
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable
+
+import torch
+
+from .config import PrecisionConfig
+from .runtime import resolve_precision_policy
+
+
+@dataclass
+class PrecisionArtifacts:
+    requested_config: PrecisionConfig
+    effective_config: PrecisionConfig
+    policy: Any
+    model: torch.nn.Module
+    scaler: Any
+    fallback_reason: str | None = None
+
+    def autocast_context(self) -> AbstractContextManager:
+        return self.policy.autocast_context()
+
+    def backward(
+        self,
+        loss: torch.Tensor,
+        optimizer: torch.optim.Optimizer,
+        clip_grad_norm: float | None = None,
+        parameters: Iterable[torch.nn.Parameter] | None = None,
+    ) -> float | None:
+        if self.scaler is None:
+            loss.backward()
+            grad_norm = None
+            if clip_grad_norm is not None:
+                if parameters is None:
+                    raise ValueError("parameters must be provided when clip_grad_norm is set.")
+                grad_norm = torch.nn.utils.clip_grad_norm_(parameters, clip_grad_norm)
+            optimizer.step()
+            return None if grad_norm is None else float(grad_norm)
+
+        self.scaler.scale(loss).backward()
+        self.scaler.unscale_(optimizer)
+        grad_norm = None
+        if clip_grad_norm is not None:
+            if parameters is None:
+                raise ValueError("parameters must be provided when clip_grad_norm is set.")
+            grad_norm = torch.nn.utils.clip_grad_norm_(parameters, clip_grad_norm)
+        self.scaler.step(optimizer)
+        self.scaler.update()
+        return None if grad_norm is None else float(grad_norm)
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            "requested_config": asdict(self.requested_config),
+            "effective_config": asdict(self.effective_config),
+            "policy": self.policy.describe(),
+            "capability_report": self.policy.capability_report(),
+            "conversion_report": self.policy.conversion_report(),
+            "fallback_reason": self.fallback_reason,
+        }
+
+
+def prepare_model_for_precision(
+    model: torch.nn.Module,
+    device: torch.device | str,
+    config: PrecisionConfig | str | dict | Any,
+) -> PrecisionArtifacts:
+    device = torch.device(device)
+    requested = PrecisionConfig.from_any(config, default_device=str(device))
+    policy = resolve_precision_policy(requested)
+    policy.check_capability(model, device)
+    prepared_model = policy.prepare_model(model)
+    effective = requested
+    scaler = policy.create_grad_scaler()
+    return PrecisionArtifacts(
+        requested_config=requested,
+        effective_config=effective,
+        policy=policy,
+        model=prepared_model,
+        scaler=scaler,
+        fallback_reason=None,
+    )
+
+
+def save_precision_reports(artifacts: PrecisionArtifacts, output_dir: str) -> None:
+    os.makedirs(output_dir, exist_ok=True)
+    payload = artifacts.describe()
+    runtime_summary = {
+        "requested_config": payload["requested_config"],
+        "effective_config": payload["effective_config"],
+        "fallback_reason": payload["fallback_reason"],
+    }
+    for filename, key in (
+        ("precision_policy.json", "policy"),
+        ("capability_report.json", "capability_report"),
+        ("conversion_report.json", "conversion_report"),
+        ("precision_runtime.json", "runtime_summary"),
+    ):
+        path = os.path.join(output_dir, filename)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(
+                runtime_summary if key == "runtime_summary" else payload[key],
+                f,
+                indent=2,
+                sort_keys=True,
+            )

--- a/spikingjelly/activation_based/precision/api.py
+++ b/spikingjelly/activation_based/precision/api.py
@@ -38,8 +38,6 @@ class PrecisionArtifacts:
             loss.backward()
             grad_norm = None
             if clip_grad_norm is not None:
-                if parameters is None:
-                    raise ValueError("parameters must be provided when clip_grad_norm is set.")
                 grad_norm = torch.nn.utils.clip_grad_norm_(parameters, clip_grad_norm)
             if step_optimizer:
                 optimizer.step()
@@ -52,8 +50,6 @@ class PrecisionArtifacts:
                 raise ValueError(
                     "clip_grad_norm with step_optimizer=False is not supported when a grad scaler is active."
                 )
-            if parameters is None:
-                raise ValueError("parameters must be provided when clip_grad_norm is set.")
             self.scaler.unscale_(optimizer)
             grad_norm = torch.nn.utils.clip_grad_norm_(parameters, clip_grad_norm)
         if step_optimizer:

--- a/spikingjelly/activation_based/precision/capability.py
+++ b/spikingjelly/activation_based/precision/capability.py
@@ -58,7 +58,7 @@ def build_capability_report(model, device, mode: str) -> dict[str, Any]:
         "bf16_supported": (
             torch.cuda.is_available() and torch.cuda.is_bf16_supported()
             if is_cuda
-            else False
+            else (device_type == "mps")
         ),
         "cpu_bf16_autocast": cpu_bf16_autocast if device_type == "cpu" else False,
         "model_class": type(model).__name__,
@@ -79,6 +79,8 @@ def validate_capability(report: dict[str, Any]) -> None:
     if mode == "fp16":
         if device_type == "cpu":
             raise RuntimeError("precision='fp16' is not supported on cpu in the current stage.")
+        if device_type == "mps":
+            return
         if not report["cuda_available"]:
             raise RuntimeError("precision='fp16' requires CUDA, but CUDA is not available.")
         return
@@ -104,6 +106,12 @@ def validate_capability(report: dict[str, Any]) -> None:
         if not report["cuda_available"]:
             raise RuntimeError(
                 "precision='fp8-torchao' requires CUDA, but CUDA is not available."
+            )
+        capability = report.get("cuda_device_capability")
+        if capability is None or capability < (8, 9):
+            raise RuntimeError(
+                "precision='fp8-torchao' requires compute capability >= 8.9; "
+                f"got {capability}."
             )
         return
 

--- a/spikingjelly/activation_based/precision/capability.py
+++ b/spikingjelly/activation_based/precision/capability.py
@@ -19,6 +19,7 @@ def build_capability_report(model, device, mode: str) -> dict[str, Any]:
     if is_cuda and torch.cuda.is_available():
         capability = torch.cuda.get_device_capability(device)
     torchao_installed = importlib.util.find_spec("torchao") is not None
+    cpu_bf16_autocast = hasattr(getattr(torch, "amp", None), "autocast")
     can_convert = True
     can_execute = True
     runtime_validation_required = False
@@ -59,6 +60,7 @@ def build_capability_report(model, device, mode: str) -> dict[str, Any]:
             if is_cuda
             else False
         ),
+        "cpu_bf16_autocast": cpu_bf16_autocast if device_type == "cpu" else False,
         "model_class": type(model).__name__,
         "can_convert": can_convert,
         "can_execute": can_execute,
@@ -83,6 +85,8 @@ def validate_capability(report: dict[str, Any]) -> None:
 
     if mode == "bf16":
         if device_type == "cpu":
+            return
+        if device_type == "mps" and report["bf16_supported"]:
             return
         if not report["cuda_available"]:
             raise RuntimeError("precision='bf16' requires CUDA or CPU bf16 autocast support.")

--- a/spikingjelly/activation_based/precision/capability.py
+++ b/spikingjelly/activation_based/precision/capability.py
@@ -86,9 +86,7 @@ def validate_capability(report: dict[str, Any]) -> None:
         return
 
     if mode == "bf16":
-        if device_type == "cpu":
-            return
-        if device_type == "mps" and report["bf16_supported"]:
+        if device_type in ("cpu", "mps"):
             return
         if not report["cuda_available"]:
             raise RuntimeError("precision='bf16' requires CUDA or CPU bf16 autocast support.")

--- a/spikingjelly/activation_based/precision/capability.py
+++ b/spikingjelly/activation_based/precision/capability.py
@@ -7,6 +7,7 @@ import torch
 
 
 def build_capability_report(model, device, mode: str) -> dict[str, Any]:
+    device = torch.device(device)
     device_str = str(device)
     if device_str.startswith("cuda"):
         device_type = "cuda"

--- a/spikingjelly/activation_based/precision/capability.py
+++ b/spikingjelly/activation_based/precision/capability.py
@@ -20,6 +20,13 @@ def build_capability_report(model, device, mode: str) -> dict[str, Any]:
         capability = torch.cuda.get_device_capability(device)
     torchao_installed = importlib.util.find_spec("torchao") is not None
     cpu_bf16_autocast = hasattr(getattr(torch, "amp", None), "autocast")
+    mps_backend = getattr(torch.backends, "mps", None)
+    mps_available = bool(mps_backend is not None and mps_backend.is_available())
+    mps_bf16_supported = bool(
+        mps_backend is not None
+        and mps_available
+        and getattr(mps_backend, "is_bf16_supported", lambda: False)()
+    )
     can_convert = True
     can_execute = True
     runtime_validation_required = False
@@ -58,9 +65,10 @@ def build_capability_report(model, device, mode: str) -> dict[str, Any]:
         "bf16_supported": (
             torch.cuda.is_available() and torch.cuda.is_bf16_supported()
             if is_cuda
-            else (device_type == "mps")
+            else mps_bf16_supported
         ),
         "cpu_bf16_autocast": cpu_bf16_autocast if device_type == "cpu" else False,
+        "mps_available": mps_available,
         "model_class": type(model).__name__,
         "can_convert": can_convert,
         "can_execute": can_execute,

--- a/spikingjelly/activation_based/precision/capability.py
+++ b/spikingjelly/activation_based/precision/capability.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import importlib.util
+from typing import Any
+
+import torch
+
+
+def build_capability_report(model, device, mode: str) -> dict[str, Any]:
+    device_str = str(device)
+    if device_str.startswith("cuda"):
+        device_type = "cuda"
+    elif device_str.startswith("mps"):
+        device_type = "mps"
+    else:
+        device_type = "cpu"
+    is_cuda = device_type == "cuda"
+    capability = None
+    if is_cuda and torch.cuda.is_available():
+        capability = torch.cuda.get_device_capability(device)
+    torchao_installed = importlib.util.find_spec("torchao") is not None
+    can_convert = True
+    can_execute = True
+    runtime_validation_required = False
+    execution_note = None
+
+    if mode == "fp8-torchao":
+        can_convert = torchao_installed
+        can_execute = (
+            is_cuda
+            and torch.cuda.is_available()
+            and capability is not None
+            and capability >= (8, 9)
+            and torchao_installed
+        )
+        runtime_validation_required = can_execute
+        if not torchao_installed:
+            execution_note = "torchao is not installed"
+        elif not is_cuda:
+            execution_note = "fp8-torchao requires a CUDA device"
+        elif capability is None or capability < (8, 9):
+            execution_note = "torch._scaled_mm requires compute capability >= 8.9"
+        else:
+            execution_note = (
+                "runtime execution still requires validation because cuBLASLt / torch._scaled_mm "
+                "support may fail on some environments"
+            )
+
+    return {
+        "requested_mode": mode,
+        "device": device_str,
+        "device_type": device_type,
+        "cuda_available": torch.cuda.is_available(),
+        "cuda_device_count": torch.cuda.device_count() if torch.cuda.is_available() else 0,
+        "cuda_device_capability": capability,
+        "torchao_installed": torchao_installed,
+        "bf16_supported": (
+            torch.cuda.is_available() and torch.cuda.is_bf16_supported()
+            if is_cuda
+            else False
+        ),
+        "model_class": type(model).__name__,
+        "can_convert": can_convert,
+        "can_execute": can_execute,
+        "runtime_validation_required": runtime_validation_required,
+        "execution_note": execution_note,
+    }
+
+
+def validate_capability(report: dict[str, Any]) -> None:
+    mode = report["requested_mode"]
+    device_type = report["device_type"]
+
+    if mode == "fp32":
+        return
+
+    if mode == "fp16":
+        if device_type == "cpu":
+            raise RuntimeError("precision='fp16' is not supported on cpu in the current stage.")
+        if not report["cuda_available"]:
+            raise RuntimeError("precision='fp16' requires CUDA, but CUDA is not available.")
+        return
+
+    if mode == "bf16":
+        if device_type == "cpu":
+            return
+        if not report["cuda_available"]:
+            raise RuntimeError("precision='bf16' requires CUDA or CPU bf16 autocast support.")
+        if not report["bf16_supported"]:
+            raise RuntimeError(
+                "precision='bf16' was requested on CUDA, but this CUDA device does not report bf16 support."
+            )
+        return
+
+    if mode == "fp8-torchao":
+        if device_type != "cuda":
+            raise RuntimeError(
+                "precision='fp8-torchao' is only supported on CUDA in the current stage."
+            )
+        if not report["cuda_available"]:
+            raise RuntimeError(
+                "precision='fp8-torchao' requires CUDA, but CUDA is not available."
+            )
+        return
+
+    raise RuntimeError(
+        f"Unsupported precision mode {mode!r}. Current stage supports: fp32, fp16, bf16, fp8-torchao."
+    )

--- a/spikingjelly/activation_based/precision/capability.py
+++ b/spikingjelly/activation_based/precision/capability.py
@@ -66,7 +66,7 @@ def build_capability_report(model, device, mode: str) -> dict[str, Any]:
         "bf16_supported": (
             torch.cuda.is_available() and torch.cuda.is_bf16_supported()
             if is_cuda
-            else mps_bf16_supported
+            else (mps_bf16_supported if device_type == "mps" else cpu_bf16_autocast)
         ),
         "cpu_bf16_autocast": cpu_bf16_autocast if device_type == "cpu" else False,
         "mps_available": mps_available,

--- a/spikingjelly/activation_based/precision/capability.py
+++ b/spikingjelly/activation_based/precision/capability.py
@@ -60,7 +60,9 @@ def build_capability_report(model, device, mode: str) -> dict[str, Any]:
         "device": device_str,
         "device_type": device_type,
         "cuda_available": torch.cuda.is_available(),
-        "cuda_device_count": torch.cuda.device_count() if torch.cuda.is_available() else 0,
+        "cuda_device_count": torch.cuda.device_count()
+        if torch.cuda.is_available()
+        else 0,
         "cuda_device_capability": capability,
         "torchao_installed": torchao_installed,
         "bf16_supported": (
@@ -87,11 +89,15 @@ def validate_capability(report: dict[str, Any]) -> None:
 
     if mode == "fp16":
         if device_type == "cpu":
-            raise RuntimeError("precision='fp16' is not supported on cpu in the current stage.")
+            raise RuntimeError(
+                "precision='fp16' is not supported on cpu in the current stage."
+            )
         if device_type == "mps":
             return
         if not report["cuda_available"]:
-            raise RuntimeError("precision='fp16' requires CUDA, but CUDA is not available.")
+            raise RuntimeError(
+                "precision='fp16' requires CUDA, but CUDA is not available."
+            )
         return
 
     if mode == "bf16":
@@ -104,7 +110,9 @@ def validate_capability(report: dict[str, Any]) -> None:
                 )
             return
         if not report["cuda_available"]:
-            raise RuntimeError("precision='bf16' requires CUDA or CPU bf16 autocast support.")
+            raise RuntimeError(
+                "precision='bf16' requires CUDA or CPU bf16 autocast support."
+            )
         if not report["bf16_supported"]:
             raise RuntimeError(
                 "precision='bf16' was requested on CUDA, but this CUDA device does not report bf16 support."

--- a/spikingjelly/activation_based/precision/capability.py
+++ b/spikingjelly/activation_based/precision/capability.py
@@ -94,7 +94,13 @@ def validate_capability(report: dict[str, Any]) -> None:
         return
 
     if mode == "bf16":
-        if device_type in ("cpu", "mps"):
+        if device_type == "cpu":
+            return
+        if device_type == "mps":
+            if not report["bf16_supported"]:
+                raise RuntimeError(
+                    "precision='bf16' was requested on MPS, but this MPS device does not support bf16."
+                )
             return
         if not report["cuda_available"]:
             raise RuntimeError("precision='bf16' requires CUDA or CPU bf16 autocast support.")

--- a/spikingjelly/activation_based/precision/capability.py
+++ b/spikingjelly/activation_based/precision/capability.py
@@ -124,6 +124,8 @@ def validate_capability(report: dict[str, Any]) -> None:
                 "precision='fp8-torchao' requires CUDA, but CUDA is not available."
             )
         capability = report.get("cuda_device_capability")
+        if capability is not None:
+            capability = tuple(capability)
         if capability is None or capability < (8, 9):
             raise RuntimeError(
                 "precision='fp8-torchao' requires compute capability >= 8.9; "

--- a/spikingjelly/activation_based/precision/capability.py
+++ b/spikingjelly/activation_based/precision/capability.py
@@ -105,6 +105,10 @@ def validate_capability(report: dict[str, Any]) -> None:
         return
 
     if mode == "fp8-torchao":
+        if not report.get("torchao_installed", False):
+            raise RuntimeError(
+                "precision='fp8-torchao' requires torchao, but torchao is not installed."
+            )
         if device_type != "cuda":
             raise RuntimeError(
                 "precision='fp8-torchao' is only supported on CUDA in the current stage."

--- a/spikingjelly/activation_based/precision/config.py
+++ b/spikingjelly/activation_based/precision/config.py
@@ -16,6 +16,8 @@ class PrecisionConfig:
     def __post_init__(self):
         if self.mode is not None:
             object.__setattr__(self, "mode", str(self.mode).lower())
+        else:
+            object.__setattr__(self, "mode", "fp32")
         if self.device is not None and not isinstance(self.device, str):
             object.__setattr__(self, "device", str(self.device))
 

--- a/spikingjelly/activation_based/precision/config.py
+++ b/spikingjelly/activation_based/precision/config.py
@@ -13,6 +13,12 @@ class PrecisionConfig:
     report: bool = True
     device: str | None = None
 
+    def __post_init__(self):
+        if self.mode is not None:
+            object.__setattr__(self, "mode", str(self.mode).lower())
+        if self.device is not None and not isinstance(self.device, str):
+            object.__setattr__(self, "device", str(self.device))
+
     @classmethod
     def from_any(
         cls,

--- a/spikingjelly/activation_based/precision/config.py
+++ b/spikingjelly/activation_based/precision/config.py
@@ -28,6 +28,8 @@ class PrecisionConfig:
         if config is None:
             return cls(device=default_device)
         if isinstance(config, cls):
+            if config.device is None and default_device is not None:
+                return dataclasses.replace(config, device=default_device)
             return config
         if isinstance(config, str):
             return cls(mode=config.lower(), device=default_device)
@@ -45,16 +47,14 @@ class PrecisionConfig:
 
         precision = getattr(config, "precision", None)
         if precision is not None:
+            device_attr = getattr(config, "device", None)
+            device_value = device_attr if device_attr is not None else default_device
             return cls(
                 mode=str(precision).lower(),
                 strictness=getattr(config, "precision_strict", "warn"),
                 fp8_recipe=getattr(config, "fp8_recipe", "auto"),
                 report=getattr(config, "fp8_report", True),
-                device=(
-                    str(getattr(config, "device", default_device))
-                    if getattr(config, "device", default_device) is not None
-                    else None
-                ),
+                device=str(device_value) if device_value is not None else None,
             )
 
         if hasattr(config, "disable_amp") or hasattr(config, "device"):

--- a/spikingjelly/activation_based/precision/config.py
+++ b/spikingjelly/activation_based/precision/config.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PrecisionConfig:
+    mode: str = "fp32"
+    strictness: str = "warn"
+    fp8_recipe: str = "auto"
+    report: bool = True
+    device: str | None = None
+
+    @classmethod
+    def from_any(
+        cls,
+        config: "PrecisionConfig | str | dict | Any",
+        default_device: str | None = None,
+    ) -> "PrecisionConfig":
+        if isinstance(config, cls):
+            return config
+        if isinstance(config, str):
+            return cls(mode=config.lower(), device=default_device)
+        if isinstance(config, dict):
+            data = dict(config)
+            if "device" not in data:
+                data["device"] = default_device
+            if "precision" in data and "mode" not in data:
+                data["mode"] = data.pop("precision")
+            return cls(**data)
+
+        precision = getattr(config, "precision", None)
+        if precision is not None:
+            return cls(
+                mode=str(precision).lower(),
+                strictness=getattr(config, "precision_strict", "warn"),
+                fp8_recipe=getattr(config, "fp8_recipe", "auto"),
+                report=getattr(config, "fp8_report", True),
+                device=getattr(config, "device", default_device),
+            )
+
+        if hasattr(config, "disable_amp") or hasattr(config, "device"):
+            if getattr(config, "disable_amp", False):
+                mode = "fp32"
+            else:
+                device = str(getattr(config, "device", default_device or "cpu"))
+                mode = "fp16" if device.startswith("cuda") else "fp32"
+            return cls(mode=mode, device=getattr(config, "device", default_device))
+
+        raise TypeError(
+            "PrecisionConfig.from_any() expects a PrecisionConfig, str, dict, or an object "
+            "with precision/disable_amp/device-style attributes."
+        )

--- a/spikingjelly/activation_based/precision/config.py
+++ b/spikingjelly/activation_based/precision/config.py
@@ -26,6 +26,8 @@ class PrecisionConfig:
             data = dict(config)
             if "device" not in data:
                 data["device"] = default_device
+            elif data["device"] is not None:
+                data["device"] = str(data["device"])
             if "precision" in data and "mode" not in data:
                 data["mode"] = data.pop("precision")
             return cls(**data)
@@ -37,7 +39,11 @@ class PrecisionConfig:
                 strictness=getattr(config, "precision_strict", "warn"),
                 fp8_recipe=getattr(config, "fp8_recipe", "auto"),
                 report=getattr(config, "fp8_report", True),
-                device=getattr(config, "device", default_device),
+                device=(
+                    str(getattr(config, "device", default_device))
+                    if getattr(config, "device", default_device) is not None
+                    else None
+                ),
             )
 
         if hasattr(config, "disable_amp") or hasattr(config, "device"):
@@ -46,7 +52,11 @@ class PrecisionConfig:
             else:
                 device = str(getattr(config, "device", default_device or "cpu"))
                 mode = "fp16" if device.startswith("cuda") else "fp32"
-            return cls(mode=mode, device=getattr(config, "device", default_device))
+            device_value = getattr(config, "device", default_device)
+            return cls(
+                mode=mode,
+                device=str(device_value) if device_value is not None else None,
+            )
 
         raise TypeError(
             "PrecisionConfig.from_any() expects a PrecisionConfig, str, dict, or an object "

--- a/spikingjelly/activation_based/precision/config.py
+++ b/spikingjelly/activation_based/precision/config.py
@@ -19,6 +19,8 @@ class PrecisionConfig:
         config: "PrecisionConfig | str | dict | Any",
         default_device: str | None = None,
     ) -> "PrecisionConfig":
+        if config is None:
+            return cls(device=default_device)
         if isinstance(config, cls):
             return config
         if isinstance(config, str):

--- a/spikingjelly/activation_based/precision/config.py
+++ b/spikingjelly/activation_based/precision/config.py
@@ -43,6 +43,10 @@ class PrecisionConfig:
                 data["device"] = str(data["device"])
             if "precision" in data and "mode" not in data:
                 data["mode"] = data.pop("precision")
+            if "precision_strict" in data and "strictness" not in data:
+                data["strictness"] = data.pop("precision_strict")
+            if "fp8_report" in data and "report" not in data:
+                data["report"] = data.pop("fp8_report")
             valid_fields = {f.name for f in dataclasses.fields(cls)}
             filtered_data = {k: v for k, v in data.items() if k in valid_fields}
             return cls(**filtered_data)

--- a/spikingjelly/activation_based/precision/config.py
+++ b/spikingjelly/activation_based/precision/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass
 from typing import Any
 
@@ -30,7 +31,9 @@ class PrecisionConfig:
                 data["device"] = str(data["device"])
             if "precision" in data and "mode" not in data:
                 data["mode"] = data.pop("precision")
-            return cls(**data)
+            valid_fields = {f.name for f in dataclasses.fields(cls)}
+            filtered_data = {k: v for k, v in data.items() if k in valid_fields}
+            return cls(**filtered_data)
 
         precision = getattr(config, "precision", None)
         if precision is not None:

--- a/spikingjelly/activation_based/precision/config.py
+++ b/spikingjelly/activation_based/precision/config.py
@@ -58,12 +58,13 @@ class PrecisionConfig:
             )
 
         if hasattr(config, "disable_amp") or hasattr(config, "device"):
+            device_attr = getattr(config, "device", None)
+            device_value = device_attr if device_attr is not None else default_device
             if getattr(config, "disable_amp", False):
                 mode = "fp32"
             else:
-                device = str(getattr(config, "device", default_device or "cpu"))
+                device = str(device_value or "cpu")
                 mode = "fp16" if device.startswith("cuda") else "fp32"
-            device_value = getattr(config, "device", default_device)
             return cls(
                 mode=mode,
                 device=str(device_value) if device_value is not None else None,

--- a/spikingjelly/activation_based/precision/convert.py
+++ b/spikingjelly/activation_based/precision/convert.py
@@ -35,7 +35,7 @@ class ConversionReport:
 
 def analyze_convertible_modules(model: nn.Module) -> ConversionReport:
     report = ConversionReport()
-    unsupported_types = (nn.Conv1d, nn.Conv2d, nn.Conv3d, nn.LayerNorm, nn.MultiheadAttention)
+    unsupported_types = (nn.Conv1d, nn.Conv2d, nn.Conv3d, nn.MultiheadAttention)
     high_precision_types = (
         BaseNode,
         SimpleBaseNode,

--- a/spikingjelly/activation_based/precision/convert.py
+++ b/spikingjelly/activation_based/precision/convert.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import torch.nn as nn
+
+from .. import layer
+from ..neuron.base_node import BaseNode, SimpleBaseNode
+from .float8_base import wrap_float8_linear_module
+
+
+@dataclass
+class ConversionReport:
+    total_modules: int = 0
+    convertible_linear: int = 0
+    convertible_torch_linear: int = 0
+    convertible_modules: list[str] = field(default_factory=list)
+    converted_modules: list[str] = field(default_factory=list)
+    skipped_modules: list[str] = field(default_factory=list)
+    high_precision_modules: list[str] = field(default_factory=list)
+    unsupported_modules: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "total_modules": self.total_modules,
+            "convertible_linear": self.convertible_linear,
+            "convertible_torch_linear": self.convertible_torch_linear,
+            "convertible_modules": self.convertible_modules,
+            "converted_modules": self.converted_modules,
+            "skipped_modules": self.skipped_modules,
+            "high_precision_modules": self.high_precision_modules,
+            "unsupported_modules": self.unsupported_modules,
+        }
+
+
+def analyze_convertible_modules(model: nn.Module) -> ConversionReport:
+    report = ConversionReport()
+    unsupported_types = (nn.Conv1d, nn.Conv2d, nn.Conv3d, nn.LayerNorm, nn.MultiheadAttention)
+    high_precision_types = (
+        BaseNode,
+        SimpleBaseNode,
+        nn.BatchNorm1d,
+        nn.BatchNorm2d,
+        nn.BatchNorm3d,
+        nn.LayerNorm,
+    )
+    for name, module in model.named_modules():
+        report.total_modules += 1
+        if isinstance(module, layer.Linear):
+            report.convertible_linear += 1
+            report.convertible_modules.append(name or "<root>")
+        elif isinstance(module, nn.Linear):
+            report.convertible_torch_linear += 1
+            report.convertible_modules.append(name or "<root>")
+        elif isinstance(module, high_precision_types):
+            report.high_precision_modules.append(name or "<root>")
+        elif isinstance(module, unsupported_types):
+            report.unsupported_modules.append(name or "<root>")
+    return report
+
+
+def convert_model_for_precision(model: nn.Module, policy) -> tuple[nn.Module, ConversionReport]:
+    report = analyze_convertible_modules(model)
+    if getattr(policy, "name", "") == "fp8-torchao":
+        from torchao.float8 import convert_to_float8_training
+
+        def module_filter_fn(module: nn.Module, fqn: str) -> bool:
+            return isinstance(module, (nn.Linear, layer.Linear))
+
+        def recursive_convert(module: nn.Module, prefix: str = ""):
+            for child_name, child in list(module.named_children()):
+                child_fqn = f"{prefix}.{child_name}" if prefix else child_name
+                if isinstance(child, (nn.Linear, layer.Linear)):
+                    converted = convert_to_float8_training(
+                        child,
+                        module_filter_fn=lambda _m, _fqn: True,
+                        config=policy.float8_linear_config,
+                    )
+                    setattr(module, child_name, wrap_float8_linear_module(child, converted))
+                    report.converted_modules.append(child_fqn)
+                else:
+                    report.skipped_modules.append(child_fqn)
+                    recursive_convert(child, child_fqn)
+
+        recursive_convert(model)
+    return model, report

--- a/spikingjelly/activation_based/precision/convert.py
+++ b/spikingjelly/activation_based/precision/convert.py
@@ -74,9 +74,14 @@ def convert_model_for_precision(model: nn.Module, policy) -> tuple[nn.Module, Co
             report.converted_modules.append("<root>")
             return wrap_float8_linear_module(model, converted), report
 
+        visited = set()
+
         def recursive_convert(module: nn.Module, prefix: str = "", memo=None):
             if memo is None:
                 memo = {}
+            if module in visited:
+                return
+            visited.add(module)
             for child_name, child in list(module.named_children()):
                 child_fqn = f"{prefix}.{child_name}" if prefix else child_name
                 if isinstance(child, (nn.Linear, layer.Linear)):

--- a/spikingjelly/activation_based/precision/convert.py
+++ b/spikingjelly/activation_based/precision/convert.py
@@ -64,8 +64,14 @@ def convert_model_for_precision(model: nn.Module, policy) -> tuple[nn.Module, Co
     if getattr(policy, "name", "") == "fp8-torchao":
         from torchao.float8 import convert_to_float8_training
 
-        def module_filter_fn(module: nn.Module, fqn: str) -> bool:
-            return isinstance(module, (nn.Linear, layer.Linear))
+        if isinstance(model, (nn.Linear, layer.Linear)):
+            converted = convert_to_float8_training(
+                model,
+                module_filter_fn=lambda _m, _fqn: True,
+                config=policy.float8_linear_config,
+            )
+            report.converted_modules.append("<root>")
+            return wrap_float8_linear_module(model, converted), report
 
         def recursive_convert(module: nn.Module, prefix: str = ""):
             for child_name, child in list(module.named_children()):

--- a/spikingjelly/activation_based/precision/convert.py
+++ b/spikingjelly/activation_based/precision/convert.py
@@ -78,6 +78,8 @@ def convert_model_for_precision(model: nn.Module, policy) -> tuple[nn.Module, Co
             if memo is None:
                 memo = {}
             for child_name, child in list(module._modules.items()):
+                if child is None:
+                    continue
                 child_fqn = f"{prefix}.{child_name}" if prefix else child_name
                 if isinstance(child, (nn.Linear, layer.Linear)):
                     if child in memo:

--- a/spikingjelly/activation_based/precision/convert.py
+++ b/spikingjelly/activation_based/precision/convert.py
@@ -74,9 +74,11 @@ def convert_model_for_precision(model: nn.Module, policy) -> tuple[nn.Module, Co
             report.converted_modules.append("<root>")
             return wrap_float8_linear_module(model, converted), report
 
-        def recursive_convert(module: nn.Module, prefix: str = "", memo=None):
+        def recursive_convert(module: nn.Module, prefix: str = "", memo=None, visited=None):
             if memo is None:
                 memo = {}
+            if visited is None:
+                visited = set()
             for child_name, child in list(module._modules.items()):
                 if child is None:
                     continue
@@ -104,7 +106,11 @@ def convert_model_for_precision(model: nn.Module, policy) -> tuple[nn.Module, Co
                     report.converted_modules.append(child_fqn)
                 else:
                     report.skipped_modules.append(child_fqn)
-                    recursive_convert(child, child_fqn, memo)
+                    child_id = id(child)
+                    if child_id in visited:
+                        continue
+                    visited.add(child_id)
+                    recursive_convert(child, child_fqn, memo, visited)
 
         recursive_convert(model)
     return model, report

--- a/spikingjelly/activation_based/precision/convert.py
+++ b/spikingjelly/activation_based/precision/convert.py
@@ -59,10 +59,13 @@ def analyze_convertible_modules(model: nn.Module) -> ConversionReport:
     return report
 
 
-def convert_model_for_precision(model: nn.Module, policy) -> tuple[nn.Module, ConversionReport]:
+def convert_model_for_precision(
+    model: nn.Module, policy
+) -> tuple[nn.Module, ConversionReport]:
     report = analyze_convertible_modules(model)
     if getattr(policy, "name", "") == "fp8-torchao":
         from torchao.float8.float8_linear import Float8Linear
+
         fp8_config = getattr(policy, "float8_linear_config", None)
         if fp8_config is None:
             raise RuntimeError(
@@ -74,7 +77,9 @@ def convert_model_for_precision(model: nn.Module, policy) -> tuple[nn.Module, Co
             report.converted_modules.append("<root>")
             return wrap_float8_linear_module(model, converted), report
 
-        def recursive_convert(module: nn.Module, prefix: str = "", memo=None, visited=None):
+        def recursive_convert(
+            module: nn.Module, prefix: str = "", memo=None, visited=None
+        ):
             if memo is None:
                 memo = {}
             if visited is None:

--- a/spikingjelly/activation_based/precision/convert.py
+++ b/spikingjelly/activation_based/precision/convert.py
@@ -63,12 +63,17 @@ def convert_model_for_precision(model: nn.Module, policy) -> tuple[nn.Module, Co
     report = analyze_convertible_modules(model)
     if getattr(policy, "name", "") == "fp8-torchao":
         from torchao.float8 import convert_to_float8_training
+        fp8_config = getattr(policy, "float8_linear_config", None)
+        if fp8_config is None:
+            raise RuntimeError(
+                "Float8TorchAOPolicy.check_capability() must be called before convert_model_for_precision()."
+            )
 
         if isinstance(model, (nn.Linear, layer.Linear)):
             converted = convert_to_float8_training(
                 model,
                 module_filter_fn=lambda _m, _fqn: True,
-                config=policy.float8_linear_config,
+                config=fp8_config,
             )
             report.converted_modules.append("<root>")
             return wrap_float8_linear_module(model, converted), report
@@ -80,7 +85,7 @@ def convert_model_for_precision(model: nn.Module, policy) -> tuple[nn.Module, Co
                     converted = convert_to_float8_training(
                         child,
                         module_filter_fn=lambda _m, _fqn: True,
-                        config=policy.float8_linear_config,
+                        config=fp8_config,
                     )
                     setattr(module, child_name, wrap_float8_linear_module(child, converted))
                     report.converted_modules.append(child_fqn)

--- a/spikingjelly/activation_based/precision/convert.py
+++ b/spikingjelly/activation_based/precision/convert.py
@@ -87,7 +87,7 @@ def convert_model_for_precision(model: nn.Module, policy) -> tuple[nn.Module, Co
                 if isinstance(child, (nn.Linear, layer.Linear)):
                     if child in memo:
                         wrapped = memo[child]
-                        if isinstance(module, nn.ModuleList):
+                        if isinstance(module, (nn.ModuleList, nn.Sequential)):
                             module[int(child_name)] = wrapped
                         elif isinstance(module, nn.ModuleDict):
                             module[child_name] = wrapped
@@ -98,7 +98,7 @@ def convert_model_for_precision(model: nn.Module, policy) -> tuple[nn.Module, Co
                     converted = Float8Linear.from_float(child, config=fp8_config)
                     wrapped = wrap_float8_linear_module(child, converted)
                     memo[child] = wrapped
-                    if isinstance(module, nn.ModuleList):
+                    if isinstance(module, (nn.ModuleList, nn.Sequential)):
                         module[int(child_name)] = wrapped
                     elif isinstance(module, nn.ModuleDict):
                         module[child_name] = wrapped

--- a/spikingjelly/activation_based/precision/convert.py
+++ b/spikingjelly/activation_based/precision/convert.py
@@ -62,7 +62,7 @@ def analyze_convertible_modules(model: nn.Module) -> ConversionReport:
 def convert_model_for_precision(model: nn.Module, policy) -> tuple[nn.Module, ConversionReport]:
     report = analyze_convertible_modules(model)
     if getattr(policy, "name", "") == "fp8-torchao":
-        from torchao.float8 import convert_to_float8_training
+        from torchao.float8.float8_linear import Float8Linear
         fp8_config = getattr(policy, "float8_linear_config", None)
         if fp8_config is None:
             raise RuntimeError(
@@ -70,28 +70,39 @@ def convert_model_for_precision(model: nn.Module, policy) -> tuple[nn.Module, Co
             )
 
         if isinstance(model, (nn.Linear, layer.Linear)):
-            converted = convert_to_float8_training(
-                model,
-                module_filter_fn=lambda _m, _fqn: True,
-                config=fp8_config,
-            )
+            converted = Float8Linear.from_float(model, config=fp8_config)
             report.converted_modules.append("<root>")
             return wrap_float8_linear_module(model, converted), report
 
-        def recursive_convert(module: nn.Module, prefix: str = ""):
+        def recursive_convert(module: nn.Module, prefix: str = "", memo=None):
+            if memo is None:
+                memo = {}
             for child_name, child in list(module.named_children()):
                 child_fqn = f"{prefix}.{child_name}" if prefix else child_name
                 if isinstance(child, (nn.Linear, layer.Linear)):
-                    converted = convert_to_float8_training(
-                        child,
-                        module_filter_fn=lambda _m, _fqn: True,
-                        config=fp8_config,
-                    )
-                    setattr(module, child_name, wrap_float8_linear_module(child, converted))
+                    if child in memo:
+                        wrapped = memo[child]
+                        if isinstance(module, nn.ModuleList):
+                            module[int(child_name)] = wrapped
+                        elif isinstance(module, nn.ModuleDict):
+                            module[child_name] = wrapped
+                        else:
+                            setattr(module, child_name, wrapped)
+                        report.converted_modules.append(child_fqn)
+                        continue
+                    converted = Float8Linear.from_float(child, config=fp8_config)
+                    wrapped = wrap_float8_linear_module(child, converted)
+                    memo[child] = wrapped
+                    if isinstance(module, nn.ModuleList):
+                        module[int(child_name)] = wrapped
+                    elif isinstance(module, nn.ModuleDict):
+                        module[child_name] = wrapped
+                    else:
+                        setattr(module, child_name, wrapped)
                     report.converted_modules.append(child_fqn)
                 else:
                     report.skipped_modules.append(child_fqn)
-                    recursive_convert(child, child_fqn)
+                    recursive_convert(child, child_fqn, memo)
 
         recursive_convert(model)
     return model, report

--- a/spikingjelly/activation_based/precision/convert.py
+++ b/spikingjelly/activation_based/precision/convert.py
@@ -74,15 +74,10 @@ def convert_model_for_precision(model: nn.Module, policy) -> tuple[nn.Module, Co
             report.converted_modules.append("<root>")
             return wrap_float8_linear_module(model, converted), report
 
-        visited = set()
-
         def recursive_convert(module: nn.Module, prefix: str = "", memo=None):
             if memo is None:
                 memo = {}
-            if module in visited:
-                return
-            visited.add(module)
-            for child_name, child in list(module.named_children()):
+            for child_name, child in list(module._modules.items()):
                 child_fqn = f"{prefix}.{child_name}" if prefix else child_name
                 if isinstance(child, (nn.Linear, layer.Linear)):
                     if child in memo:

--- a/spikingjelly/activation_based/precision/float8_base.py
+++ b/spikingjelly/activation_based/precision/float8_base.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from .. import functional, layer
+
+
+class Float8LinearStepModule(nn.Module):
+    def __init__(self, wrapped: nn.Module, step_mode: str = "s"):
+        super().__init__()
+        self.wrapped = wrapped
+        self.step_mode = step_mode
+
+    def forward(self, x: torch.Tensor):
+        if self.step_mode == "s":
+            return self.wrapped(x)
+        if self.step_mode == "m":
+            return functional.seq_to_ann_forward(x, self.wrapped)
+        raise ValueError(f"Unsupported step_mode {self.step_mode!r}.")
+
+
+def wrap_float8_linear_module(original: nn.Module, converted: nn.Module) -> nn.Module:
+    if isinstance(original, layer.Linear):
+        return Float8LinearStepModule(converted, step_mode=original.step_mode)
+    return converted
+
+__all__ = ["Float8LinearStepModule", "wrap_float8_linear_module"]

--- a/spikingjelly/activation_based/precision/float8_base.py
+++ b/spikingjelly/activation_based/precision/float8_base.py
@@ -11,6 +11,8 @@ class Float8LinearStepModule(nn.Module):
         super().__init__()
         self.wrapped = wrapped
         self.step_mode = step_mode
+        self._wrapped_load_from_state_dict = wrapped._load_from_state_dict
+        self.wrapped._load_from_state_dict = lambda *args, **kwargs: None
 
     def forward(self, x: torch.Tensor):
         if self.step_mode == "s":
@@ -40,7 +42,7 @@ class Float8LinearStepModule(nn.Module):
         unexpected_keys,
         error_msgs,
     ):
-        self.wrapped._load_from_state_dict(
+        self._wrapped_load_from_state_dict(
             state_dict,
             prefix,
             local_metadata,

--- a/spikingjelly/activation_based/precision/float8_base.py
+++ b/spikingjelly/activation_based/precision/float8_base.py
@@ -11,8 +11,6 @@ class Float8LinearStepModule(nn.Module):
         super().__init__()
         self.wrapped = wrapped
         self.step_mode = step_mode
-        self._wrapped_load_from_state_dict = wrapped._load_from_state_dict
-        self.wrapped._load_from_state_dict = lambda *args, **kwargs: None
 
     def forward(self, x: torch.Tensor):
         if self.step_mode == "s":
@@ -25,12 +23,20 @@ class Float8LinearStepModule(nn.Module):
         try:
             return super().__getattr__(name)
         except AttributeError:
-            return getattr(self.wrapped, name)
+            wrapped = self.__dict__.get("_modules", {}).get("wrapped")
+            if wrapped is None:
+                raise AttributeError(
+                    f"'{type(self).__name__}' object has no attribute '{name}'"
+                )
+            return getattr(wrapped, name)
 
     def state_dict(self, destination=None, prefix="", keep_vars=False):
         return self.wrapped.state_dict(
             destination=destination, prefix=prefix, keep_vars=keep_vars
         )
+
+    def _save_to_state_dict(self, destination, prefix, keep_vars):
+        self.wrapped._save_to_state_dict(destination, prefix, keep_vars)
 
     def _load_from_state_dict(
         self,
@@ -42,9 +48,19 @@ class Float8LinearStepModule(nn.Module):
         unexpected_keys,
         error_msgs,
     ):
-        self._wrapped_load_from_state_dict(
+        wrapped_prefix = prefix + "wrapped."
+        keys_to_rename = [
+            k
+            for k in list(state_dict.keys())
+            if k.startswith(prefix) and not k.startswith(wrapped_prefix)
+        ]
+        for k in keys_to_rename:
+            suffix = k[len(prefix) :]
+            state_dict[wrapped_prefix + suffix] = state_dict.pop(k)
+        type(self.wrapped)._load_from_state_dict(
+            self.wrapped,
             state_dict,
-            prefix,
+            wrapped_prefix,
             local_metadata,
             strict,
             missing_keys,

--- a/spikingjelly/activation_based/precision/float8_base.py
+++ b/spikingjelly/activation_based/precision/float8_base.py
@@ -7,6 +7,16 @@ from .. import functional, layer
 
 
 class Float8LinearStepModule(nn.Module):
+    """Step-mode wrapper around a float8 linear module.
+
+    Note:
+        `_load_from_state_dict` rewrites the provided state_dict keys in place
+        from `prefix + key` to `prefix + "wrapped." + key` so that PyTorch's
+        recursive loading can populate the registered `wrapped` child module.
+        Callers that intend to reuse the same state dict object elsewhere should
+        clone or copy it first.
+    """
+
     def __init__(self, wrapped: nn.Module, step_mode: str = "s"):
         super().__init__()
         self.wrapped = wrapped

--- a/spikingjelly/activation_based/precision/float8_base.py
+++ b/spikingjelly/activation_based/precision/float8_base.py
@@ -19,6 +19,37 @@ class Float8LinearStepModule(nn.Module):
             return functional.seq_to_ann_forward(x, self.wrapped)
         raise ValueError(f"Unsupported step_mode {self.step_mode!r}.")
 
+    def __getattr__(self, name: str):
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            return getattr(self.wrapped, name)
+
+    def state_dict(self, destination=None, prefix="", keep_vars=False):
+        return self.wrapped.state_dict(
+            destination=destination, prefix=prefix, keep_vars=keep_vars
+        )
+
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        self.wrapped._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+
 
 def wrap_float8_linear_module(original: nn.Module, converted: nn.Module) -> nn.Module:
     if isinstance(original, layer.Linear):

--- a/spikingjelly/activation_based/precision/float8_base.py
+++ b/spikingjelly/activation_based/precision/float8_base.py
@@ -62,6 +62,7 @@ class Float8LinearStepModule(nn.Module):
         error_msgs,
     ):
         wrapped_prefix = prefix + "wrapped."
+        wrapped_keys = set(self.wrapped.state_dict().keys())
         keys_to_rename = [
             k
             for k in list(state_dict.keys())
@@ -69,7 +70,8 @@ class Float8LinearStepModule(nn.Module):
         ]
         for k in keys_to_rename:
             suffix = k[len(prefix) :]
-            state_dict[wrapped_prefix + suffix] = state_dict.pop(k)
+            if suffix in wrapped_keys:
+                state_dict[wrapped_prefix + suffix] = state_dict.pop(k)
 
 
 def wrap_float8_linear_module(original: nn.Module, converted: nn.Module) -> nn.Module:

--- a/spikingjelly/activation_based/precision/float8_base.py
+++ b/spikingjelly/activation_based/precision/float8_base.py
@@ -12,6 +12,9 @@ class Float8LinearStepModule(nn.Module):
         self.wrapped = wrapped
         self.step_mode = step_mode
 
+    def set_step_mode(self, step_mode: str):
+        self.step_mode = step_mode
+
     def forward(self, x: torch.Tensor):
         if self.step_mode == "s":
             return self.wrapped(x)
@@ -62,6 +65,8 @@ class Float8LinearStepModule(nn.Module):
 def wrap_float8_linear_module(original: nn.Module, converted: nn.Module) -> nn.Module:
     if isinstance(original, layer.Linear):
         return Float8LinearStepModule(converted, step_mode=original.step_mode)
+    if isinstance(original, nn.Linear):
+        return Float8LinearStepModule(converted, step_mode="s")
     return converted
 
 __all__ = ["Float8LinearStepModule", "wrap_float8_linear_module"]

--- a/spikingjelly/activation_based/precision/float8_base.py
+++ b/spikingjelly/activation_based/precision/float8_base.py
@@ -57,16 +57,6 @@ class Float8LinearStepModule(nn.Module):
         for k in keys_to_rename:
             suffix = k[len(prefix) :]
             state_dict[wrapped_prefix + suffix] = state_dict.pop(k)
-        type(self.wrapped)._load_from_state_dict(
-            self.wrapped,
-            state_dict,
-            wrapped_prefix,
-            local_metadata,
-            strict,
-            missing_keys,
-            unexpected_keys,
-            error_msgs,
-        )
 
 
 def wrap_float8_linear_module(original: nn.Module, converted: nn.Module) -> nn.Module:

--- a/spikingjelly/activation_based/precision/float8_base.py
+++ b/spikingjelly/activation_based/precision/float8_base.py
@@ -81,4 +81,5 @@ def wrap_float8_linear_module(original: nn.Module, converted: nn.Module) -> nn.M
         return Float8LinearStepModule(converted, step_mode="s")
     return converted
 
+
 __all__ = ["Float8LinearStepModule", "wrap_float8_linear_module"]

--- a/spikingjelly/activation_based/precision/float8_torchao.py
+++ b/spikingjelly/activation_based/precision/float8_torchao.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import importlib.util
+
+from torchao.float8 import Float8LinearConfig
+
+from .policy import PrecisionPolicy
+
+
+class Float8TorchAOPolicy(PrecisionPolicy):
+    name = "fp8-torchao"
+
+    def __init__(self, device_type: str = "cuda", strict: str = "warn"):
+        super().__init__()
+        self.device_type = device_type
+        self.strict = strict
+        self.float8_linear_config = Float8LinearConfig()
+
+    def describe(self) -> dict:
+        return {
+            "name": self.name,
+            "backend": "torchao",
+            "device_type": self.device_type,
+            "strict": self.strict,
+            "float8_linear_config": type(self.float8_linear_config).__name__,
+            "autocast": False,
+            "grad_scaler": False,
+        }
+
+    def check_capability(self, model, device) -> None:
+        super().check_capability(model, device)
+        if importlib.util.find_spec("torchao") is None:
+            raise RuntimeError(
+                "precision='fp8-torchao' requires torchao, but torchao is not installed."
+            )
+        if self.device_type != "cuda":
+            raise RuntimeError(
+                "precision='fp8-torchao' is only supported on CUDA in the current stage."
+            )
+        if not str(device).startswith("cuda"):
+            raise RuntimeError(
+                "precision='fp8-torchao' requires a CUDA device in the current stage."
+            )

--- a/spikingjelly/activation_based/precision/float8_torchao.py
+++ b/spikingjelly/activation_based/precision/float8_torchao.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib.util
 import warnings
 
+import torch
+
 from .policy import PrecisionPolicy
 
 
@@ -61,8 +63,10 @@ class Float8TorchAOPolicy(PrecisionPolicy):
                 "precision='fp8-torchao' requires a CUDA device in the current stage."
             )
         model_devices = {p.device for p in model.parameters()}
-        if model_devices and not any(d.type == "cuda" for d in model_devices):
+        target_device = torch.device(device)
+        if model_devices and any(d != target_device for d in model_devices):
             raise RuntimeError(
-                f"The model must be moved to the target CUDA device (e.g. model.to('{device}')) "
-                "before calling prepare_model_for_precision() for 'fp8-torchao'."
+                f"All model parameters must be moved to the target CUDA device '{target_device}' "
+                f"(e.g. model.to('{target_device}')) before calling "
+                "prepare_model_for_precision() for 'fp8-torchao'."
             )

--- a/spikingjelly/activation_based/precision/float8_torchao.py
+++ b/spikingjelly/activation_based/precision/float8_torchao.py
@@ -64,6 +64,8 @@ class Float8TorchAOPolicy(PrecisionPolicy):
             )
         model_devices = {p.device for p in model.parameters()}
         target_device = torch.device(device)
+        if target_device.type == "cuda" and target_device.index is None:
+            target_device = torch.device("cuda", torch.cuda.current_device())
         if model_devices and any(d != target_device for d in model_devices):
             raise RuntimeError(
                 f"All model parameters must be moved to the target CUDA device '{target_device}' "

--- a/spikingjelly/activation_based/precision/float8_torchao.py
+++ b/spikingjelly/activation_based/precision/float8_torchao.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import importlib.util
 
-from torchao.float8 import Float8LinearConfig
-
 from .policy import PrecisionPolicy
 
 
@@ -14,7 +12,7 @@ class Float8TorchAOPolicy(PrecisionPolicy):
         super().__init__()
         self.device_type = device_type
         self.strict = strict
-        self.float8_linear_config = Float8LinearConfig()
+        self.float8_linear_config = None
 
     def describe(self) -> dict:
         return {
@@ -22,7 +20,11 @@ class Float8TorchAOPolicy(PrecisionPolicy):
             "backend": "torchao",
             "device_type": self.device_type,
             "strict": self.strict,
-            "float8_linear_config": type(self.float8_linear_config).__name__,
+            "float8_linear_config": (
+                type(self.float8_linear_config).__name__
+                if self.float8_linear_config is not None
+                else None
+            ),
             "autocast": False,
             "grad_scaler": False,
         }
@@ -33,6 +35,9 @@ class Float8TorchAOPolicy(PrecisionPolicy):
             raise RuntimeError(
                 "precision='fp8-torchao' requires torchao, but torchao is not installed."
             )
+        from torchao.float8 import Float8LinearConfig
+
+        self.float8_linear_config = Float8LinearConfig()
         if self.device_type != "cuda":
             raise RuntimeError(
                 "precision='fp8-torchao' is only supported on CUDA in the current stage."

--- a/spikingjelly/activation_based/precision/float8_torchao.py
+++ b/spikingjelly/activation_based/precision/float8_torchao.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import warnings
 
 from .policy import PrecisionPolicy
 
@@ -8,10 +9,16 @@ from .policy import PrecisionPolicy
 class Float8TorchAOPolicy(PrecisionPolicy):
     name = "fp8-torchao"
 
-    def __init__(self, device_type: str = "cuda", strict: str = "warn"):
+    def __init__(
+        self,
+        device_type: str = "cuda",
+        strict: str = "warn",
+        fp8_recipe: str = "auto",
+    ):
         super().__init__()
         self.device_type = device_type
         self.strict = strict
+        self.fp8_recipe = fp8_recipe
         self.float8_linear_config = None
 
     def describe(self) -> dict:
@@ -20,6 +27,7 @@ class Float8TorchAOPolicy(PrecisionPolicy):
             "backend": "torchao",
             "device_type": self.device_type,
             "strict": self.strict,
+            "fp8_recipe": self.fp8_recipe,
             "float8_linear_config": (
                 type(self.float8_linear_config).__name__
                 if self.float8_linear_config is not None
@@ -37,6 +45,12 @@ class Float8TorchAOPolicy(PrecisionPolicy):
             )
         from torchao.float8 import Float8LinearConfig
 
+        if self.fp8_recipe != "auto":
+            warnings.warn(
+                "fp8_recipe is currently ignored by the torchao backend and only kept for future extension.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         self.float8_linear_config = Float8LinearConfig()
         if self.device_type != "cuda":
             raise RuntimeError(

--- a/spikingjelly/activation_based/precision/float8_torchao.py
+++ b/spikingjelly/activation_based/precision/float8_torchao.py
@@ -60,3 +60,9 @@ class Float8TorchAOPolicy(PrecisionPolicy):
             raise RuntimeError(
                 "precision='fp8-torchao' requires a CUDA device in the current stage."
             )
+        model_devices = {p.device for p in model.parameters()}
+        if model_devices and not any(d.type == "cuda" for d in model_devices):
+            raise RuntimeError(
+                f"The model must be moved to the target CUDA device (e.g. model.to('{device}')) "
+                "before calling prepare_model_for_precision() for 'fp8-torchao'."
+            )

--- a/spikingjelly/activation_based/precision/policy.py
+++ b/spikingjelly/activation_based/precision/policy.py
@@ -74,7 +74,10 @@ class _AutocastPolicy(PrecisionPolicy):
     def create_grad_scaler(self):
         if self.device_type != "cuda":
             return None
-        return torch.amp.GradScaler("cuda")
+        try:
+            return torch.amp.GradScaler("cuda")
+        except AttributeError:
+            return torch.cuda.amp.GradScaler()
 
     def describe(self) -> dict:
         return {

--- a/spikingjelly/activation_based/precision/policy.py
+++ b/spikingjelly/activation_based/precision/policy.py
@@ -74,7 +74,7 @@ class _AutocastPolicy(PrecisionPolicy):
     def create_grad_scaler(self):
         if self.device_type != "cuda":
             return None
-        return torch.cuda.amp.GradScaler()
+        return torch.amp.GradScaler("cuda")
 
     def describe(self) -> dict:
         return {

--- a/spikingjelly/activation_based/precision/policy.py
+++ b/spikingjelly/activation_based/precision/policy.py
@@ -49,6 +49,8 @@ class PrecisionPolicy:
                 "convertible_torch_linear": 0,
                 "convertible_modules": [],
                 "converted_modules": [],
+                "skipped_modules": [],
+                "high_precision_modules": [],
                 "unsupported_modules": [],
             }
         return self._conversion_report.to_dict()

--- a/spikingjelly/activation_based/precision/policy.py
+++ b/spikingjelly/activation_based/precision/policy.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import torch
+
+from .capability import build_capability_report, validate_capability
+from .convert import convert_model_for_precision
+
+
+class PrecisionPolicy:
+    name = "fp32"
+
+    def __init__(self):
+        self._capability_report = None
+        self._conversion_report = None
+
+    def check_capability(self, model, device) -> None:
+        report = build_capability_report(model, device, self.name)
+        validate_capability(report)
+        self._capability_report = report
+
+    def prepare_model(self, model):
+        model, report = convert_model_for_precision(model, self)
+        self._conversion_report = report
+        return model
+
+    def autocast_context(self):
+        return nullcontext()
+
+    def create_grad_scaler(self):
+        return None
+
+    def describe(self) -> dict:
+        return {
+            "name": self.name,
+            "autocast": False,
+            "grad_scaler": False,
+        }
+
+    def capability_report(self) -> dict:
+        return self._capability_report or {"requested_mode": self.name}
+
+    def conversion_report(self) -> dict:
+        if self._conversion_report is None:
+            return {
+                "total_modules": 0,
+                "convertible_linear": 0,
+                "convertible_torch_linear": 0,
+                "convertible_modules": [],
+                "converted_modules": [],
+                "unsupported_modules": [],
+            }
+        return self._conversion_report.to_dict()
+
+
+class FP32Policy(PrecisionPolicy):
+    name = "fp32"
+
+
+class _AutocastPolicy(PrecisionPolicy):
+    amp_dtype: torch.dtype
+    name: str
+
+    def __init__(self, device_type: str = "cuda"):
+        super().__init__()
+        self.device_type = device_type
+
+    def autocast_context(self):
+        return torch.amp.autocast(self.device_type, dtype=self.amp_dtype)
+
+    def create_grad_scaler(self):
+        if self.device_type != "cuda":
+            return None
+        return torch.cuda.amp.GradScaler()
+
+    def describe(self) -> dict:
+        return {
+            "name": self.name,
+            "autocast": True,
+            "device_type": self.device_type,
+            "dtype": str(self.amp_dtype),
+            "grad_scaler": self.device_type == "cuda",
+        }
+
+
+class FP16Policy(_AutocastPolicy):
+    name = "fp16"
+    amp_dtype = torch.float16
+
+
+class BF16Policy(_AutocastPolicy):
+    name = "bf16"
+    amp_dtype = torch.bfloat16

--- a/spikingjelly/activation_based/precision/runtime.py
+++ b/spikingjelly/activation_based/precision/runtime.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import torch
+
+from .config import PrecisionConfig
+from .float8_torchao import Float8TorchAOPolicy
+from .policy import BF16Policy, FP16Policy, FP32Policy
+
+
+def normalize_precision_mode(config: PrecisionConfig | str | dict | object) -> str:
+    return PrecisionConfig.from_any(config).mode.lower()
+
+
+def resolve_precision_policy(config: PrecisionConfig | str | dict | object):
+    cfg = PrecisionConfig.from_any(config)
+    mode = cfg.mode.lower()
+    device = cfg.device or "cuda"
+    device_type = "cuda" if str(device).startswith("cuda") else "cpu"
+
+    if mode == "fp32":
+        return FP32Policy()
+    if mode == "fp16":
+        return FP16Policy(device_type=device_type)
+    if mode == "bf16":
+        return BF16Policy(device_type=device_type)
+    if mode == "fp8-torchao":
+        return Float8TorchAOPolicy(
+            device_type=device_type,
+            strict=cfg.strictness,
+        )
+
+    raise ValueError(
+        f"Unsupported precision mode {mode!r}. "
+        "Supported modes in the current stage are: fp32, fp16, bf16, fp8-torchao."
+    )

--- a/spikingjelly/activation_based/precision/runtime.py
+++ b/spikingjelly/activation_based/precision/runtime.py
@@ -33,6 +33,7 @@ def resolve_precision_policy(config: PrecisionConfig | str | dict | object):
         return Float8TorchAOPolicy(
             device_type=device_type,
             strict=cfg.strictness,
+            fp8_recipe=cfg.fp8_recipe,
         )
 
     raise ValueError(

--- a/spikingjelly/activation_based/precision/runtime.py
+++ b/spikingjelly/activation_based/precision/runtime.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import torch
 
 from .config import PrecisionConfig
-from .float8_torchao import Float8TorchAOPolicy
 from .policy import BF16Policy, FP16Policy, FP32Policy
 
 
@@ -15,7 +14,12 @@ def resolve_precision_policy(config: PrecisionConfig | str | dict | object):
     cfg = PrecisionConfig.from_any(config)
     mode = cfg.mode.lower()
     device = cfg.device or "cuda"
-    device_type = "cuda" if str(device).startswith("cuda") else "cpu"
+    if str(device).startswith("cuda"):
+        device_type = "cuda"
+    elif str(device).startswith("mps"):
+        device_type = "mps"
+    else:
+        device_type = "cpu"
 
     if mode == "fp32":
         return FP32Policy()
@@ -24,6 +28,8 @@ def resolve_precision_policy(config: PrecisionConfig | str | dict | object):
     if mode == "bf16":
         return BF16Policy(device_type=device_type)
     if mode == "fp8-torchao":
+        from .float8_torchao import Float8TorchAOPolicy
+
         return Float8TorchAOPolicy(
             device_type=device_type,
             strict=cfg.strictness,

--- a/test/activation_based/test_precision_conversion.py
+++ b/test/activation_based/test_precision_conversion.py
@@ -65,6 +65,15 @@ def test_float8_linear_step_module_load_state_dict_from_parent():
     parent.load_state_dict(state_dict, strict=True)
 
 
+def test_float8_linear_step_module_parent_load_state_dict_has_no_duplicate_errors():
+    base = torch.nn.Linear(8, 4)
+    parent = torch.nn.Sequential(Float8LinearStepModule(base, step_mode="s"))
+    state_dict = parent.state_dict()
+    incompatible = parent.load_state_dict(state_dict, strict=False)
+    assert incompatible.missing_keys == []
+    assert incompatible.unexpected_keys == []
+
+
 @pytest.mark.skipif(
     not HAS_TORCHAO
     or not torch.cuda.is_available()

--- a/test/activation_based/test_precision_conversion.py
+++ b/test/activation_based/test_precision_conversion.py
@@ -155,9 +155,6 @@ def test_convert_model_for_precision_preserves_shared_linear_module_identity_fp8
         def forward(self, x):
             return self.base(x)
 
-    def _fake_import(*args, **kwargs):
-        return DummyFloat8Linear
-
     monkeypatch.setattr(
         "torchao.float8.float8_linear.Float8Linear",
         DummyFloat8Linear,

--- a/test/activation_based/test_precision_conversion.py
+++ b/test/activation_based/test_precision_conversion.py
@@ -11,6 +11,7 @@ from spikingjelly.activation_based.precision import (
     analyze_convertible_modules,
     prepare_model_for_precision,
 )
+from spikingjelly.activation_based.precision.convert import convert_model_for_precision
 
 
 HAS_TORCHAO = importlib.util.find_spec("torchao") is not None
@@ -130,16 +131,54 @@ def test_prepare_model_for_precision_replaces_root_linear_module():
 def test_convert_model_for_precision_preserves_shared_linear_module_identity():
     shared = torch.nn.Linear(8, 8)
     model = torch.nn.ModuleList([shared, shared])
-    policy = type(
-        "StubPolicy",
-        (),
-        {
-            "name": "fp32",
-        },
-    )()
     converted, _ = prepare_model_for_precision(
         model,
         "cpu",
         PrecisionConfig(mode="fp32"),
     ).model, None
     assert converted[0] is converted[1]
+
+
+def test_convert_model_for_precision_preserves_shared_linear_module_identity_fp8(
+    monkeypatch,
+):
+    class DummyFloat8Linear(torch.nn.Module):
+        def __init__(self, base):
+            super().__init__()
+            self.base = base
+
+        @classmethod
+        def from_float(cls, base, config):
+            return cls(base)
+
+        def forward(self, x):
+            return self.base(x)
+
+    def _fake_import(*args, **kwargs):
+        return DummyFloat8Linear
+
+    monkeypatch.setattr(
+        "torchao.float8.float8_linear.Float8Linear",
+        DummyFloat8Linear,
+        raising=False,
+    )
+
+    class SharedLinearModule(torch.nn.Module):
+        def __init__(self, shared):
+            super().__init__()
+            self.first = shared
+            self.second = shared
+
+    shared = torch.nn.Linear(8, 8)
+    model = SharedLinearModule(shared)
+    policy = type(
+        "DummyPolicy",
+        (),
+        {
+            "name": "fp8-torchao",
+            "float8_linear_config": object(),
+        },
+    )()
+    converted, report = convert_model_for_precision(model, policy)
+    assert converted.first is converted.second
+    assert len(report.converted_modules) == 2

--- a/test/activation_based/test_precision_conversion.py
+++ b/test/activation_based/test_precision_conversion.py
@@ -131,11 +131,14 @@ def test_prepare_model_for_precision_replaces_root_linear_module():
 def test_convert_model_for_precision_preserves_shared_linear_module_identity():
     shared = torch.nn.Linear(8, 8)
     model = torch.nn.ModuleList([shared, shared])
-    converted, _ = prepare_model_for_precision(
-        model,
-        "cpu",
-        PrecisionConfig(mode="fp32"),
-    ).model, None
+    converted, _ = (
+        prepare_model_for_precision(
+            model,
+            "cpu",
+            PrecisionConfig(mode="fp32"),
+        ).model,
+        None,
+    )
     assert converted[0] is converted[1]
 
 

--- a/test/activation_based/test_precision_conversion.py
+++ b/test/activation_based/test_precision_conversion.py
@@ -139,6 +139,7 @@ def test_convert_model_for_precision_preserves_shared_linear_module_identity():
     assert converted[0] is converted[1]
 
 
+@pytest.mark.skipif(not HAS_TORCHAO, reason="torchao not installed")
 def test_convert_model_for_precision_preserves_shared_linear_module_identity_fp8(
     monkeypatch,
 ):

--- a/test/activation_based/test_precision_conversion.py
+++ b/test/activation_based/test_precision_conversion.py
@@ -57,6 +57,14 @@ def test_float8_linear_step_module_load_state_dict():
     wrapped.load_state_dict(state_dict, strict=True)
 
 
+def test_float8_linear_step_module_load_state_dict_from_parent():
+    base = torch.nn.Linear(8, 4)
+    parent = torch.nn.Sequential(Float8LinearStepModule(base, step_mode="s"))
+    state_dict = parent.state_dict()
+    assert all("wrapped" not in k for k in state_dict), state_dict.keys()
+    parent.load_state_dict(state_dict, strict=True)
+
+
 @pytest.mark.skipif(
     not HAS_TORCHAO
     or not torch.cuda.is_available()

--- a/test/activation_based/test_precision_conversion.py
+++ b/test/activation_based/test_precision_conversion.py
@@ -180,3 +180,53 @@ def test_convert_model_for_precision_preserves_shared_linear_module_identity_fp8
     converted, report = convert_model_for_precision(model, policy)
     assert converted.first is converted.second
     assert len(report.converted_modules) == 2
+
+
+@pytest.mark.skipif(not HAS_TORCHAO, reason="torchao not installed")
+def test_convert_model_for_precision_skips_revisiting_shared_non_linear_modules(
+    monkeypatch,
+):
+    class DummyFloat8Linear(torch.nn.Module):
+        def __init__(self, base):
+            super().__init__()
+            self.base = base
+
+        @classmethod
+        def from_float(cls, base, config):
+            return cls(base)
+
+        def forward(self, x):
+            return self.base(x)
+
+    monkeypatch.setattr(
+        "torchao.float8.float8_linear.Float8Linear",
+        DummyFloat8Linear,
+        raising=False,
+    )
+
+    class SharedBlock(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(8, 8)
+
+    shared = SharedBlock()
+
+    class Parent(torch.nn.Module):
+        def __init__(self, block):
+            super().__init__()
+            self.first = block
+            self.second = block
+
+    model = Parent(shared)
+    policy = type(
+        "DummyPolicy",
+        (),
+        {
+            "name": "fp8-torchao",
+            "float8_linear_config": object(),
+        },
+    )()
+    converted, report = convert_model_for_precision(model, policy)
+    assert converted.first is converted.second
+    assert converted.first.linear is converted.second.linear
+    assert report.converted_modules == ["first.linear"]

--- a/test/activation_based/test_precision_conversion.py
+++ b/test/activation_based/test_precision_conversion.py
@@ -50,6 +50,13 @@ def test_float8_linear_step_module_delegates_attributes():
     assert wrapped.weight is base.weight
 
 
+def test_float8_linear_step_module_load_state_dict():
+    base = torch.nn.Linear(8, 4)
+    wrapped = Float8LinearStepModule(base, step_mode="s")
+    state_dict = wrapped.state_dict()
+    wrapped.load_state_dict(state_dict, strict=True)
+
+
 @pytest.mark.skipif(
     not HAS_TORCHAO
     or not torch.cuda.is_available()

--- a/test/activation_based/test_precision_conversion.py
+++ b/test/activation_based/test_precision_conversion.py
@@ -1,3 +1,5 @@
+import importlib.util
+
 import pytest
 import torch
 
@@ -9,6 +11,9 @@ from spikingjelly.activation_based.precision import (
     analyze_convertible_modules,
     prepare_model_for_precision,
 )
+
+
+HAS_TORCHAO = importlib.util.find_spec("torchao") is not None
 
 
 def test_conversion_report_marks_spikformer_linear_and_high_precision_modules():
@@ -38,7 +43,9 @@ def test_float8_linear_step_module_preserves_multistep_shape():
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability(0) < (8, 9),
+    not HAS_TORCHAO
+    or not torch.cuda.is_available()
+    or torch.cuda.get_device_capability(0) < (8, 9),
     reason="Static fp8-torchao replacement test requires CUDA compute capability >= 8.9.",
 )
 def test_prepare_model_for_precision_replaces_spikformer_head_with_float8_wrapper():
@@ -69,3 +76,20 @@ def test_capability_report_splits_can_convert_and_can_execute():
     report = artifacts.policy.capability_report()
     assert report["can_convert"] is True
     assert report["can_execute"] is True
+
+
+@pytest.mark.skipif(
+    not HAS_TORCHAO
+    or not torch.cuda.is_available()
+    or torch.cuda.get_device_capability(0) < (8, 9),
+    reason="Root Linear fp8-torchao conversion requires torchao and CUDA compute capability >= 8.9.",
+)
+def test_prepare_model_for_precision_replaces_root_linear_module():
+    model = layer.Linear(16, 32).cuda()
+    artifacts = prepare_model_for_precision(
+        model,
+        "cuda:0",
+        PrecisionConfig(mode="fp8-torchao", strictness="strict", device="cuda:0"),
+    )
+    assert isinstance(artifacts.model, Float8LinearStepModule)
+    assert "<root>" in artifacts.policy.conversion_report()["converted_modules"]

--- a/test/activation_based/test_precision_conversion.py
+++ b/test/activation_based/test_precision_conversion.py
@@ -1,0 +1,71 @@
+import pytest
+import torch
+
+from spikingjelly.activation_based import layer
+from spikingjelly.activation_based.model import Spikformer
+from spikingjelly.activation_based.precision import (
+    Float8LinearStepModule,
+    PrecisionConfig,
+    analyze_convertible_modules,
+    prepare_model_for_precision,
+)
+
+
+def test_conversion_report_marks_spikformer_linear_and_high_precision_modules():
+    model = Spikformer(
+        T=2,
+        in_channels=3,
+        img_size_h=64,
+        img_size_w=64,
+        num_classes=7,
+        embed_dims=64,
+        num_heads=4,
+        depths=2,
+        backend="torch",
+    )
+    report = analyze_convertible_modules(model).to_dict()
+    assert report["convertible_linear"] >= 1
+    assert "head" in report["convertible_modules"]
+    assert report["high_precision_modules"]
+
+
+def test_float8_linear_step_module_preserves_multistep_shape():
+    base = torch.nn.Linear(8, 4)
+    wrapped = Float8LinearStepModule(base, step_mode="m")
+    x = torch.randn(3, 2, 8)
+    y = wrapped(x)
+    assert y.shape == (3, 2, 4)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability(0) < (8, 9),
+    reason="Static fp8-torchao replacement test requires CUDA compute capability >= 8.9.",
+)
+def test_prepare_model_for_precision_replaces_spikformer_head_with_float8_wrapper():
+    model = Spikformer(
+        T=2,
+        in_channels=3,
+        img_size_h=64,
+        img_size_w=64,
+        num_classes=7,
+        embed_dims=64,
+        num_heads=4,
+        depths=2,
+        backend="torch",
+    ).cuda()
+    artifacts = prepare_model_for_precision(
+        model,
+        "cuda:0",
+        PrecisionConfig(mode="fp8-torchao", strictness="strict", device="cuda:0"),
+    )
+    assert isinstance(artifacts.model.head, Float8LinearStepModule)
+    report = artifacts.policy.conversion_report()
+    assert "head" in report["converted_modules"]
+
+
+def test_capability_report_splits_can_convert_and_can_execute():
+    model = torch.nn.Sequential(layer.Linear(4, 8), torch.nn.ReLU(), layer.Linear(8, 4))
+    artifacts = prepare_model_for_precision(model, "cpu", PrecisionConfig(mode="fp32"))
+    report = artifacts.policy.capability_report()
+    assert report["can_convert"] is True
+    assert report["can_execute"] is True

--- a/test/activation_based/test_precision_conversion.py
+++ b/test/activation_based/test_precision_conversion.py
@@ -42,6 +42,14 @@ def test_float8_linear_step_module_preserves_multistep_shape():
     assert y.shape == (3, 2, 4)
 
 
+def test_float8_linear_step_module_delegates_attributes():
+    base = torch.nn.Linear(8, 4)
+    wrapped = Float8LinearStepModule(base, step_mode="s")
+    assert wrapped.in_features == 8
+    assert wrapped.out_features == 4
+    assert wrapped.weight is base.weight
+
+
 @pytest.mark.skipif(
     not HAS_TORCHAO
     or not torch.cuda.is_available()

--- a/test/activation_based/test_precision_conversion.py
+++ b/test/activation_based/test_precision_conversion.py
@@ -108,3 +108,21 @@ def test_prepare_model_for_precision_replaces_root_linear_module():
     )
     assert isinstance(artifacts.model, Float8LinearStepModule)
     assert "<root>" in artifacts.policy.conversion_report()["converted_modules"]
+
+
+def test_convert_model_for_precision_preserves_shared_linear_module_identity():
+    shared = torch.nn.Linear(8, 8)
+    model = torch.nn.ModuleList([shared, shared])
+    policy = type(
+        "StubPolicy",
+        (),
+        {
+            "name": "fp32",
+        },
+    )()
+    converted, _ = prepare_model_for_precision(
+        model,
+        "cpu",
+        PrecisionConfig(mode="fp32"),
+    ).model, None
+    assert converted[0] is converted[1]

--- a/test/activation_based/test_precision_core.py
+++ b/test/activation_based/test_precision_core.py
@@ -17,6 +17,12 @@ def test_precision_config_from_string():
     assert cfg.device == "cuda:0"
 
 
+def test_precision_config_from_none_uses_defaults():
+    cfg = PrecisionConfig.from_any(None, default_device="cpu")
+    assert cfg.mode == "fp32"
+    assert cfg.device == "cpu"
+
+
 def test_precision_config_from_dict_aliases_precision_key():
     cfg = PrecisionConfig.from_any({"precision": "fp16", "device": "cuda:0"})
     assert cfg.mode == "fp16"
@@ -82,4 +88,3 @@ def test_build_capability_report_fp8_cpu_cannot_execute():
         "fp8-torchao",
     )
     assert report["can_execute"] is False
-

--- a/test/activation_based/test_precision_core.py
+++ b/test/activation_based/test_precision_core.py
@@ -23,6 +23,11 @@ def test_precision_config_from_none_uses_defaults():
     assert cfg.device == "cpu"
 
 
+def test_precision_config_with_none_mode_falls_back_to_fp32():
+    cfg = PrecisionConfig(mode=None)
+    assert cfg.mode == "fp32"
+
+
 def test_precision_config_instance_with_none_device_uses_default_device():
     cfg = PrecisionConfig.from_any(
         PrecisionConfig(mode="bf16", device=None),
@@ -83,6 +88,12 @@ def test_build_capability_report_cpu_fp32():
     assert report["device_type"] == "cpu"
     assert report["can_convert"] is True
     assert report["can_execute"] is True
+
+
+def test_build_capability_report_accepts_string_device():
+    report = build_capability_report(torch.nn.Linear(4, 4), "cpu", "fp32")
+    assert report["device"] == "cpu"
+    assert report["device_type"] == "cpu"
 
 
 def test_build_capability_report_mps_classification():

--- a/test/activation_based/test_precision_core.py
+++ b/test/activation_based/test_precision_core.py
@@ -23,6 +23,15 @@ def test_precision_config_from_none_uses_defaults():
     assert cfg.device == "cpu"
 
 
+def test_precision_config_instance_with_none_device_uses_default_device():
+    cfg = PrecisionConfig.from_any(
+        PrecisionConfig(mode="bf16", device=None),
+        default_device="cuda:0",
+    )
+    assert cfg.mode == "bf16"
+    assert cfg.device == "cuda:0"
+
+
 def test_precision_config_from_dict_aliases_precision_key():
     cfg = PrecisionConfig.from_any({"precision": "fp16", "device": "cuda:0"})
     assert cfg.mode == "fp16"
@@ -41,6 +50,16 @@ def test_precision_config_from_object_with_precision_fields():
     assert cfg.mode == "fp8-torchao"
     assert cfg.strictness == "strict"
     assert cfg.report is False
+
+
+def test_precision_config_from_object_with_none_device_uses_default_device():
+    obj = SimpleNamespace(
+        precision="fp16",
+        device=None,
+    )
+    cfg = PrecisionConfig.from_any(obj, default_device="cuda:0")
+    assert cfg.mode == "fp16"
+    assert cfg.device == "cuda:0"
 
 
 def test_precision_config_from_legacy_amp_like_object():

--- a/test/activation_based/test_precision_core.py
+++ b/test/activation_based/test_precision_core.py
@@ -1,0 +1,85 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from spikingjelly.activation_based.precision import (
+    PrecisionConfig,
+    build_capability_report,
+    resolve_precision_policy,
+    validate_capability,
+)
+
+
+def test_precision_config_from_string():
+    cfg = PrecisionConfig.from_any("bf16", default_device="cuda:0")
+    assert cfg.mode == "bf16"
+    assert cfg.device == "cuda:0"
+
+
+def test_precision_config_from_dict_aliases_precision_key():
+    cfg = PrecisionConfig.from_any({"precision": "fp16", "device": "cuda:0"})
+    assert cfg.mode == "fp16"
+    assert cfg.device == "cuda:0"
+
+
+def test_precision_config_from_object_with_precision_fields():
+    obj = SimpleNamespace(
+        precision="fp8-torchao",
+        precision_strict="strict",
+        fp8_recipe="auto",
+        fp8_report=False,
+        device="cuda:0",
+    )
+    cfg = PrecisionConfig.from_any(obj)
+    assert cfg.mode == "fp8-torchao"
+    assert cfg.strictness == "strict"
+    assert cfg.report is False
+
+
+def test_precision_config_from_legacy_amp_like_object():
+    obj = SimpleNamespace(disable_amp=False, device="cuda:0")
+    cfg = PrecisionConfig.from_any(obj)
+    assert cfg.mode == "fp16"
+
+
+def test_precision_config_from_unknown_object_raises():
+    with pytest.raises(TypeError):
+        PrecisionConfig.from_any(object())
+
+
+def test_resolve_precision_policy_fp32():
+    policy = resolve_precision_policy(PrecisionConfig(mode="fp32"))
+    assert policy.describe()["name"] == "fp32"
+
+
+def test_build_capability_report_cpu_fp32():
+    report = build_capability_report(torch.nn.Linear(4, 4), torch.device("cpu"), "fp32")
+    assert report["device_type"] == "cpu"
+    assert report["can_convert"] is True
+    assert report["can_execute"] is True
+
+
+def test_build_capability_report_mps_classification():
+    report = build_capability_report(
+        torch.nn.Linear(4, 4),
+        torch.device("mps"),
+        "fp32",
+    )
+    assert report["device_type"] == "mps"
+
+
+def test_validate_capability_rejects_fp16_on_cpu():
+    report = build_capability_report(torch.nn.Linear(4, 4), torch.device("cpu"), "fp16")
+    with pytest.raises(RuntimeError, match="fp16"):
+        validate_capability(report)
+
+
+def test_build_capability_report_fp8_cpu_cannot_execute():
+    report = build_capability_report(
+        torch.nn.Linear(4, 4),
+        torch.device("cpu"),
+        "fp8-torchao",
+    )
+    assert report["can_execute"] is False
+

--- a/test/activation_based/test_precision_core.py
+++ b/test/activation_based/test_precision_core.py
@@ -43,6 +43,20 @@ def test_precision_config_from_dict_aliases_precision_key():
     assert cfg.device == "cuda:0"
 
 
+def test_precision_config_from_dict_supports_precision_aliases():
+    cfg = PrecisionConfig.from_any(
+        {
+            "precision": "fp8-torchao",
+            "precision_strict": "strict",
+            "fp8_report": False,
+            "device": "cuda:0",
+        }
+    )
+    assert cfg.mode == "fp8-torchao"
+    assert cfg.strictness == "strict"
+    assert cfg.report is False
+
+
 def test_precision_config_from_object_with_precision_fields():
     obj = SimpleNamespace(
         precision="fp8-torchao",
@@ -88,6 +102,11 @@ def test_build_capability_report_cpu_fp32():
     assert report["device_type"] == "cpu"
     assert report["can_convert"] is True
     assert report["can_execute"] is True
+
+
+def test_build_capability_report_cpu_reports_bf16_autocast_support():
+    report = build_capability_report(torch.nn.Linear(4, 4), torch.device("cpu"), "bf16")
+    assert report["bf16_supported"] == report["cpu_bf16_autocast"]
 
 
 def test_build_capability_report_accepts_string_device():

--- a/test/activation_based/test_precision_core.py
+++ b/test/activation_based/test_precision_core.py
@@ -88,3 +88,15 @@ def test_build_capability_report_fp8_cpu_cannot_execute():
         "fp8-torchao",
     )
     assert report["can_execute"] is False
+
+
+def test_validate_capability_rejects_fp8_torchao_when_torchao_missing():
+    report = {
+        "requested_mode": "fp8-torchao",
+        "device_type": "cuda",
+        "cuda_available": True,
+        "cuda_device_capability": (9, 0),
+        "torchao_installed": False,
+    }
+    with pytest.raises(RuntimeError, match="torchao"):
+        validate_capability(report)

--- a/test/activation_based/test_precision_reports.py
+++ b/test/activation_based/test_precision_reports.py
@@ -1,0 +1,36 @@
+import json
+
+import torch
+
+from spikingjelly.activation_based.precision import (
+    PrecisionConfig,
+    prepare_model_for_precision,
+    save_precision_reports,
+)
+
+
+def test_save_precision_reports_writes_expected_files(tmp_path):
+    model = torch.nn.Sequential(torch.nn.Linear(4, 8), torch.nn.ReLU(), torch.nn.Linear(8, 4))
+    artifacts = prepare_model_for_precision(model, "cpu", PrecisionConfig(mode="fp32"))
+    save_precision_reports(artifacts, str(tmp_path))
+
+    files = sorted(p.name for p in tmp_path.iterdir())
+    assert files == [
+        "capability_report.json",
+        "conversion_report.json",
+        "precision_policy.json",
+        "precision_runtime.json",
+    ]
+
+    runtime = json.loads((tmp_path / "precision_runtime.json").read_text())
+    assert set(runtime.keys()) == {
+        "requested_config",
+        "effective_config",
+        "fallback_reason",
+    }
+
+    conversion = json.loads((tmp_path / "conversion_report.json").read_text())
+    assert "convertible_modules" in conversion
+    assert "converted_modules" in conversion
+    assert "high_precision_modules" in conversion
+    assert "skipped_modules" in conversion

--- a/test/activation_based/test_precision_spikformer_example.py
+++ b/test/activation_based/test_precision_spikformer_example.py
@@ -159,3 +159,24 @@ def test_fp8_torchao_rejects_model_on_different_cuda_device():
 
     with pytest.raises(RuntimeError, match="target CUDA device 'cuda:1'"):
         prepare_model_for_precision(model, torch.device("cuda:1"), config)
+
+
+@pytest.mark.skipif(
+    not HAS_TORCHAO
+    or not torch.cuda.is_available()
+    or torch.cuda.get_device_capability(0) < (8, 9),
+    reason="This fp8-torchao unindexed CUDA test requires torchao and CUDA compute capability >= 8.9.",
+)
+def test_fp8_torchao_accepts_unindexed_cuda_device_string():
+    model = torch.nn.Sequential(
+        layer.Linear(16, 32),
+        torch.nn.ReLU(),
+        layer.Linear(32, 16),
+    ).to("cuda:0")
+    artifacts = prepare_model_for_precision(
+        model,
+        "cuda",
+        PrecisionConfig(mode="fp8-torchao", strictness="strict", device="cuda"),
+    )
+
+    assert any(isinstance(m, Float8LinearStepModule) for m in artifacts.model.modules())

--- a/test/activation_based/test_precision_spikformer_example.py
+++ b/test/activation_based/test_precision_spikformer_example.py
@@ -61,6 +61,33 @@ def test_spikformer_precision_tools_support_custom_training_loop_fp32():
     assert report["converted_modules"] == []
 
 
+def test_precision_artifacts_backward_supports_accumulation_without_scaler():
+    model = _make_tiny_spikformer()
+    artifacts = prepare_model_for_precision(
+        model,
+        torch.device("cpu"),
+        PrecisionConfig(mode="fp32"),
+    )
+    model = artifacts.model
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+    x = torch.randn(2, 3, 64, 64)
+    target = torch.randint(0, 16, (2,))
+
+    functional.reset_net(model)
+    optimizer.zero_grad(set_to_none=True)
+    with artifacts.autocast_context():
+        y = model(x)
+        loss = torch.nn.functional.cross_entropy(y.mean(0), target)
+    grad_norm = artifacts.backward(
+        loss,
+        optimizer,
+        clip_grad_norm=1.0,
+        step_optimizer=False,
+    )
+    assert grad_norm is not None
+    assert any(p.grad is not None for p in model.parameters())
+
+
 @pytest.mark.skipif(
     not HAS_TORCHAO
     or not torch.cuda.is_available()

--- a/test/activation_based/test_precision_spikformer_example.py
+++ b/test/activation_based/test_precision_spikformer_example.py
@@ -1,3 +1,5 @@
+import importlib.util
+
 import pytest
 import torch
 
@@ -8,6 +10,8 @@ from spikingjelly.activation_based.precision import (
     PrecisionConfig,
     prepare_model_for_precision,
 )
+
+HAS_TORCHAO = importlib.util.find_spec("torchao") is not None
 
 
 def _make_tiny_spikformer():
@@ -58,7 +62,9 @@ def test_spikformer_precision_tools_support_custom_training_loop_fp32():
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability(0) < (8, 9),
+    not HAS_TORCHAO
+    or not torch.cuda.is_available()
+    or torch.cuda.get_device_capability(0) < (8, 9),
     reason="This fp8-torchao smoke test requires CUDA compute capability >= 8.9.",
 )
 def test_fp8_torchao_aligned_linear_smoke():
@@ -87,7 +93,7 @@ def test_fp8_torchao_aligned_linear_smoke():
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available(),
+    not HAS_TORCHAO or not torch.cuda.is_available(),
     reason="CUDA is required to validate fp8-torchao capability handling.",
 )
 def test_spikformer_precision_tools_fp8_torchao_smoke():

--- a/test/activation_based/test_precision_spikformer_example.py
+++ b/test/activation_based/test_precision_spikformer_example.py
@@ -143,3 +143,19 @@ def test_spikformer_precision_tools_fp8_torchao_smoke():
     else:
         with pytest.raises(RuntimeError):
             prepare_model_for_precision(model, torch.device("cuda:0"), config)
+
+
+@pytest.mark.skipif(
+    not HAS_TORCHAO or torch.cuda.device_count() < 2,
+    reason="This fp8-torchao device mismatch test requires torchao and at least 2 CUDA devices.",
+)
+def test_fp8_torchao_rejects_model_on_different_cuda_device():
+    model = torch.nn.Sequential(
+        layer.Linear(16, 32),
+        torch.nn.ReLU(),
+        layer.Linear(32, 16),
+    ).to("cuda:0")
+    config = PrecisionConfig(mode="fp8-torchao", strictness="strict", device="cuda:1")
+
+    with pytest.raises(RuntimeError, match="target CUDA device 'cuda:1'"):
+        prepare_model_for_precision(model, torch.device("cuda:1"), config)

--- a/test/activation_based/test_precision_spikformer_example.py
+++ b/test/activation_based/test_precision_spikformer_example.py
@@ -99,7 +99,7 @@ def test_fp8_torchao_aligned_linear_smoke():
         layer.Linear(16, 32),
         torch.nn.ReLU(),
         layer.Linear(32, 16),
-    ).train()
+    ).train().to("cuda:0")
     artifacts = prepare_model_for_precision(
         model,
         torch.device("cuda:0"),
@@ -128,7 +128,7 @@ def test_spikformer_precision_tools_fp8_torchao_smoke():
     config = PrecisionConfig(mode="fp8-torchao", strictness="strict", device="cuda:0")
     if torch.cuda.get_device_capability(0) >= (8, 9):
         artifacts, y, loss = _run_one_training_step(
-            model,
+            model.to("cuda:0"),
             torch.device("cuda:0"),
             config,
             batch_size=16,

--- a/test/activation_based/test_precision_spikformer_example.py
+++ b/test/activation_based/test_precision_spikformer_example.py
@@ -95,11 +95,15 @@ def test_precision_artifacts_backward_supports_accumulation_without_scaler():
     reason="This fp8-torchao smoke test requires CUDA compute capability >= 8.9.",
 )
 def test_fp8_torchao_aligned_linear_smoke():
-    model = torch.nn.Sequential(
-        layer.Linear(16, 32),
-        torch.nn.ReLU(),
-        layer.Linear(32, 16),
-    ).train().to("cuda:0")
+    model = (
+        torch.nn.Sequential(
+            layer.Linear(16, 32),
+            torch.nn.ReLU(),
+            layer.Linear(32, 16),
+        )
+        .train()
+        .to("cuda:0")
+    )
     artifacts = prepare_model_for_precision(
         model,
         torch.device("cuda:0"),

--- a/test/activation_based/test_precision_spikformer_example.py
+++ b/test/activation_based/test_precision_spikformer_example.py
@@ -1,0 +1,112 @@
+import pytest
+import torch
+
+from spikingjelly.activation_based import functional, layer
+from spikingjelly.activation_based.model import Spikformer
+from spikingjelly.activation_based.precision import (
+    Float8LinearStepModule,
+    PrecisionConfig,
+    prepare_model_for_precision,
+)
+
+
+def _make_tiny_spikformer():
+    return Spikformer(
+        T=2,
+        in_channels=3,
+        img_size_h=64,
+        img_size_w=64,
+        num_classes=16,
+        embed_dims=64,
+        num_heads=4,
+        depths=2,
+        backend="torch",
+    ).train()
+
+
+def _run_one_training_step(model, device, config: PrecisionConfig, batch_size: int = 2):
+    artifacts = prepare_model_for_precision(model, device, config)
+    model = artifacts.model.to(device)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+
+    x = torch.randn(batch_size, 3, 64, 64, device=device)
+    target = torch.randint(0, 16, (batch_size,), device=device)
+
+    functional.reset_net(model)
+    optimizer.zero_grad(set_to_none=True)
+    with artifacts.autocast_context():
+        y = model(x)
+        loss = torch.nn.functional.cross_entropy(y.mean(0), target)
+    artifacts.backward(loss, optimizer, parameters=model.parameters())
+    functional.reset_net(model)
+    return artifacts, y, loss
+
+
+def test_spikformer_precision_tools_support_custom_training_loop_fp32():
+    model = _make_tiny_spikformer()
+    artifacts, y, loss = _run_one_training_step(
+        model,
+        torch.device("cpu"),
+        PrecisionConfig(mode="fp32"),
+    )
+
+    assert y.shape == (2, 2, 16)
+    assert torch.isfinite(loss)
+    report = artifacts.policy.conversion_report()
+    assert report["convertible_linear"] >= 1
+    assert report["converted_modules"] == []
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability(0) < (8, 9),
+    reason="This fp8-torchao smoke test requires CUDA compute capability >= 8.9.",
+)
+def test_fp8_torchao_aligned_linear_smoke():
+    model = torch.nn.Sequential(
+        layer.Linear(16, 32),
+        torch.nn.ReLU(),
+        layer.Linear(32, 16),
+    ).train()
+    artifacts = prepare_model_for_precision(
+        model,
+        torch.device("cuda:0"),
+        PrecisionConfig(mode="fp8-torchao", strictness="strict", device="cuda:0"),
+    )
+    model = artifacts.model.to("cuda:0")
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+    x = torch.randn(16, 16, device="cuda:0")
+    optimizer.zero_grad(set_to_none=True)
+    with artifacts.autocast_context():
+        y = model(x)
+        loss = y.sum()
+    artifacts.backward(loss, optimizer, parameters=model.parameters())
+
+    assert y.shape == (16, 16)
+    assert torch.isfinite(loss)
+    assert any(isinstance(m, Float8LinearStepModule) for m in model.modules())
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA is required to validate fp8-torchao capability handling.",
+)
+def test_spikformer_precision_tools_fp8_torchao_smoke():
+    model = _make_tiny_spikformer()
+    config = PrecisionConfig(mode="fp8-torchao", strictness="strict", device="cuda:0")
+    if torch.cuda.get_device_capability(0) >= (8, 9):
+        artifacts, y, loss = _run_one_training_step(
+            model,
+            torch.device("cuda:0"),
+            config,
+            batch_size=16,
+        )
+        assert y.shape == (2, 16, 16)
+        assert torch.isfinite(loss)
+        converted = artifacts.policy.conversion_report()["converted_modules"]
+        assert converted
+        assert any(
+            isinstance(m, Float8LinearStepModule) for m in artifacts.model.modules()
+        )
+    else:
+        with pytest.raises(RuntimeError):
+            prepare_model_for_precision(model, torch.device("cuda:0"), config)


### PR DESCRIPTION
## Summary

This PR adds an initial precision tooling layer for low-precision training in SpikingJelly, with a first working `fp8-torchao` path for `torch.nn.Linear` and `spikingjelly.activation_based.layer.Linear`.

The design is intentionally library-first:

- `train_classify.py` is kept unchanged from `master`
- precision handling lives under `spikingjelly.activation_based.precision`
- users can call the precision helpers from their own training loop

## What is included

- A standalone precision toolkit under `spikingjelly.activation_based.precision`
- `PrecisionConfig` and policy resolution helpers
- capability reporting and conversion reporting
- actual `torchao`-based replacement for:
  - `torch.nn.Linear`
  - `spikingjelly.activation_based.layer.Linear`
- step-mode-preserving wrapping for `layer.Linear`
- tests for config parsing, reports, conversion behavior, and FP8 smoke examples

## Current scope

This PR only supports `Linear`-based replacement.

This means:

- plain `nn.Linear` models are supported
- `layer.Linear` models are supported
- `Spikformer` only gets replacement where it uses real `Linear` modules (currently the classification head)
- convolution-based projection paths are intentionally out of scope for this first version

## Validation

### Functional smoke validation on H20

Validated on an H20 machine with:

- `torch 2.7.0+cu128`
- `torchao 0.12.0`
- compute capability `9.0`

Confirmed working:

- FP8 smoke test for aligned `layer.Linear` modules
- minimal `Spikformer` FP8 training step under the current Linear-only scope

### Test-directory regression

I ran the `test/` directory in a file-by-file manner on the H20 machine because `pytest` with default capture segfaulted during initialization on that environment.

Observed results:

- 29 test files executed
- 21 passed directly
- the remaining failures were dominated by pre-existing `sew_resnet.py` / `spiking_vgg.py` docstring syntax issues outside the scope of this PR
- after excluding those known unrelated issues, the precision-related failures were fixed

## Notes

- This PR does not add full FP8 coverage for SpikingJelly models
- it establishes the first working library-level precision API and the first verified FP8 execution path on supported hardware


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comprehensive precision subsystem: configure, validate, and prepare models for fp32/fp16/bf16 and fp8 (TorchAO) with device-aware policy selection, model conversion, and FP8 linear wrapping/step support.
  * Saveable precision reports (policy, capability, conversion, runtime) and improved runtime energy reporting with total/compute/memory and per-stage/per-op/component breakdowns.
  * Precision training helper: controllable backward behavior via optional optimizer stepping.

* **Tests**
  * Extensive tests for config parsing, capability validation, model conversion/FP8 wrapping and delegation, report writing, and end-to-end precision examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangwei123456/spikingjelly/pull/685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->