### PR TITLE
fix: harden reset_net cache semantics

### DIFF
--- a/spikingjelly/activation_based/functional/net_config.py
+++ b/spikingjelly/activation_based/functional/net_config.py
@@ -27,9 +27,24 @@ def collect_reset_modules(net: nn.Module) -> tuple[nn.Module, ...]:
     return tuple(m for m in net.modules() if callable(getattr(m, "reset", None)))
 
 
+def _supports_reset_cache_key(net: nn.Module) -> bool:
+    net_type = type(net)
+    if net_type.__eq__ is not object.__eq__:
+        return False
+    if net_type.__hash__ is not object.__hash__:
+        return False
+    try:
+        ref(net)
+    except TypeError:
+        return False
+    return True
+
+
 def _resolve_cached_reset_modules(
     net: nn.Module,
 ) -> Optional[tuple[nn.Module, ...]]:
+    if not _supports_reset_cache_key(net):
+        return None
     cached = _RESET_MODULE_CACHE.get(net)
     if cached is None:
         return None
@@ -81,7 +96,8 @@ def invalidate_reset_cache(net: nn.Module) -> None:
     :param net: Target network
     :type net: torch.nn.Module
     """
-    _RESET_MODULE_CACHE.pop(net, None)
+    if _supports_reset_cache_key(net):
+        _RESET_MODULE_CACHE.pop(net, None)
 
 
 def reset_net(net: nn.Module):
@@ -143,7 +159,11 @@ def reset_net(net: nn.Module):
         reset_collected_modules(cached)
         return
     modules = collect_reset_modules(net)
-    _RESET_MODULE_CACHE[net] = tuple(ref(module) for module in modules)
+    if _supports_reset_cache_key(net):
+        try:
+            _RESET_MODULE_CACHE[net] = tuple(ref(module) for module in modules)
+        except TypeError:
+            pass
     reset_collected_modules(modules)
 
 

--- a/spikingjelly/activation_based/functional/net_config.py
+++ b/spikingjelly/activation_based/functional/net_config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from typing import Optional, Union
+from weakref import ReferenceType, WeakKeyDictionary, ref
 
 import torch.nn as nn
 
@@ -10,15 +11,37 @@ from .. import base
 __all__ = [
     "collect_reset_modules",
     "detach_net",
+    "invalidate_reset_cache",
     "reset_collected_modules",
     "reset_net",
     "set_backend",
     "set_step_mode",
 ]
 
+_RESET_MODULE_CACHE: WeakKeyDictionary[nn.Module, tuple[ReferenceType[nn.Module], ...]] = (
+    WeakKeyDictionary()
+)
+
 
 def collect_reset_modules(net: nn.Module) -> tuple[nn.Module, ...]:
     return tuple(m for m in net.modules() if callable(getattr(m, "reset", None)))
+
+
+def _resolve_cached_reset_modules(
+    net: nn.Module,
+) -> Optional[tuple[nn.Module, ...]]:
+    cached = _RESET_MODULE_CACHE.get(net)
+    if cached is None:
+        return None
+
+    modules = []
+    for cached_module in cached:
+        module = cached_module()
+        if module is None:
+            invalidate_reset_cache(net)
+            return None
+        modules.append(module)
+    return tuple(modules)
 
 
 def reset_collected_modules(modules: tuple[nn.Module, ...]) -> None:
@@ -29,6 +52,36 @@ def reset_collected_modules(modules: tuple[nn.Module, ...]) -> None:
                 f".MemoryModule"
             )
         m.reset()
+
+
+def invalidate_reset_cache(net: nn.Module) -> None:
+    r"""
+    **API Language:**
+    :ref:`中文 <invalidate_reset_cache-cn>` | :ref:`English <invalidate_reset_cache-en>`
+
+    ----
+
+    .. _invalidate_reset_cache-cn:
+    * **中文**
+
+    清除 ``net`` 的 reset 模块缓存。当模型结构发生变化后调用
+    （如 ``torch.compile`` 或模块替换）。
+
+    :param net: 目标网络
+    :type net: torch.nn.Module
+
+    ----
+
+    .. _invalidate_reset_cache-en:
+    * **English**
+
+    Clear the reset module cache for ``net``.
+    Call after model structure changes (e.g. ``torch.compile`` or module swaps).
+
+    :param net: Target network
+    :type net: torch.nn.Module
+    """
+    _RESET_MODULE_CACHE.pop(net, None)
 
 
 def reset_net(net: nn.Module):
@@ -47,6 +100,10 @@ def reset_net(net: nn.Module):
     ``reset()`` 方法，则调用该方法。对于不是
     :class:`~spikingjelly.activation_based.base.MemoryModule` 但实现了
     ``reset()`` 的模块，此函数仍会调用 ``reset()``，同时记录告警。
+
+    首次调用时收集并缓存可重置模块列表，后续调用直接复用缓存。
+    若模型结构发生变化（如 ``torch.compile`` 或模块替换），
+    请调用 :func:`invalidate_reset_cache` 清除缓存。
 
     :param net: 任何属于 ``nn.Module`` 子类的网络
     :type net: torch.nn.Module
@@ -68,6 +125,11 @@ def reset_net(net: nn.Module):
     :class:`~spikingjelly.activation_based.base.MemoryModule` but still defines
     ``reset()``, the function will still call it and emit a warning.
 
+    On the first call, the resettable module list is collected and cached;
+    subsequent calls reuse the cache.
+    If the model structure changes (e.g. ``torch.compile`` or module swaps),
+    call :func:`invalidate_reset_cache` to clear the cache.
+
     :param net: Any network inherits from ``nn.Module``
     :type net: torch.nn.Module
 
@@ -76,7 +138,13 @@ def reset_net(net: nn.Module):
 
     :raises Exception: Any exception raised by a submodule ``reset()`` call is propagated unchanged
     """
-    reset_collected_modules(collect_reset_modules(net))
+    cached = _resolve_cached_reset_modules(net)
+    if cached is not None:
+        reset_collected_modules(cached)
+        return
+    modules = collect_reset_modules(net)
+    _RESET_MODULE_CACHE[net] = tuple(ref(module) for module in modules)
+    reset_collected_modules(modules)
 
 
 def set_step_mode(net: nn.Module, step_mode: str):

--- a/test/activation_based/test_functional.py
+++ b/test/activation_based/test_functional.py
@@ -48,6 +48,35 @@ class _StatefulCounter(base.MemoryModule):
         super().reset()
 
 
+class _EqualHashableResetCounter(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.reset_calls = 0
+
+    def __eq__(self, other):
+        return isinstance(other, _EqualHashableResetCounter)
+
+    def __hash__(self):
+        return 1
+
+    def reset(self):
+        self.reset_calls += 1
+
+
+class _EqualUnhashableResetCounter(nn.Module):
+    __hash__ = None
+
+    def __init__(self):
+        super().__init__()
+        self.reset_calls = 0
+
+    def __eq__(self, other):
+        return self is other
+
+    def reset(self):
+        self.reset_calls += 1
+
+
 def test_collect_reset_modules_ignores_non_callable_reset_attributes():
     net = nn.Sequential(_NonCallableReset(), _ResetCounter())
     modules = collect_reset_modules(net)
@@ -252,7 +281,7 @@ def test_reset_net_preserves_parameters():
     reset_net(net)
     try:
         params_after = list(net.parameters())
-        for pb, pa in zip(params_before, params_after):
+        for pb, pa in zip(params_before, params_after, strict=True):
             assert torch.equal(pb, pa)
     finally:
         invalidate_reset_cache(net)
@@ -324,6 +353,25 @@ def test_reset_net_cache_entry_is_released_for_top_level_memorymodule():
 
     assert net_ref() is None
     assert len(_RESET_MODULE_CACHE) == cache_size - 1
+
+
+def test_reset_net_bypasses_cache_for_equal_hashable_modules():
+    net1 = _EqualHashableResetCounter()
+    net2 = _EqualHashableResetCounter()
+
+    reset_net(net1)
+    reset_net(net2)
+
+    assert net1.reset_calls == 1
+    assert net2.reset_calls == 1
+    assert net1 not in _RESET_MODULE_CACHE
+    assert net2 not in _RESET_MODULE_CACHE
+
+
+def test_invalidate_reset_cache_ignores_unhashable_modules():
+    net = _EqualUnhashableResetCounter()
+
+    invalidate_reset_cache(net)
 
 
 def test_reset_net_cached_modules_follow_memorymodule_reset_semantics():

--- a/test/activation_based/test_functional.py
+++ b/test/activation_based/test_functional.py
@@ -1,0 +1,339 @@
+"""Tests for functional.net_config reset cache semantics."""
+
+import gc
+import logging
+import weakref
+
+import pytest
+import torch
+import torch.nn as nn
+
+from spikingjelly.activation_based import base, neuron
+from spikingjelly.activation_based.functional import (
+    collect_reset_modules,
+    invalidate_reset_cache,
+    reset_collected_modules,
+    reset_net,
+)
+from spikingjelly.activation_based.functional.net_config import _RESET_MODULE_CACHE
+
+
+class _ResetCounter(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.reset_calls = 0
+
+    def reset(self):
+        self.reset_calls += 1
+
+
+class _NonCallableReset(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.reset = 1
+
+
+class _StatefulCounter(base.MemoryModule):
+    def __init__(self):
+        super().__init__()
+        self.register_memory("state", 0.0)
+        self.reset_calls = 0
+
+    def single_step_forward(self, x: torch.Tensor):
+        self.state = x.detach().clone()
+        return self.state
+
+    def reset(self):
+        self.reset_calls += 1
+        super().reset()
+
+
+def test_collect_reset_modules_ignores_non_callable_reset_attributes():
+    net = nn.Sequential(_NonCallableReset(), _ResetCounter())
+    modules = collect_reset_modules(net)
+    assert modules == (net[1],)
+
+
+def test_reset_net_caches_modules():
+    net = nn.Sequential(_ResetCounter(), nn.ReLU(), _ResetCounter())
+    reset_net(net)
+    try:
+        assert net in _RESET_MODULE_CACHE
+        assert tuple(module() for module in _RESET_MODULE_CACHE[net]) == (net[0], net[2])
+    finally:
+        invalidate_reset_cache(net)
+
+
+def test_reset_net_cache_hit_reuses_same_module_tuple():
+    net = nn.Sequential(_ResetCounter(), nn.ReLU(), _ResetCounter())
+    reset_net(net)
+    try:
+        cached = _RESET_MODULE_CACHE[net]
+        reset_net(net)
+        assert _RESET_MODULE_CACHE[net] is cached
+        assert net[0].reset_calls == 2
+        assert net[2].reset_calls == 2
+    finally:
+        invalidate_reset_cache(net)
+
+
+def test_invalidate_reset_cache_clears_entry():
+    net = nn.Sequential(_ResetCounter(), nn.ReLU(), _ResetCounter())
+    reset_net(net)
+    assert net in _RESET_MODULE_CACHE
+    invalidate_reset_cache(net)
+    assert net not in _RESET_MODULE_CACHE
+
+
+def test_invalidate_then_reset_recollects():
+    net = nn.Sequential(_ResetCounter(), nn.ReLU(), _ResetCounter())
+    reset_net(net)
+    old_cached = _RESET_MODULE_CACHE[net]
+    invalidate_reset_cache(net)
+    reset_net(net)
+    try:
+        new_cached = _RESET_MODULE_CACHE[net]
+        assert tuple(module() for module in new_cached) == tuple(
+            module() for module in old_cached
+        )
+        assert new_cached is not old_cached
+    finally:
+        invalidate_reset_cache(net)
+
+
+def test_invalidate_reset_cache_ignores_unknown_net():
+    net = nn.Linear(4, 2)
+    invalidate_reset_cache(net)
+
+
+def test_reset_net_with_ifnode_actually_resets():
+    net = nn.Sequential(nn.Linear(4, 8), neuron.IFNode())
+    x = torch.randn(2, 4)
+    net(x)
+    assert torch.is_tensor(net[1].v)
+    reset_net(net)
+    try:
+        assert net[1].v == 0.0
+    finally:
+        invalidate_reset_cache(net)
+
+
+def test_reset_net_cached_produces_same_result_as_fresh():
+    net = nn.Sequential(nn.Linear(4, 8), neuron.IFNode())
+    x = torch.randn(2, 4)
+    net(x)
+    reset_net(net)
+    assert net[1].v == 0.0
+    net(x)
+    reset_net(net)
+    try:
+        assert net[1].v == 0.0
+    finally:
+        invalidate_reset_cache(net)
+
+
+def test_reset_net_with_lifnode():
+    net = nn.Sequential(nn.Linear(4, 8), neuron.LIFNode())
+    x = torch.randn(2, 4)
+    net(x)
+    assert net[1].v is not None
+    reset_net(net)
+    try:
+        assert net[1].v == 0.0
+    finally:
+        invalidate_reset_cache(net)
+
+
+def test_reset_net_with_deeply_nested_modules():
+    net = nn.Sequential(
+        nn.Sequential(nn.Sequential(nn.Linear(4, 8), neuron.IFNode())),
+        nn.Sequential(nn.Linear(8, 4), neuron.IFNode()),
+    )
+    x = torch.randn(2, 4)
+    net(x)
+    reset_net(net)
+    try:
+        assert net[0][0][1].v == 0.0
+        assert net[1][1].v == 0.0
+    finally:
+        invalidate_reset_cache(net)
+
+
+def test_reset_net_with_module_list():
+    net = nn.ModuleList(
+        [nn.Sequential(nn.Linear(4, 8), neuron.IFNode()) for _ in range(3)]
+    )
+    x = torch.randn(2, 4)
+    for block in net:
+        block(x)
+    reset_net(net)
+    try:
+        for block in net:
+            assert block[1].v == 0.0
+    finally:
+        invalidate_reset_cache(net)
+
+
+def test_independent_models_have_independent_caches():
+    net1 = nn.Sequential(_ResetCounter(), _ResetCounter())
+    net2 = nn.Sequential(_ResetCounter())
+    reset_net(net1)
+    reset_net(net2)
+    try:
+        assert net1 in _RESET_MODULE_CACHE
+        assert net2 in _RESET_MODULE_CACHE
+        assert len(_RESET_MODULE_CACHE[net1]) == 2
+        assert len(_RESET_MODULE_CACHE[net2]) == 1
+    finally:
+        invalidate_reset_cache(net1)
+        invalidate_reset_cache(net2)
+
+
+def test_collect_reset_modules_remains_stateless():
+    net = nn.Sequential(_ResetCounter(), nn.ReLU(), _ResetCounter())
+    m1 = collect_reset_modules(net)
+    m2 = collect_reset_modules(net)
+    assert m1 == m2
+    assert m1 is not m2
+
+
+def test_reset_collected_modules_works_after_invalidate():
+    net = nn.Sequential(_ResetCounter(), nn.ReLU(), _ResetCounter())
+    reset_net(net)
+    invalidate_reset_cache(net)
+    modules = collect_reset_modules(net)
+    reset_collected_modules(modules)
+    assert net[0].reset_calls == 2
+    assert net[2].reset_calls == 2
+
+
+def test_reset_net_with_no_resettable_modules():
+    net = nn.Sequential(nn.ReLU(), nn.Linear(4, 2))
+    reset_net(net)
+    try:
+        assert net in _RESET_MODULE_CACHE
+        assert _RESET_MODULE_CACHE[net] == ()
+    finally:
+        invalidate_reset_cache(net)
+
+
+def test_reset_net_idempotent():
+    net = nn.Sequential(_ResetCounter(), _ResetCounter())
+    reset_net(net)
+    reset_net(net)
+    reset_net(net)
+    try:
+        assert net[0].reset_calls == 3
+        assert net[1].reset_calls == 3
+    finally:
+        invalidate_reset_cache(net)
+
+
+def test_reset_net_in_training_loop():
+    net = nn.Sequential(nn.Linear(4, 8), neuron.IFNode(), nn.Linear(8, 2))
+    criterion = nn.MSELoss()
+    optimizer = torch.optim.SGD(net.parameters(), lr=0.01)
+    for _ in range(5):
+        x = torch.randn(2, 4)
+        y = torch.randn(2, 2)
+        out = net(x)
+        loss = criterion(out, y)
+        loss.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+        reset_net(net)
+        assert net[1].v == 0.0
+    invalidate_reset_cache(net)
+
+
+def test_reset_net_preserves_parameters():
+    net = nn.Sequential(nn.Linear(4, 8), neuron.IFNode())
+    params_before = [p.clone() for p in net.parameters()]
+    reset_net(net)
+    try:
+        params_after = list(net.parameters())
+        for pb, pa in zip(params_before, params_after):
+            assert torch.equal(pb, pa)
+    finally:
+        invalidate_reset_cache(net)
+
+
+def test_reset_net_warns_for_non_memorymodule(caplog: pytest.LogCaptureFixture):
+    net = nn.Sequential(_ResetCounter())
+    with caplog.at_level(logging.WARNING):
+        reset_net(net)
+    try:
+        assert net[0].reset_calls == 1
+        assert any("not spikingjelly.activation_based.base.MemoryModule" in r.message for r in caplog.records)
+    finally:
+        invalidate_reset_cache(net)
+
+
+def test_reset_net_propagates_submodule_reset_exception():
+    class _BrokenReset(nn.Module):
+        def reset(self):
+            raise RuntimeError("boom")
+
+    net = nn.Sequential(_BrokenReset())
+    with pytest.raises(RuntimeError, match="boom"):
+        reset_net(net)
+    invalidate_reset_cache(net)
+
+
+def test_reset_net_cache_must_be_invalidated_after_module_swap():
+    net = nn.Sequential(_ResetCounter())
+    reset_net(net)
+    old_module = net[0]
+    replacement = _ResetCounter()
+    net[0] = replacement
+
+    reset_net(net)
+    assert old_module.reset_calls == 2
+    assert replacement.reset_calls == 0
+
+    invalidate_reset_cache(net)
+    reset_net(net)
+    try:
+        assert old_module.reset_calls == 2
+        assert replacement.reset_calls == 1
+    finally:
+        invalidate_reset_cache(net)
+
+
+def test_reset_net_cache_entry_is_released_with_network():
+    net = nn.Sequential(_ResetCounter())
+    reset_net(net)
+    net_ref = weakref.ref(net)
+    cache_size = len(_RESET_MODULE_CACHE)
+    assert net in _RESET_MODULE_CACHE
+    del net
+    gc.collect()
+
+    assert net_ref() is None
+    assert len(_RESET_MODULE_CACHE) == cache_size - 1
+
+
+def test_reset_net_cache_entry_is_released_for_top_level_memorymodule():
+    net = _StatefulCounter()
+    reset_net(net)
+    net_ref = weakref.ref(net)
+    cache_size = len(_RESET_MODULE_CACHE)
+    assert net in _RESET_MODULE_CACHE
+    del net
+    gc.collect()
+
+    assert net_ref() is None
+    assert len(_RESET_MODULE_CACHE) == cache_size - 1
+
+
+def test_reset_net_cached_modules_follow_memorymodule_reset_semantics():
+    net = nn.Sequential(_StatefulCounter())
+    x = torch.randn(2, 3)
+    net(x)
+    reset_net(net)
+    reset_net(net)
+    try:
+        assert net[0].reset_calls == 2
+        assert net[0].state == 0.0
+    finally:
+        invalidate_reset_cache(net)


### PR DESCRIPTION
## Summary
- replace the reset_net cache with weak-key + weak-value semantics
- add explicit invalidate_reset_cache support for topology changes
- add regression tests for cache lifetime, module swaps, warnings, and reset behavior

## Why
The first cached implementation had two semantic risks:
- `id(net)` cache keys could leave stale entries behind and potentially collide with future object id reuse
- even with weak keys, strong references in cached module tuples could keep top-level `MemoryModule` instances alive

This change keeps the cache aligned with module object lifetimes and falls back to recollection if a cached weak reference has expired.

## Validation
### Local
- `.venv/bin/pytest -q test/activation_based/test_functional.py`
- `PYTHONPATH=/Users/allenyolk/CodeRepo/spikingjelly-dev .venv/bin/pytest -q test/activation_based/test_distributed_dtensor.py -k "collect_reset_modules or reset_collected_modules"`
- `.venv/bin/pytest -q test/activation_based/test_benchmark_snn_distributed.py -k cached_reset_modules`

### g3
- `cd ~/CodeRepo/spikingjelly-dev && source .venv/bin/activate && pytest -q test/activation_based/test_functional.py`
- `cd ~/CodeRepo/spikingjelly-dev && source .venv/bin/activate && PYTHONPATH=~/CodeRepo/spikingjelly-dev pytest -q test/activation_based/test_distributed_dtensor.py -k "collect_reset_modules or reset_collected_modules"`
- `cd ~/CodeRepo/spikingjelly-dev && source .venv/bin/activate && pytest -q test/activation_based/test_benchmark_snn_distributed.py -k cached_reset_modules`
- `cd ~/CodeRepo/spikingjelly-dev && source .venv/bin/activate && pytest -q test/activation_based/test_spikformer_model.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved model reset performance by reusing cached “resettable” modules on repeated resets of the same network.
  * Added `invalidate_reset_cache(net)` to clear reset-cache entries for a given model.
* **Documentation**
  * Updated reset documentation to explain caching behavior and when to call cache invalidation after changing model structure.
* **Tests**
  * Added a comprehensive test suite covering cache reuse, invalidation, edge cases, and correct reset semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->