### PR TITLE
refactor(ann2snn): rule/factory/threshold pipeline + bilingual docstrings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,4 @@ workspace/
 .goal*/
 ObsidianVault
 .mimocode/
+.codegraph/

--- a/spikingjelly/activation_based/ann2snn/__init__.py
+++ b/spikingjelly/activation_based/ann2snn/__init__.py
@@ -1,4 +1,4 @@
-"""
+r"""
 **API Language:**
 :ref:`中文 <ann2snn-cn>` | :ref:`English <ann2snn-en>`
 
@@ -8,10 +8,9 @@
 
 * **中文**
 
-ANN到SNN转换模块，包含转换器工具和示例模型。
-
-:return: None
-:rtype: None
+ANN 到 SNN 的转换模块。提供 :class:`Converter` 转换器，以及 ``HookFactory``、
+``NeuronFactory``、``ActivationRule``、``ThresholdOptimizer`` 等可扩展组件，
+并附带 ``download_url`` 工具函数。
 
 ----
 
@@ -19,13 +18,23 @@ ANN到SNN转换模块，包含转换器工具和示例模型。
 
 * **English**
 
-ANN-to-SNN conversion module with converter utilities and sample models.
-
-:return: None
-:rtype: None
+ANN-to-SNN conversion module. Provides the :class:`Converter` driver together
+with extensible building blocks — :class:`HookFactory`, :class:`NeuronFactory`,
+:class:`ActivationRule` and :class:`ThresholdOptimizer` — and a
+``download_url`` helper for fetching pretrained models.
 """
 
 from .converter import Converter
+from .factories import HookFactory, NeuronFactory
+from .rules import ReLURule
+from .threshold import ThresholdOptimizer
 from .utils import download_url
 
-__all__ = ["Converter", "download_url"]
+__all__ = [
+    "Converter",
+    "download_url",
+    "ReLURule",
+    "NeuronFactory",
+    "HookFactory",
+    "ThresholdOptimizer",
+]

--- a/spikingjelly/activation_based/ann2snn/__init__.py
+++ b/spikingjelly/activation_based/ann2snn/__init__.py
@@ -9,7 +9,7 @@ r"""
 * **中文**
 
 ANN 到 SNN 的转换模块。提供 :class:`Converter` 转换器，以及 ``HookFactory``、
-``NeuronFactory``、``ActivationRule``、``ThresholdOptimizer`` 等可扩展组件，
+``NeuronFactory``、``ReLURule``、``ThresholdOptimizer`` 等可扩展组件，
 并附带 ``download_url`` 工具函数。
 
 ----
@@ -20,7 +20,7 @@ ANN 到 SNN 的转换模块。提供 :class:`Converter` 转换器，以及 ``Hoo
 
 ANN-to-SNN conversion module. Provides the :class:`Converter` driver together
 with extensible building blocks — :class:`HookFactory`, :class:`NeuronFactory`,
-:class:`ActivationRule` and :class:`ThresholdOptimizer` — and a
+:class:`ReLURule` and :class:`ThresholdOptimizer` — and a
 ``download_url`` helper for fetching pretrained models.
 """
 

--- a/spikingjelly/activation_based/ann2snn/converter.py
+++ b/spikingjelly/activation_based/ann2snn/converter.py
@@ -165,8 +165,8 @@ class Converter(nn.Module):
         ).to(self.device)
         with torch.no_grad():
             for _, data in enumerate(tqdm(self.dataloader)):
-                imgs = self._extract_batch_input(data).float()
-                ann_with_hook(imgs.to(self.device))
+                imgs = self._extract_batch_input(data)
+                ann_with_hook(imgs.to(device=self.device, dtype=torch.float))
         snn = self.replace_by_neurons(ann_with_hook).to(self.device)
         return snn
 
@@ -177,6 +177,9 @@ class Converter(nn.Module):
         if isinstance(data, (list, tuple)):
             return data[0]
         if isinstance(data, dict):
+            for key in ("input", "image", "img", "x", "data", "pixel_values"):
+                if key in data:
+                    return data[key]
             return next(iter(data.values()))
         return data[0]
 

--- a/spikingjelly/activation_based/ann2snn/converter.py
+++ b/spikingjelly/activation_based/ann2snn/converter.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Iterable, Tuple, Type
+import warnings
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Type
 
 import torch
 import torch.nn as nn
@@ -6,13 +7,22 @@ from torch import fx
 from torch.nn.utils.fusion import fuse_conv_bn_eval
 from tqdm import tqdm
 
-from spikingjelly.activation_based import neuron
-from spikingjelly.activation_based.ann2snn.modules import VoltageHook, VoltageScaler
+from spikingjelly.activation_based.ann2snn.factories import HookFactory, NeuronFactory
+from spikingjelly.activation_based.ann2snn.rules import ActivationRule, ReLURule
+from spikingjelly.activation_based.ann2snn.threshold import ThresholdOptimizer
 
 
 class Converter(nn.Module):
     def __init__(
-        self, dataloader, device=None, mode="Max", momentum=0.1, fuse_flag=True
+        self,
+        dataloader,
+        device=None,
+        mode="Max",
+        momentum=0.1,
+        fuse_flag=True,
+        rules: Optional[List[ActivationRule]] = None,
+        neuron_factory: Optional[NeuronFactory] = None,
+        threshold_optimizer: Optional[ThresholdOptimizer] = None,
     ):
         r"""
         **API Language:**
@@ -40,7 +50,8 @@ class Converter(nn.Module):
 
             您最好在ANN模型中使用平均池化而不是最大池化。否则，可能会损害转换后的SNN模型的性能。
 
-        :param dataloader: 数据加载器
+        :param dataloader: 数据加载器。迭代返回的每个 batch 必须支持
+            ``data[0]`` 取出输入张量，例如 ``(input, label)`` 或 ``(input,)``。
         :type dataloader: Dataloader
         :param device: Device
         :type device: str
@@ -50,6 +61,14 @@ class Converter(nn.Module):
         :type momentum: float
         :param fuse_flag: 标志位，设置为True，则进行conv与bn的融合，反之不进行。
         :type fuse_flag: bool
+        :param rules: 激活函数转换规则列表。每个规则必须实现
+            ``match``、``insert_hooks``、``find_replacements`` 和
+            ``replace_with_neurons``。默认使用 ``[ReLURule()]``。
+        :type rules: Optional[List[ActivationRule]]
+        :param neuron_factory: 脉冲神经元工厂。默认使用 ``NeuronFactory()``（IFNode, threshold=1.0）。
+        :type neuron_factory: Optional[NeuronFactory]
+        :param threshold_optimizer: 阈值优化器。默认使用 ``ThresholdOptimizer("fixed")``。
+        :type threshold_optimizer: Optional[ThresholdOptimizer]
 
         ----
 
@@ -73,7 +92,9 @@ class Converter(nn.Module):
 
             You'd better use ``avgpool`` rather than ``maxpool`` in your ann model. If not, the performance of the converted snn model may be ruined.
 
-        :param dataloader: Dataloader for converting
+        :param dataloader: Dataloader for converting. Each yielded batch must
+            support ``data[0]`` as the input tensor, for example
+            ``(input, label)`` or ``(input,)``.
         :type dataloader: Dataloader
         :param device: Device
         :type device: str
@@ -83,6 +104,14 @@ class Converter(nn.Module):
         :type momentum: float
         :param fuse_flag: Bool specifying if fusion of the conv and the bn happens, by default it happens.
         :type fuse_flag: bool
+        :param rules: List of activation conversion rules. Each rule must
+            implement ``match``, ``insert_hooks``, ``find_replacements`` and
+            ``replace_with_neurons``. Defaults to ``[ReLURule()]``.
+        :type rules: Optional[List[ActivationRule]]
+        :param neuron_factory: Neuron factory. Defaults to ``NeuronFactory()`` (IFNode, threshold=1.0).
+        :type neuron_factory: Optional[NeuronFactory]
+        :param threshold_optimizer: Threshold optimizer. Defaults to ``ThresholdOptimizer("fixed")``.
+        :type threshold_optimizer: Optional[ThresholdOptimizer]
         """
         super().__init__()
         self.mode = mode
@@ -91,6 +120,15 @@ class Converter(nn.Module):
         self._check_mode()
         self.device = device
         self.momentum = momentum
+        self.rules = rules if rules is not None else [ReLURule()]
+        self.neuron_factory = (
+            neuron_factory if neuron_factory is not None else NeuronFactory()
+        )
+        self.threshold_optimizer = (
+            threshold_optimizer
+            if threshold_optimizer is not None
+            else ThresholdOptimizer()
+        )
 
     def forward(self, ann: nn.Module):
         r"""
@@ -127,14 +165,13 @@ class Converter(nn.Module):
         ann.eval()
         ann_fused = self.fuse(ann, fuse_flag=self.fuse_flag).to(self.device)
         ann_with_hook = self.set_voltagehook(
-            ann_fused, momentum=self.momentum, mode=self.mode
+            ann_fused, momentum=self.momentum, mode=self.mode, rules=self.rules
         ).to(self.device)
         for _, data in enumerate(tqdm(self.dataloader)):
-            # changed this because I was using a detection dataset
             imgs = data[0].float()
             ann_with_hook(imgs.to(self.device))
-        snn = self.replace_by_ifnode(ann_with_hook).to(self.device)
-        return snn  # return type: GraphModule
+        snn = self.replace_by_neurons(ann_with_hook).to(self.device)
+        return snn
 
     def _check_mode(self):
         err_msg = "You have used a non-defined VoltageScale Method."
@@ -195,7 +232,6 @@ class Converter(nn.Module):
         :rtype: torch.fx.GraphModule
         """
 
-        # return asap is no fuse is needed
         if not fuse_flag:
             return fx_model
 
@@ -222,10 +258,6 @@ class Converter(nn.Module):
             node: fx.Node, modules: Dict[str, Any], new_module: torch.nn.Module
         ):
             def parent_name(target: str) -> Tuple[str, str]:
-                """
-                Splits a qualname into parent path and last atom.
-                For example, `foo.bar.baz` -> (`foo.bar`, `baz`)
-                """
                 *parent, name = target.rsplit(".", 1)
                 return parent[0] if parent else "", name
 
@@ -245,9 +277,7 @@ class Converter(nn.Module):
         for pattern in patterns:
             for node in fx_model.graph.nodes:
                 if matches_module_pattern(pattern, node, modules):
-                    if (
-                        len(node.args[0].users) > 1
-                    ):  # Output of conv is used by other nodes
+                    if len(node.args[0].users) > 1:
                         continue
                     conv = modules[node.args[0].target]
                     bn = modules[node.target]
@@ -256,13 +286,16 @@ class Converter(nn.Module):
                     node.replace_all_uses_with(node.args[0])
                     fx_model.graph.erase_node(node)
         fx_model.graph.lint()
-        fx_model.delete_all_unused_submodules()  # remove unused bn modules
+        fx_model.delete_all_unused_submodules()
         fx_model.recompile()
         return fx_model
 
     @staticmethod
     def set_voltagehook(
-        fx_model: torch.fx.GraphModule, mode="Max", momentum=0.1
+        fx_model: torch.fx.GraphModule,
+        mode="Max",
+        momentum=0.1,
+        rules: Optional[List[ActivationRule]] = None,
     ) -> torch.fx.GraphModule:
         r"""
         **API Language:**
@@ -282,6 +315,9 @@ class Converter(nn.Module):
         :type mode: str, float
         :param momentum: 动量值，用于VoltageHook
         :type momentum: float
+        :param rules: 自定义的激活匹配规则列表。默认值为 ``None``，此时使用 ``[ReLURule()]``，即匹配 ``ReLU`` / ``ReLU6`` 等
+            常见激活并为其前后插入 ``VoltageHook``。传入自定义规则可扩展匹配的激活类型或调整 hook 插入位置。
+        :type rules: Optional[List[ActivationRule]]
         :return: 带有VoltageHook的模型.
         :rtype: torch.fx.GraphModule
 
@@ -299,36 +335,102 @@ class Converter(nn.Module):
         :type mode: str, float
         :param momentum: momentum value used by VoltageHook
         :type momentum: float
+        :param rules: Optional list of activation matching rules. When ``None`` (default) ``[ReLURule()]`` is used,
+            which matches common activations such as ``ReLU`` / ``ReLU6`` and wraps them with ``VoltageHook``.
+            Pass custom rules to match additional activation types or to change where hooks are inserted.
+        :type rules: Optional[List[ActivationRule]]
         :return: fx_model with VoltageHook.
         :rtype: torch.fx.GraphModule
         """
+        hook_factory = HookFactory(mode=mode, momentum=momentum)
+        hook_counts_per_prefix: Dict[str, int] = {}
+        modules = dict(fx_model.named_modules())
+        active_rules = rules if rules is not None else [ReLURule()]
 
-        hook_counts_per_prefix = {}
         for node in fx_model.graph.nodes:
             if node.op != "call_module":
                 continue
+            if node.target not in modules:
+                continue
+            for rule in active_rules:
+                if rule.match(node, modules):
+                    rule.insert_hooks(
+                        fx_model, node, hook_factory, hook_counts_per_prefix
+                    )
+                    break
 
-            if type(fx_model.get_submodule(node.target)) is nn.ReLU:
-                # use the input to ReLU to get the prefix
-                prefix = str(node.args[0])
-                prefix = prefix.split("_")
+        fx_model.graph.lint()
+        fx_model.recompile()
+        return fx_model
 
-                # if we have a prefix, it means we are at a submodule
-                if len(prefix) > 1:
-                    prefix = ".".join(prefix[:-1])
-                    counter = hook_counts_per_prefix.get(prefix, 0)
-                    hook_counts_per_prefix[prefix] = counter + 1
-                    target = f"{prefix}.voltage_hook_{counter}"  # voltage_hook
+    def replace_by_neurons(
+        self, fx_model: torch.fx.GraphModule
+    ) -> torch.fx.GraphModule:
+        r"""
+        **API Language:**
+        :ref:`中文 <Converter.replace_by_neurons-cn>` | :ref:`English <Converter.replace_by_neurons-en>`
 
-                # if we don't have a prefix, it means we are at the first level of the module
-                else:
-                    prefix = "__FIRST_LEVEL_OF_MODULE__"
-                    counter = hook_counts_per_prefix.get(prefix, 0)
-                    hook_counts_per_prefix[prefix] = counter + 1
-                    target = f"voltage_hook_{counter}"  # voltage_hook
+        ----
 
-                m = VoltageHook(momentum=momentum, mode=mode)
-                _ = Converter._add_module_and_node(fx_model, target, node, m, (node,))
+        .. _Converter.replace_by_neurons-cn:
+
+        * **中文**
+
+        将 ``self.rules`` 匹配到的激活节点替换为脉冲神经元，并按 ``self.threshold_optimizer`` 计算出的阈值
+        完成 ``VoltageScaler(1/v_threshold) -> Neuron -> VoltageScaler(v_threshold)`` 的等价变换。
+        默认规则、神经元工厂与阈值优化器可复现原 ``replace_by_ifnode`` 的 ``ReLU -> IFNode`` 替换语义。
+
+        :param fx_model: 已插入校准 hook 的 ``GraphModule``
+        :type fx_model: torch.fx.GraphModule
+        :return: 激活节点被替换为脉冲神经元后的模型
+        :rtype: torch.fx.GraphModule
+
+        ----
+
+        .. _Converter.replace_by_neurons-en:
+
+        * **English**
+
+        Replace activations matched by ``self.rules`` with spiking neurons, applying the
+        ``VoltageScaler(1/v_threshold) -> Neuron -> VoltageScaler(v_threshold)`` transformation
+        using the threshold computed by ``self.threshold_optimizer``. With the default rule,
+        neuron factory and threshold optimizer this reproduces the original
+        ``replace_by_ifnode`` ``ReLU -> IFNode`` replacement semantics.
+
+        :param fx_model: ``GraphModule`` with calibration hooks already inserted.
+        :type fx_model: torch.fx.GraphModule
+        :return: Model with activations replaced by spiking neurons.
+        :rtype: torch.fx.GraphModule
+        """
+        return Converter._replace_by_neurons_impl(
+            fx_model,
+            self.rules,
+            self.neuron_factory,
+            self.threshold_optimizer,
+        )
+
+    @staticmethod
+    def _replace_by_neurons_impl(
+        fx_model: torch.fx.GraphModule,
+        rules: List[ActivationRule],
+        neuron_factory: NeuronFactory,
+        threshold_optimizer: ThresholdOptimizer,
+    ) -> torch.fx.GraphModule:
+        replaced_hooks = set()
+        for rule in rules:
+            modules = dict(fx_model.named_modules())
+            for activation_node, hook_node in rule.find_replacements(fx_model, modules):
+                if hook_node in replaced_hooks:
+                    continue
+                replaced_hooks.add(hook_node)
+                rule.replace_with_neurons(
+                    fx_model,
+                    activation_node,
+                    hook_node,
+                    neuron_factory,
+                    threshold_optimizer,
+                )
+                modules = dict(fx_model.named_modules())
 
         fx_model.graph.lint()
         fx_model.recompile()
@@ -336,95 +438,22 @@ class Converter(nn.Module):
 
     @staticmethod
     def replace_by_ifnode(fx_model: torch.fx.GraphModule) -> torch.fx.GraphModule:
-        r"""
-        **API Language:**
-        :ref:`中文 <Converter.replace_by_ifnode-cn>` | :ref:`English <Converter.replace_by_ifnode-en>`
+        r"""Replace ReLU with IF neurons (legacy API, use :meth:`replace_by_neurons` instead).
 
-        ----
-
-        .. _Converter.replace_by_ifnode-cn:
-        * **中文**
-
-        * **中文**
-
-        ``replace_by_ifnode`` 用于将模型的ReLU替换为IF脉冲神经元。
-
-        :param fx_model: 原模型
+        :deprecated: Use :meth:`replace_by_neurons` instead.
+        :param fx_model: Model with calibration hooks inserted.
         :type fx_model: torch.fx.GraphModule
-        :return: 将ReLU替换为IF脉冲神经元后的模型.
-        :rtype: torch.fx.GraphModule
-
-        ----
-
-        .. _Converter.replace_by_ifnode-en:
-        * **English**
-
-        * **English**
-
-        ``replace_by_ifnode`` is used to replace ReLU with IF neuron.
-
-        :param fx_model: Original fx_model
-        :type fx_model: torch.fx.GraphModule
-        :return: fx_model whose ReLU has been replaced by IF neuron.
+        :return: Model with ReLU replaced by IF neurons.
         :rtype: torch.fx.GraphModule
         """
-
-        hook_cnt = -1
-        for node in fx_model.graph.nodes:
-            if node.op != "call_module":
-                continue
-            if (
-                type(fx_model.get_submodule(node.target)) is VoltageHook
-                and type(fx_model.get_submodule(node.args[0].target)) is nn.ReLU
-            ):
-                hook_cnt += 1
-                hook_node = node
-                relu_node = node.args[0]
-                if len(relu_node.args) != 1:
-                    raise NotImplementedError(
-                        "The number of relu_node.args should be 1."
-                    )
-
-                # get the voltage hook prefix
-                prefix = node.name.replace("voltage_hook_", "spiking")
-                prefix = prefix.split("_")
-                prefix = ".".join(prefix)
-
-                s = fx_model.get_submodule(node.target).scale.item()
-                # this allows for easier import/export of the model
-                target0 = f"{prefix}.scaler0"  # voltage_scaler
-                target1 = f"{prefix}.if_node"  # IF_node
-                target2 = f"{prefix}.scaler1"  # voltage_scaler
-
-                m0 = VoltageScaler(1.0 / s)
-                m1 = neuron.IFNode(v_threshold=1.0, v_reset=None)
-                m2 = VoltageScaler(s)
-
-                node0 = Converter._add_module_and_node(
-                    fx_model, target0, hook_node, m0, relu_node.args
-                )
-                node1 = Converter._add_module_and_node(
-                    fx_model, target1, node0, m1, (node0,)
-                )
-                node2 = Converter._add_module_and_node(
-                    fx_model, target2, node1, m2, args=(node1,)
-                )
-
-                relu_node.replace_all_uses_with(node2)
-                node2.args = (node1,)
-                fx_model.graph.erase_node(hook_node)
-                fx_model.graph.erase_node(relu_node)
-                fx_model.delete_all_unused_submodules()
-
-        fx_model.graph.lint()
-        fx_model.recompile()
-        return fx_model
-
-    @staticmethod
-    def _add_module_and_node(
-        fx_model: fx.GraphModule, target: str, after: fx.Node, m: nn.Module, args: Tuple
-    ) -> fx.Node:
-        fx_model.add_submodule(target=target, m=m)
-        with fx_model.graph.inserting_after(n=after):
-            new_node = fx_model.graph.call_module(module_name=target, args=args)
-        return new_node
+        warnings.warn(
+            "replace_by_ifnode is deprecated, use replace_by_neurons instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return Converter._replace_by_neurons_impl(
+            fx_model,
+            [ReLURule()],
+            NeuronFactory(),
+            ThresholdOptimizer(),
+        )

--- a/spikingjelly/activation_based/ann2snn/converter.py
+++ b/spikingjelly/activation_based/ann2snn/converter.py
@@ -177,8 +177,12 @@ class Converter(nn.Module):
         if isinstance(data, torch.Tensor):
             return data
         if isinstance(data, (list, tuple)):
+            if not data:
+                raise ValueError("Batch data is an empty list or tuple.")
             return data[0]
         if isinstance(data, dict):
+            if not data:
+                raise ValueError("Batch data is an empty dictionary.")
             for key in ("input", "image", "img", "x", "data", "pixel_values"):
                 if key in data:
                     return data[key]

--- a/spikingjelly/activation_based/ann2snn/converter.py
+++ b/spikingjelly/activation_based/ann2snn/converter.py
@@ -373,6 +373,7 @@ class Converter(nn.Module):
                     rule.insert_hooks(
                         fx_model, node, hook_factory, hook_counts_per_prefix
                     )
+                    modules = dict(fx_model.named_modules())
                     break
 
         fx_model.graph.lint()

--- a/spikingjelly/activation_based/ann2snn/converter.py
+++ b/spikingjelly/activation_based/ann2snn/converter.py
@@ -183,7 +183,7 @@ class Converter(nn.Module):
                 if key in data:
                     return data[key]
             return next(iter(data.values()))
-        return data[0]
+        return data
 
     def _check_mode(self):
         err_msg = "You have used a non-defined VoltageScale Method."

--- a/spikingjelly/activation_based/ann2snn/converter.py
+++ b/spikingjelly/activation_based/ann2snn/converter.py
@@ -315,8 +315,8 @@ class Converter(nn.Module):
         :type mode: str, float
         :param momentum: 动量值，用于VoltageHook
         :type momentum: float
-        :param rules: 自定义的激活匹配规则列表。默认值为 ``None``，此时使用 ``[ReLURule()]``，即匹配 ``ReLU`` / ``ReLU6`` 等
-            常见激活并为其前后插入 ``VoltageHook``。传入自定义规则可扩展匹配的激活类型或调整 hook 插入位置。
+        :param rules: 自定义的激活匹配规则列表。默认值为 ``None``，此时使用 ``[ReLURule()]``，即匹配
+            ``ReLU`` 并为其前后插入 ``VoltageHook``。传入自定义规则可扩展匹配的激活类型或调整 hook 插入位置。
         :type rules: Optional[List[ActivationRule]]
         :return: 带有VoltageHook的模型.
         :rtype: torch.fx.GraphModule
@@ -336,7 +336,7 @@ class Converter(nn.Module):
         :param momentum: momentum value used by VoltageHook
         :type momentum: float
         :param rules: Optional list of activation matching rules. When ``None`` (default) ``[ReLURule()]`` is used,
-            which matches common activations such as ``ReLU`` / ``ReLU6`` and wraps them with ``VoltageHook``.
+            which matches ``ReLU`` and wraps it with ``VoltageHook``.
             Pass custom rules to match additional activation types or to change where hooks are inserted.
         :type rules: Optional[List[ActivationRule]]
         :return: fx_model with VoltageHook.
@@ -419,7 +419,8 @@ class Converter(nn.Module):
         replaced_hooks = set()
         for rule in rules:
             modules = dict(fx_model.named_modules())
-            for activation_node, hook_node in rule.find_replacements(fx_model, modules):
+            replacements = list(rule.find_replacements(fx_model, modules))
+            for activation_node, hook_node in replacements:
                 if hook_node in replaced_hooks:
                     continue
                 replaced_hooks.add(hook_node)
@@ -433,6 +434,7 @@ class Converter(nn.Module):
                 modules = dict(fx_model.named_modules())
 
         fx_model.graph.lint()
+        fx_model.delete_all_unused_submodules()
         fx_model.recompile()
         return fx_model
 

--- a/spikingjelly/activation_based/ann2snn/converter.py
+++ b/spikingjelly/activation_based/ann2snn/converter.py
@@ -140,8 +140,6 @@ class Converter(nn.Module):
         .. _Converter.forward-cn:
         * **中文**
 
-        * **中文**
-
         :param ann: 待转换的ann
         :type ann: torch.nn.Module
         :return: 转换得到的snn
@@ -150,8 +148,6 @@ class Converter(nn.Module):
         ----
 
         .. _Converter.forward-en:
-        * **English**
-
         * **English**
 
         :param ann: ann to be converted
@@ -431,7 +427,6 @@ class Converter(nn.Module):
                     neuron_factory,
                     threshold_optimizer,
                 )
-                modules = dict(fx_model.named_modules())
 
         fx_model.graph.lint()
         fx_model.delete_all_unused_submodules()

--- a/spikingjelly/activation_based/ann2snn/converter.py
+++ b/spikingjelly/activation_based/ann2snn/converter.py
@@ -165,10 +165,20 @@ class Converter(nn.Module):
         ).to(self.device)
         with torch.no_grad():
             for _, data in enumerate(tqdm(self.dataloader)):
-                imgs = data[0].float()
+                imgs = self._extract_batch_input(data).float()
                 ann_with_hook(imgs.to(self.device))
         snn = self.replace_by_neurons(ann_with_hook).to(self.device)
         return snn
+
+    @staticmethod
+    def _extract_batch_input(data):
+        if isinstance(data, torch.Tensor):
+            return data
+        if isinstance(data, (list, tuple)):
+            return data[0]
+        if isinstance(data, dict):
+            return next(iter(data.values()))
+        return data[0]
 
     def _check_mode(self):
         err_msg = "You have used a non-defined VoltageScale Method."

--- a/spikingjelly/activation_based/ann2snn/converter.py
+++ b/spikingjelly/activation_based/ann2snn/converter.py
@@ -163,9 +163,10 @@ class Converter(nn.Module):
         ann_with_hook = self.set_voltagehook(
             ann_fused, momentum=self.momentum, mode=self.mode, rules=self.rules
         ).to(self.device)
-        for _, data in enumerate(tqdm(self.dataloader)):
-            imgs = data[0].float()
-            ann_with_hook(imgs.to(self.device))
+        with torch.no_grad():
+            for _, data in enumerate(tqdm(self.dataloader)):
+                imgs = data[0].float()
+                ann_with_hook(imgs.to(self.device))
         snn = self.replace_by_neurons(ann_with_hook).to(self.device)
         return snn
 
@@ -343,7 +344,7 @@ class Converter(nn.Module):
         modules = dict(fx_model.named_modules())
         active_rules = rules if rules is not None else [ReLURule()]
 
-        for node in fx_model.graph.nodes:
+        for node in list(fx_model.graph.nodes):
             if node.op != "call_module":
                 continue
             if node.target not in modules:
@@ -413,13 +414,18 @@ class Converter(nn.Module):
         threshold_optimizer: ThresholdOptimizer,
     ) -> torch.fx.GraphModule:
         replaced_hooks = set()
+        replaced_activations = set()
         for rule in rules:
             modules = dict(fx_model.named_modules())
             replacements = list(rule.find_replacements(fx_model, modules))
             for activation_node, hook_node in replacements:
-                if hook_node in replaced_hooks:
+                if (
+                    hook_node in replaced_hooks
+                    or activation_node in replaced_activations
+                ):
                     continue
                 replaced_hooks.add(hook_node)
+                replaced_activations.add(activation_node)
                 rule.replace_with_neurons(
                     fx_model,
                     activation_node,

--- a/spikingjelly/activation_based/ann2snn/converter.py
+++ b/spikingjelly/activation_based/ann2snn/converter.py
@@ -166,7 +166,9 @@ class Converter(nn.Module):
         with torch.no_grad():
             for _, data in enumerate(tqdm(self.dataloader)):
                 imgs = self._extract_batch_input(data)
-                ann_with_hook(imgs.to(device=self.device, dtype=torch.float))
+                ann_with_hook(
+                    torch.as_tensor(imgs).to(device=self.device, dtype=torch.float)
+                )
         snn = self.replace_by_neurons(ann_with_hook).to(self.device)
         return snn
 

--- a/spikingjelly/activation_based/ann2snn/factories.py
+++ b/spikingjelly/activation_based/ann2snn/factories.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type
+from typing import Optional, Type, Union
 
 import torch.nn as nn
 
@@ -153,7 +153,7 @@ class HookFactory:
     :type momentum: float
     """
 
-    def __init__(self, mode: str = "Max", momentum: float = 0.1):
+    def __init__(self, mode: Union[str, float] = "Max", momentum: float = 0.1):
         self.mode = mode
         self.momentum = momentum
 

--- a/spikingjelly/activation_based/ann2snn/factories.py
+++ b/spikingjelly/activation_based/ann2snn/factories.py
@@ -1,0 +1,187 @@
+from typing import Optional, Type
+
+import torch.nn as nn
+
+from spikingjelly.activation_based import neuron
+from spikingjelly.activation_based.ann2snn.modules import VoltageHook
+
+
+class NeuronFactory:
+    r"""
+    **API Language:**
+    :ref:`中文 <NeuronFactory.__init__-cn>` | :ref:`English <NeuronFactory.__init__-en>`
+
+    ----
+
+    .. _NeuronFactory.__init__-cn:
+
+    * **中文**
+
+    用于创建替换激活函数的脉冲神经元模块。默认创建
+    :class:`spikingjelly.activation_based.neuron.IFNode`，并使用
+    ``v_threshold=1.0`` 与 ``v_reset=None`` 保持原有 ANN2SNN 行为。默认转换会通过
+    :class:`VoltageScaler` 处理激活尺度，因此默认工厂不会把 ``scale`` 直接写入
+    神经元阈值；自定义工厂可读取 ``scale`` 派生阈值或其他参数。
+
+    :param neuron_type: 神经元类，必须接受 ``v_threshold`` 与 ``v_reset`` 关键字参数。
+        默认为 :class:`spikingjelly.activation_based.neuron.IFNode`。
+    :type neuron_type: Type[nn.Module]
+    :param v_threshold: 神经元发放阈值，传递给神经元构造函数。
+    :type v_threshold: float
+    :param v_reset: 膜电位复位值。``None`` 表示软复位（减法复位），默认为 ``None``。
+    :type v_reset: Optional[float]
+    :param kwargs: 透传给神经元构造函数的其他关键字参数。
+
+    ----
+
+    .. _NeuronFactory.__init__-en:
+
+    * **English**
+
+    Factory that creates spiking-neuron modules used to replace ANN activation
+    functions. By default it instantiates
+    :class:`spikingjelly.activation_based.neuron.IFNode` with
+    ``v_threshold=1.0`` and ``v_reset=None`` to preserve the original
+    ANN2SNN behaviour. The default conversion handles the activation scale
+    with :class:`VoltageScaler`, so the default factory does not copy
+    ``scale`` into the neuron threshold. Custom factories may derive
+    thresholds or other neuron parameters from ``scale``.
+
+    :param neuron_type: Neuron class to instantiate. Must accept
+        ``v_threshold`` and ``v_reset`` keyword arguments. Defaults to
+        :class:`spikingjelly.activation_based.neuron.IFNode`.
+    :type neuron_type: Type[nn.Module]
+    :param v_threshold: Firing threshold passed to the neuron constructor.
+    :type v_threshold: float
+    :param v_reset: Membrane reset value. ``None`` means soft reset
+        (subtractive reset). Defaults to ``None``.
+    :type v_reset: Optional[float]
+    :param kwargs: Additional keyword arguments forwarded to the neuron
+        constructor.
+    """
+
+    def __init__(
+        self,
+        neuron_type: Type[nn.Module] = neuron.IFNode,
+        v_threshold: float = 1.0,
+        v_reset: Optional[float] = None,
+        **kwargs,
+    ):
+        self.neuron_type = neuron_type
+        self.v_threshold = v_threshold
+        self.v_reset = v_reset
+        self.neuron_kwargs = kwargs
+
+    def create(self, scale: float) -> nn.Module:
+        r"""
+        **API Language:**
+        :ref:`中文 <NeuronFactory.create-cn>` | :ref:`English <NeuronFactory.create-en>`
+
+        ----
+
+        .. _NeuronFactory.create-cn:
+
+        * **中文**
+
+        根据工厂配置创建一个脉冲神经元模块实例。``scale`` 为当前层校准得到的激活
+        尺度，默认实现不直接使用该值，但子类可据此派生阈值或其他参数。
+
+        :param scale: 当前层的校准尺度。
+        :type scale: float
+        :return: 配置完成的脉冲神经元模块。
+        :rtype: nn.Module
+
+        ----
+
+        .. _NeuronFactory.create-en:
+
+        * **English**
+
+        Instantiate a spiking-neuron module with the configured parameters.
+        ``scale`` is the calibrated activation scale of the current layer; the
+        default implementation does not use it directly, but subclasses can
+        derive thresholds or other neuron parameters from it.
+
+        :param scale: Calibration scale for the layer.
+        :type scale: float
+        :return: A spiking-neuron module.
+        :rtype: nn.Module
+        """
+        return self.neuron_type(
+            v_threshold=self.v_threshold,
+            v_reset=self.v_reset,
+            **self.neuron_kwargs,
+        )
+
+
+class HookFactory:
+    r"""
+    **API Language:**
+    :ref:`中文 <HookFactory.__init__-cn>` | :ref:`English <HookFactory.__init__-en>`
+
+    ----
+
+    .. _HookFactory.__init__-cn:
+
+    * **中文**
+
+    用于创建校准阶段使用的 :class:`VoltageHook` 实例。每个匹配到的激活节点会获得
+    独立的 hook 实例。
+
+    :param mode: 校准模式，传递给 :class:`VoltageHook`。``"Max"`` 记录激活最大值；
+        ``"99.9%"`` 记录 99.9 分位点；``(0, 1]`` 区间的 float 表示
+        ``max * mode``。
+    :type mode: str, float
+    :param momentum: :class:`VoltageHook` 的 EMA 动量。
+    :type momentum: float
+
+    ----
+
+    .. _HookFactory.__init__-en:
+
+    * **English**
+
+    Factory that creates :class:`VoltageHook` instances used during
+    calibration. Each matched activation node receives an independent hook
+    instance.
+
+    :param mode: Calibration mode forwarded to :class:`VoltageHook`.
+        ``"Max"`` records the maximum activation; ``"99.9%"`` records the
+        99.9-th percentile; a float in ``(0, 1]`` records ``max * mode``.
+    :type mode: str, float
+    :param momentum: EMA momentum for :class:`VoltageHook`.
+    :type momentum: float
+    """
+
+    def __init__(self, mode: str = "Max", momentum: float = 0.1):
+        self.mode = mode
+        self.momentum = momentum
+
+    def create(self) -> VoltageHook:
+        r"""
+        **API Language:**
+        :ref:`中文 <HookFactory.create-cn>` | :ref:`English <HookFactory.create-en>`
+
+        ----
+
+        .. _HookFactory.create-cn:
+
+        * **中文**
+
+        创建一个新的 :class:`VoltageHook` 实例。
+
+        :return: 配置完成的 :class:`VoltageHook`。
+        :rtype: VoltageHook
+
+        ----
+
+        .. _HookFactory.create-en:
+
+        * **English**
+
+        Create a new :class:`VoltageHook` instance.
+
+        :return: A configured :class:`VoltageHook`.
+        :rtype: VoltageHook
+        """
+        return VoltageHook(momentum=self.momentum, mode=self.mode)

--- a/spikingjelly/activation_based/ann2snn/rules.py
+++ b/spikingjelly/activation_based/ann2snn/rules.py
@@ -359,6 +359,8 @@ class ReLURule:
 
         m1 = neuron_factory.create(scale=s)
         neuron_threshold = getattr(m1, "v_threshold", 1.0)
+        if hasattr(neuron_threshold, "item"):
+            neuron_threshold = neuron_threshold.item()
         m0 = VoltageScaler(neuron_threshold / s)
         m2 = VoltageScaler(s)
 
@@ -368,8 +370,8 @@ class ReLURule:
         node1 = _add_module_and_node(fx_model, target1, node0, m1, (node0,))
         node2 = _add_module_and_node(fx_model, target2, node1, m2, args=(node1,))
 
+        hook_node.replace_all_uses_with(node2)
         activation_node.replace_all_uses_with(node2)
-        node2.args = (node1,)
         fx_model.graph.erase_node(hook_node)
         fx_model.graph.erase_node(activation_node)
 

--- a/spikingjelly/activation_based/ann2snn/rules.py
+++ b/spikingjelly/activation_based/ann2snn/rules.py
@@ -1,3 +1,4 @@
+import math
 from typing import TYPE_CHECKING, Dict, Iterator, Protocol, Tuple
 
 import torch.nn as nn
@@ -349,9 +350,10 @@ class ReLURule:
         if not isinstance(hook, VoltageHook):
             raise TypeError("hook_node must target a VoltageHook module.")
         s = float(threshold_optimizer.compute_threshold(hook))
-        if not (s > 0.0):
+        if not (s > 0.0) or not math.isfinite(s):
             raise ValueError(
-                f"Threshold must be > 0, got {s} for hook {hook_node.target!r}."
+                f"Threshold must be a finite positive number, got {s} "
+                f"for hook {hook_node.target!r}."
             )
         target0 = f"{prefix}.scaler0"
         target1 = f"{prefix}.if_node"

--- a/spikingjelly/activation_based/ann2snn/rules.py
+++ b/spikingjelly/activation_based/ann2snn/rules.py
@@ -331,6 +331,12 @@ class ReLURule:
         neuron_factory: "NeuronFactory",
         threshold_optimizer: "ThresholdOptimizer",
     ) -> None:
+        if len(activation_node.args) != 1:
+            raise ValueError(
+                f"The activation node {activation_node.target!r} must have exactly "
+                f"1 argument, but got {len(activation_node.args)}."
+            )
+
         # The prefix mirrors the hook target generated in insert_hooks. Keeping
         # the names paired makes exported GraphModules easier to inspect.
         if not isinstance(hook_node.target, str):
@@ -343,7 +349,7 @@ class ReLURule:
         if not isinstance(hook, VoltageHook):
             raise TypeError("hook_node must target a VoltageHook module.")
         s = float(threshold_optimizer.compute_threshold(hook))
-        if s <= 0.0:
+        if not (s > 0.0):
             raise ValueError(
                 f"Threshold must be > 0, got {s} for hook {hook_node.target!r}."
             )

--- a/spikingjelly/activation_based/ann2snn/rules.py
+++ b/spikingjelly/activation_based/ann2snn/rules.py
@@ -290,18 +290,17 @@ class ReLURule:
         hook_factory: "HookFactory",
         hook_counts_per_prefix: Dict[str, int],
     ) -> fx.Node:
-        prefix = str(node.args[0]).split("_")
-
-        if len(prefix) > 1:
-            prefix = ".".join(prefix[:-1])
-            counter = hook_counts_per_prefix.get(prefix, 0)
-            hook_counts_per_prefix[prefix] = counter + 1
-            target = f"{prefix}.voltage_hook_{counter}"
-        else:
-            prefix = "__FIRST_LEVEL_OF_MODULE__"
-            counter = hook_counts_per_prefix.get(prefix, 0)
-            hook_counts_per_prefix[prefix] = counter + 1
-            target = f"voltage_hook_{counter}"
+        if not isinstance(node.target, str):
+            raise TypeError("node.target must be a module path string.")
+        parent, _, _ = node.target.rpartition(".")
+        key = parent or "__FIRST_LEVEL_OF_MODULE__"
+        counter = hook_counts_per_prefix.get(key, 0)
+        hook_counts_per_prefix[key] = counter + 1
+        target = (
+            f"{parent}.voltage_hook_{counter}"
+            if parent
+            else f"voltage_hook_{counter}"
+        )
 
         m = hook_factory.create()
         return _add_module_and_node(fx_model, target, node, m, (node,))
@@ -334,14 +333,20 @@ class ReLURule:
     ) -> None:
         # The prefix mirrors the hook target generated in insert_hooks. Keeping
         # the names paired makes exported GraphModules easier to inspect.
-        prefix = hook_node.name.replace("voltage_hook_", "spiking")
-        prefix = prefix.split("_")
-        prefix = ".".join(prefix)
+        if not isinstance(hook_node.target, str):
+            raise TypeError("hook_node.target must be a module path string.")
+        hook_parent, _, hook_leaf = hook_node.target.rpartition(".")
+        spike_leaf = hook_leaf.replace("voltage_hook_", "spiking_")
+        prefix = f"{hook_parent}.{spike_leaf}" if hook_parent else spike_leaf
 
         hook = fx_model.get_submodule(hook_node.target)
         if not isinstance(hook, VoltageHook):
             raise TypeError("hook_node must target a VoltageHook module.")
-        s = threshold_optimizer.compute_threshold(hook)
+        s = float(threshold_optimizer.compute_threshold(hook))
+        if s <= 0.0:
+            raise ValueError(
+                f"Threshold must be > 0, got {s} for hook {hook_node.target!r}."
+            )
         target0 = f"{prefix}.scaler0"
         target1 = f"{prefix}.if_node"
         target2 = f"{prefix}.scaler1"
@@ -361,7 +366,6 @@ class ReLURule:
         node2.args = (node1,)
         fx_model.graph.erase_node(hook_node)
         fx_model.graph.erase_node(activation_node)
-        fx_model.delete_all_unused_submodules()
 
 
 def _add_module_and_node(

--- a/spikingjelly/activation_based/ann2snn/rules.py
+++ b/spikingjelly/activation_based/ann2snn/rules.py
@@ -362,8 +362,12 @@ class ReLURule:
         m1 = neuron_factory.create(scale=s)
         neuron_threshold = getattr(m1, "v_threshold", 1.0)
         if hasattr(neuron_threshold, "item"):
-            neuron_threshold = neuron_threshold.item()
-        m0 = VoltageScaler(neuron_threshold / s)
+            if not hasattr(neuron_threshold, "numel") or neuron_threshold.numel() == 1:
+                neuron_threshold = neuron_threshold.item()
+        input_scale = neuron_threshold / s
+        if hasattr(input_scale, "detach"):
+            input_scale = input_scale.detach().cpu().tolist()
+        m0 = VoltageScaler(input_scale)
         m2 = VoltageScaler(s)
 
         node0 = _add_module_and_node(

--- a/spikingjelly/activation_based/ann2snn/rules.py
+++ b/spikingjelly/activation_based/ann2snn/rules.py
@@ -1,0 +1,377 @@
+from typing import TYPE_CHECKING, Dict, Iterator, Protocol, Tuple
+
+import torch.nn as nn
+from torch import fx
+
+from spikingjelly.activation_based import neuron
+from spikingjelly.activation_based.ann2snn.modules import VoltageHook, VoltageScaler
+
+if TYPE_CHECKING:
+    from spikingjelly.activation_based.ann2snn.factories import (
+        HookFactory,
+        NeuronFactory,
+    )
+    from spikingjelly.activation_based.ann2snn.threshold import ThresholdOptimizer
+
+
+class ActivationRule(Protocol):
+    r"""
+    **API Language:**
+    :ref:`中文 <ActivationRule-cn>` | :ref:`English <ActivationRule-en>`
+
+    ----
+
+    .. _ActivationRule-cn:
+
+    * **中文**
+
+    激活函数转换规则协议。实现该协议即可接入新的 ANN→SNN 转换算法。规则需要负责：
+
+    1. 通过 :meth:`match` 判断是否处理某个 ``fx.Node``；
+    2. 通过 :meth:`insert_hooks` 在节点后插入校准 hook；
+    3. 通过 :meth:`find_replacements` 找到 ``(activation_node, hook_node)`` 对；
+    4. 通过 :meth:`replace_with_neurons` 将激活节点与 hook 替换为脉冲神经元结构。
+
+    ----
+
+    .. _ActivationRule-en:
+
+    * **English**
+
+    Protocol for activation-to-neuron conversion rules. Implement this
+    protocol to plug a new ANN→SNN algorithm into the converter. A rule
+    must:
+
+    1. decide whether it handles a given ``fx.Node`` via :meth:`match`;
+    2. insert a calibration hook after the node via :meth:`insert_hooks`;
+    3. enumerate ``(activation_node, hook_node)`` pairs to replace via
+       :meth:`find_replacements`;
+    4. replace the activation + hook pair with spiking neurons via
+       :meth:`replace_with_neurons`.
+    """
+
+    def match(self, node: fx.Node, modules: Dict[str, nn.Module]) -> bool:
+        r"""
+        **API Language:**
+        :ref:`中文 <ActivationRule.match-cn>` | :ref:`English <ActivationRule.match-en>`
+
+        ----
+
+        .. _ActivationRule.match-cn:
+
+        * **中文**
+
+        判断该规则是否处理给定节点。
+
+        :param node: 待检查的 ``fx.Node``。
+        :type node: fx.Node
+        :param modules: ``fx.GraphModule.named_modules()`` 得到的模块名字典。
+        :type modules: Dict[str, nn.Module]
+        :return: 若该规则负责此节点则返回 ``True``。
+        :rtype: bool
+
+        ----
+
+        .. _ActivationRule.match-en:
+
+        * **English**
+
+        Return *True* if this rule handles the given graph node.
+
+        :param node: The ``fx.Node`` to check.
+        :type node: fx.Node
+        :param modules: Module-name dictionary obtained from
+            ``fx.GraphModule.named_modules()``.
+        :type modules: Dict[str, nn.Module]
+        :return: ``True`` if this rule handles the node.
+        :rtype: bool
+        """
+        ...
+
+    def insert_hooks(
+        self,
+        fx_model: fx.GraphModule,
+        node: fx.Node,
+        hook_factory: "HookFactory",
+        hook_counts_per_prefix: Dict[str, int],
+    ) -> fx.Node:
+        r"""
+        **API Language:**
+        :ref:`中文 <ActivationRule.insert_hooks-cn>` | :ref:`English <ActivationRule.insert_hooks-en>`
+
+        ----
+
+        .. _ActivationRule.insert_hooks-cn:
+
+        * **中文**
+
+        在 ``node`` 之后插入一个由 ``hook_factory`` 创建的校准 hook，并将新节点加入
+        ``fx_model``。``hook_counts_per_prefix`` 用于在多 hook 场景下生成唯一的目标
+        名称。
+
+        :param fx_model: 待修改的 ``GraphModule``。
+        :type fx_model: fx.GraphModule
+        :param node: 触发 hook 插入的 ``fx.Node``。
+        :type node: fx.Node
+        :param hook_factory: 校准 hook 工厂。
+        :type hook_factory: HookFactory
+        :param hook_counts_per_prefix: 用于生成唯一 hook 目标名的前缀计数器。
+        :type hook_counts_per_prefix: Dict[str, int]
+        :return: 新插入的 hook 节点。
+        :rtype: fx.Node
+
+        ----
+
+        .. _ActivationRule.insert_hooks-en:
+
+        * **English**
+
+        Insert a calibration hook created by ``hook_factory`` after ``node`` and
+        register the new node inside ``fx_model``. ``hook_counts_per_prefix`` is
+        used to generate unique hook target names when multiple hooks are
+        inserted.
+
+        :param fx_model: The ``GraphModule`` to modify.
+        :type fx_model: fx.GraphModule
+        :param node: The ``fx.Node`` after which the hook is inserted.
+        :type node: fx.Node
+        :param hook_factory: Hook factory used to build the calibration hook.
+        :type hook_factory: HookFactory
+        :param hook_counts_per_prefix: Per-prefix counters used to build
+            unique hook target names.
+        :type hook_counts_per_prefix: Dict[str, int]
+        :return: The newly inserted hook node.
+        :rtype: fx.Node
+        """
+        ...
+
+    def find_replacements(
+        self, fx_model: fx.GraphModule, modules: Dict[str, nn.Module]
+    ) -> Iterator[Tuple[fx.Node, fx.Node]]:
+        r"""
+        **API Language:**
+        :ref:`中文 <ActivationRule.find_replacements-cn>` | :ref:`English <ActivationRule.find_replacements-en>`
+
+        ----
+
+        .. _ActivationRule.find_replacements-cn:
+
+        * **中文**
+
+        遍历 ``fx_model``，产出需要被替换的 ``(activation_node, hook_node)`` 对。
+        对于非标准图结构的规则，应重写该方法实现自定义遍历。
+
+        :param fx_model: 已插入校准 hook 的 ``GraphModule``。
+        :type fx_model: fx.GraphModule
+        :param modules: ``fx.GraphModule.named_modules()`` 得到的模块名字典。
+        :type modules: Dict[str, nn.Module]
+        :return: 形如 ``(activation_node, hook_node)`` 的迭代器。
+        :rtype: Iterator[Tuple[fx.Node, fx.Node]]
+
+        ----
+
+        .. _ActivationRule.find_replacements-en:
+
+        * **English**
+
+        Iterate over ``fx_model`` and yield ``(activation_node, hook_node)``
+        pairs to replace. Rules with non-standard graph patterns should
+        override this method with their own traversal.
+
+        :param fx_model: ``GraphModule`` with calibration hooks already
+            inserted.
+        :type fx_model: fx.GraphModule
+        :param modules: Module-name dictionary obtained from
+            ``fx.GraphModule.named_modules()``.
+        :type modules: Dict[str, nn.Module]
+        :return: Iterator of ``(activation_node, hook_node)`` pairs.
+        :rtype: Iterator[Tuple[fx.Node, fx.Node]]
+        """
+        ...
+
+    def replace_with_neurons(
+        self,
+        fx_model: fx.GraphModule,
+        activation_node: fx.Node,
+        hook_node: fx.Node,
+        neuron_factory: "NeuronFactory",
+        threshold_optimizer: "ThresholdOptimizer",
+    ) -> None:
+        r"""
+        **API Language:**
+        :ref:`中文 <ActivationRule.replace_with_neurons-cn>` | :ref:`English <ActivationRule.replace_with_neurons-en>`
+
+        ----
+
+        .. _ActivationRule.replace_with_neurons-cn:
+
+        * **中文**
+
+        将 ``activation_node`` 与 ``hook_node`` 替换为对应的脉冲神经元结构。``threshold``
+        由 ``threshold_optimizer`` 基于 hook 校准数据计算得到；神经元由
+        ``neuron_factory`` 构造。
+
+        :param fx_model: 待修改的 ``GraphModule``。
+        :type fx_model: fx.GraphModule
+        :param activation_node: 激活节点。
+        :type activation_node: fx.Node
+        :param hook_node: 校准 hook 节点。
+        :type hook_node: fx.Node
+        :param neuron_factory: 脉冲神经元工厂。
+        :type neuron_factory: NeuronFactory
+        :param threshold_optimizer: 阈值优化器。
+        :type threshold_optimizer: ThresholdOptimizer
+        :return: ``None``。
+        :rtype: None
+
+        ----
+
+        .. _ActivationRule.replace_with_neurons-en:
+
+        * **English**
+
+        Replace the activation + hook pair with the corresponding spiking
+        neuron structure. The threshold is computed by ``threshold_optimizer``
+        from the calibration hook; the neuron is built by ``neuron_factory``.
+
+        :param fx_model: The ``GraphModule`` to modify.
+        :type fx_model: fx.GraphModule
+        :param activation_node: The activation node.
+        :type activation_node: fx.Node
+        :param hook_node: The calibration hook node.
+        :type hook_node: fx.Node
+        :param neuron_factory: Spiking-neuron factory.
+        :type neuron_factory: NeuronFactory
+        :param threshold_optimizer: Threshold optimizer.
+        :type threshold_optimizer: ThresholdOptimizer
+        :return: ``None``.
+        :rtype: None
+        """
+        ...
+
+
+class ReLURule:
+    r"""
+    **API Language:**
+    :ref:`中文 <ReLURule-cn>` | :ref:`English <ReLURule-en>`
+
+    ----
+
+    .. _ReLURule-cn:
+
+    * **中文**
+
+    ``nn.ReLU`` 转换规则。复现 SpikingJelly 原有行为：将每个 ``nn.ReLU`` 替换为
+    ``VoltageScaler(1/s) -> IFNode -> VoltageScaler(s)``，其中 ``s`` 由
+    :class:`ThresholdOptimizer` 基于 :class:`VoltageHook` 的校准结果计算。
+
+    ----
+
+    .. _ReLURule-en:
+
+    * **English**
+
+    Conversion rule for ``nn.ReLU`` modules. Reproduces the original
+    SpikingJelly behaviour: each ``nn.ReLU`` is replaced by
+    ``VoltageScaler(1/s) -> IFNode -> VoltageScaler(s)``, where ``s`` is
+    computed by :class:`ThresholdOptimizer` from the
+    :class:`VoltageHook` calibration data.
+    """
+
+    def match(self, node: fx.Node, modules: Dict[str, nn.Module]) -> bool:
+        if node.op != "call_module":
+            return False
+        return type(modules[node.target]) is nn.ReLU
+
+    def insert_hooks(
+        self,
+        fx_model: fx.GraphModule,
+        node: fx.Node,
+        hook_factory: "HookFactory",
+        hook_counts_per_prefix: Dict[str, int],
+    ) -> fx.Node:
+        prefix = str(node.args[0]).split("_")
+
+        if len(prefix) > 1:
+            prefix = ".".join(prefix[:-1])
+            counter = hook_counts_per_prefix.get(prefix, 0)
+            hook_counts_per_prefix[prefix] = counter + 1
+            target = f"{prefix}.voltage_hook_{counter}"
+        else:
+            prefix = "__FIRST_LEVEL_OF_MODULE__"
+            counter = hook_counts_per_prefix.get(prefix, 0)
+            hook_counts_per_prefix[prefix] = counter + 1
+            target = f"voltage_hook_{counter}"
+
+        m = hook_factory.create()
+        return _add_module_and_node(fx_model, target, node, m, (node,))
+
+    def find_replacements(
+        self, fx_model: fx.GraphModule, modules: Dict[str, nn.Module]
+    ) -> Iterator[Tuple[fx.Node, fx.Node]]:
+        for hook_node in fx_model.graph.nodes:
+            if hook_node.op != "call_module":
+                continue
+            if not isinstance(modules.get(hook_node.target), VoltageHook):
+                continue
+            if len(hook_node.args) == 0 or not isinstance(hook_node.args[0], fx.Node):
+                continue
+            activation_node = hook_node.args[0]
+            if activation_node.op != "call_module":
+                continue
+            if activation_node.target not in modules:
+                continue
+            if self.match(activation_node, modules):
+                yield activation_node, hook_node
+
+    def replace_with_neurons(
+        self,
+        fx_model: fx.GraphModule,
+        activation_node: fx.Node,
+        hook_node: fx.Node,
+        neuron_factory: "NeuronFactory",
+        threshold_optimizer: "ThresholdOptimizer",
+    ) -> None:
+        # The prefix mirrors the hook target generated in insert_hooks. Keeping
+        # the names paired makes exported GraphModules easier to inspect.
+        prefix = hook_node.name.replace("voltage_hook_", "spiking")
+        prefix = prefix.split("_")
+        prefix = ".".join(prefix)
+
+        hook = fx_model.get_submodule(hook_node.target)
+        if not isinstance(hook, VoltageHook):
+            raise TypeError("hook_node must target a VoltageHook module.")
+        s = threshold_optimizer.compute_threshold(hook)
+        target0 = f"{prefix}.scaler0"
+        target1 = f"{prefix}.if_node"
+        target2 = f"{prefix}.scaler1"
+
+        m1 = neuron_factory.create(scale=s)
+        neuron_threshold = getattr(m1, "v_threshold", 1.0)
+        m0 = VoltageScaler(neuron_threshold / s)
+        m2 = VoltageScaler(s)
+
+        node0 = _add_module_and_node(
+            fx_model, target0, hook_node, m0, activation_node.args
+        )
+        node1 = _add_module_and_node(fx_model, target1, node0, m1, (node0,))
+        node2 = _add_module_and_node(fx_model, target2, node1, m2, args=(node1,))
+
+        activation_node.replace_all_uses_with(node2)
+        node2.args = (node1,)
+        fx_model.graph.erase_node(hook_node)
+        fx_model.graph.erase_node(activation_node)
+        fx_model.delete_all_unused_submodules()
+
+
+def _add_module_and_node(
+    fx_model: fx.GraphModule,
+    target: str,
+    after: fx.Node,
+    m: nn.Module,
+    args: Tuple,
+) -> fx.Node:
+    fx_model.add_submodule(target=target, m=m)
+    with fx_model.graph.inserting_after(n=after):
+        new_node = fx_model.graph.call_module(module_name=target, args=args)
+    return new_node

--- a/spikingjelly/activation_based/ann2snn/rules.py
+++ b/spikingjelly/activation_based/ann2snn/rules.py
@@ -282,7 +282,7 @@ class ReLURule:
     def match(self, node: fx.Node, modules: Dict[str, nn.Module]) -> bool:
         if node.op != "call_module":
             return False
-        return type(modules[node.target]) is nn.ReLU
+        return type(modules.get(node.target)) is nn.ReLU
 
     def insert_hooks(
         self,
@@ -364,10 +364,7 @@ class ReLURule:
         if hasattr(neuron_threshold, "item"):
             if not hasattr(neuron_threshold, "numel") or neuron_threshold.numel() == 1:
                 neuron_threshold = neuron_threshold.item()
-        input_scale = neuron_threshold / s
-        if hasattr(input_scale, "detach"):
-            input_scale = input_scale.detach().cpu().tolist()
-        m0 = VoltageScaler(input_scale)
+        m0 = VoltageScaler(neuron_threshold / s)
         m2 = VoltageScaler(s)
 
         node0 = _add_module_and_node(

--- a/spikingjelly/activation_based/ann2snn/threshold.py
+++ b/spikingjelly/activation_based/ann2snn/threshold.py
@@ -1,0 +1,93 @@
+from spikingjelly.activation_based.ann2snn.modules import VoltageHook
+
+
+class ThresholdOptimizer:
+    r"""
+    **API Language:**
+    :ref:`中文 <ThresholdOptimizer.__init__-cn>` | :ref:`English <ThresholdOptimizer.__init__-en>`
+
+    ----
+
+    .. _ThresholdOptimizer.__init__-cn:
+
+    * **中文**
+
+    阈值优化器。根据 :class:`VoltageHook` 在校准阶段记录的 ``scale`` 计算当前层的
+    神经元阈值。当前内置策略：
+
+    * ``"fixed"`` — 阈值等于校准 ``scale``（默认，等价于 SpikingJelly 原有行为）。
+
+    其他策略需通过子类化并重写 :meth:`compute_threshold` 实现；基类可接受任意策略
+    名，但只有 ``"fixed"`` 在基类中真正生效。
+
+    :param strategy: 阈值计算策略名称。
+    :type strategy: str
+
+    ----
+
+    .. _ThresholdOptimizer.__init__-en:
+
+    * **English**
+
+    Threshold optimizer. Computes the neuron threshold for a layer from the
+    ``scale`` recorded by :class:`VoltageHook` during calibration. Built-in
+    strategy:
+
+    * ``"fixed"`` — threshold equals the calibrated ``scale`` (default,
+      matches the original SpikingJelly behaviour).
+
+    Additional strategies should be implemented by subclassing and overriding
+    :meth:`compute_threshold`. The base class accepts any strategy name but
+    only implements ``"fixed"`` itself.
+
+    :param strategy: Name of the threshold computation strategy.
+    :type strategy: str
+    """
+
+    def __init__(self, strategy: str = "fixed"):
+        self.strategy = strategy
+
+    def compute_threshold(self, hook: VoltageHook) -> float:
+        r"""
+        **API Language:**
+        :ref:`中文 <ThresholdOptimizer.compute_threshold-cn>` | :ref:`English <ThresholdOptimizer.compute_threshold-en>`
+
+        ----
+
+        .. _ThresholdOptimizer.compute_threshold-cn:
+
+        * **中文**
+
+        返回当前层对应的脉冲神经元阈值。当前仅在 ``strategy="fixed"`` 时直接返回
+        hook 中记录的 ``scale``；其他策略由子类实现。
+
+        :param hook: 已完成校准的 :class:`VoltageHook`，其 ``scale`` 属性保存激活
+            范围统计量。
+        :type hook: VoltageHook
+        :return: 神经元阈值。
+        :rtype: float
+        :raises NotImplementedError: 当 ``strategy`` 不是已实现策略时抛出。
+        :raises AttributeError: 当 ``hook`` 不包含 ``scale`` 属性时抛出。
+
+        ----
+
+        .. _ThresholdOptimizer.compute_threshold-en:
+
+        * **English**
+
+        Return the spiking-neuron threshold for the layer represented by
+        *hook*. With ``strategy="fixed"`` this returns the ``scale`` stored
+        in the hook; other strategies should be implemented by subclasses.
+
+        :param hook: A calibrated :class:`VoltageHook` whose ``scale``
+            attribute holds the activation range statistic.
+        :type hook: VoltageHook
+        :return: The neuron threshold.
+        :rtype: float
+        :raises NotImplementedError: If ``strategy`` is not implemented.
+        :raises AttributeError: If ``hook`` does not expose a ``scale``
+            attribute.
+        """
+        if self.strategy == "fixed":
+            return hook.scale.item()
+        raise NotImplementedError(f"Strategy {self.strategy!r} is not implemented.")

--- a/test/activation_based/test_ann2snn.py
+++ b/test/activation_based/test_ann2snn.py
@@ -296,6 +296,19 @@ class TestConverterBackwardCompat:
         snn = converter(model)
         assert snn is not None
 
+    def test_dict_dataloader_prefers_input_key(self):
+        model = SimpleCNNNoBN()
+        model.eval()
+        imgs = torch.randn(2, 1, 28, 28)
+        labels = torch.zeros(2, dtype=torch.long)
+        converter = Converter(
+            dataloader=[{"label": labels, "input": imgs}],
+            mode="Max",
+            fuse_flag=False,
+        )
+        snn = converter(model)
+        assert snn is not None
+
 
 class TestFuse:
     def test_conv_bn_fusion_matches_eval_output(self):
@@ -503,6 +516,26 @@ class TestRuleBasedConversion:
         assert scalers[0].scale.item() == pytest.approx(
             if_nodes[0].v_threshold.item() / scalers[1].scale.item()
         )
+
+    def test_multi_element_neuron_threshold_updates_input_scaler(self):
+        class MultiThresholdFactory(NeuronFactory):
+            def create(self, scale):
+                n = super().create(scale)
+                n.v_threshold = torch.tensor([2.0, 4.0])
+                return n
+
+        model = SimpleCNNNoBN()
+        model.eval()
+        snn = Converter(
+            dataloader=_make_loader(),
+            neuron_factory=MultiThresholdFactory(),
+            threshold_optimizer=ThresholdOptimizer("fixed"),
+            fuse_flag=False,
+        )(model)
+
+        scalers = [m for m in snn.modules() if isinstance(m, VoltageScaler)]
+        assert len(scalers) == 2
+        assert scalers[0].scale.shape == torch.Size([2])
 
     def test_module_names_with_underscores_convert(self):
         model = UnderscoreModuleCNN()

--- a/test/activation_based/test_ann2snn.py
+++ b/test/activation_based/test_ann2snn.py
@@ -454,6 +454,22 @@ class TestRuleBasedConversion:
         with pytest.raises(ValueError, match="Threshold must be > 0"):
             converter(model)
 
+    def test_nan_threshold_raises(self):
+        class NaNScaleOptimizer:
+            def compute_threshold(self, hook):
+                return float("nan")
+
+        model = SimpleCNNNoBN()
+        model.eval()
+        converter = Converter(
+            dataloader=_make_loader(),
+            threshold_optimizer=NaNScaleOptimizer(),
+            fuse_flag=False,
+        )
+
+        with pytest.raises(ValueError, match="Threshold must be > 0"):
+            converter(model)
+
 
 class TestReplaceByIfnodeDeprecation:
     def test_set_voltagehook_static_legacy_api(self):

--- a/test/activation_based/test_ann2snn.py
+++ b/test/activation_based/test_ann2snn.py
@@ -278,6 +278,24 @@ class TestConverterBackwardCompat:
         with pytest.raises(NotImplementedError):
             Converter(dataloader=[], mode=0.0)
 
+    def test_tensor_dataloader_converts(self):
+        model = SimpleCNNNoBN()
+        model.eval()
+        imgs = torch.randn(2, 1, 28, 28)
+        converter = Converter(dataloader=[imgs], mode="Max", fuse_flag=False)
+        snn = converter(model)
+        assert snn is not None
+
+    def test_dict_dataloader_converts(self):
+        model = SimpleCNNNoBN()
+        model.eval()
+        imgs = torch.randn(2, 1, 28, 28)
+        converter = Converter(
+            dataloader=[{"input": imgs}], mode="Max", fuse_flag=False
+        )
+        snn = converter(model)
+        assert snn is not None
+
 
 class TestFuse:
     def test_conv_bn_fusion_matches_eval_output(self):
@@ -508,7 +526,7 @@ class TestRuleBasedConversion:
             fuse_flag=False,
         )
 
-        with pytest.raises(ValueError, match="Threshold must be > 0"):
+        with pytest.raises(ValueError, match="finite positive"):
             converter(model)
 
     def test_nan_threshold_raises(self):
@@ -524,7 +542,23 @@ class TestRuleBasedConversion:
             fuse_flag=False,
         )
 
-        with pytest.raises(ValueError, match="Threshold must be > 0"):
+        with pytest.raises(ValueError, match="finite positive"):
+            converter(model)
+
+    def test_infinite_threshold_raises(self):
+        class InfiniteScaleOptimizer:
+            def compute_threshold(self, hook):
+                return float("inf")
+
+        model = SimpleCNNNoBN()
+        model.eval()
+        converter = Converter(
+            dataloader=_make_loader(),
+            threshold_optimizer=InfiniteScaleOptimizer(),
+            fuse_flag=False,
+        )
+
+        with pytest.raises(ValueError, match="finite positive"):
             converter(model)
 
 

--- a/test/activation_based/test_ann2snn.py
+++ b/test/activation_based/test_ann2snn.py
@@ -453,6 +453,48 @@ class TestRuleBasedConversion:
         assert rule.find_count == 1
         assert rule.replace_count == 1
 
+    def test_set_voltagehook_refreshes_modules_after_rule_insert(self):
+        class TwoReLUCNN(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.relu0 = nn.ReLU()
+                self.relu1 = nn.ReLU()
+
+            def forward(self, x):
+                return self.relu1(self.relu0(x))
+
+        class MarkerRule:
+            def __init__(self):
+                self.inserted = False
+
+            def match(self, node, modules):
+                return not self.inserted and node.target == "relu0"
+
+            def insert_hooks(self, fx_model, node, *args, **kwargs):
+                self.inserted = True
+                fx_model.add_submodule("marker", nn.Identity())
+
+        class MarkerAwareRule:
+            def __init__(self):
+                self.saw_marker = False
+
+            def match(self, node, modules):
+                if node.target == "relu1" and "marker" in modules:
+                    self.saw_marker = True
+                return False
+
+        marker_rule = MarkerRule()
+        marker_aware_rule = MarkerAwareRule()
+        fx_model = torch.fx.symbolic_trace(TwoReLUCNN())
+
+        Converter.set_voltagehook(
+            fx_model,
+            rules=[marker_rule, marker_aware_rule],
+        )
+
+        assert marker_rule.inserted
+        assert marker_aware_rule.saw_marker
+
     def test_duplicate_activation_replacements_are_skipped(self):
         class DuplicateActivationRule(ReLURule):
             def __init__(self):

--- a/test/activation_based/test_ann2snn.py
+++ b/test/activation_based/test_ann2snn.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 import torch
 import torch.nn as nn
@@ -282,6 +283,14 @@ class TestConverterBackwardCompat:
         model = SimpleCNNNoBN()
         model.eval()
         imgs = torch.randn(2, 1, 28, 28)
+        converter = Converter(dataloader=[imgs], mode="Max", fuse_flag=False)
+        snn = converter(model)
+        assert snn is not None
+
+    def test_numpy_dataloader_converts_full_batch(self):
+        model = SimpleCNNNoBN()
+        model.eval()
+        imgs = np.random.randn(2, 1, 28, 28).astype(np.float32)
         converter = Converter(dataloader=[imgs], mode="Max", fuse_flag=False)
         snn = converter(model)
         assert snn is not None

--- a/test/activation_based/test_ann2snn.py
+++ b/test/activation_based/test_ann2snn.py
@@ -517,26 +517,6 @@ class TestRuleBasedConversion:
             if_nodes[0].v_threshold.item() / scalers[1].scale.item()
         )
 
-    def test_multi_element_neuron_threshold_updates_input_scaler(self):
-        class MultiThresholdFactory(NeuronFactory):
-            def create(self, scale):
-                n = super().create(scale)
-                n.v_threshold = torch.tensor([2.0, 4.0])
-                return n
-
-        model = SimpleCNNNoBN()
-        model.eval()
-        snn = Converter(
-            dataloader=_make_loader(),
-            neuron_factory=MultiThresholdFactory(),
-            threshold_optimizer=ThresholdOptimizer("fixed"),
-            fuse_flag=False,
-        )(model)
-
-        scalers = [m for m in snn.modules() if isinstance(m, VoltageScaler)]
-        assert len(scalers) == 2
-        assert scalers[0].scale.shape == torch.Size([2])
-
     def test_module_names_with_underscores_convert(self):
         model = UnderscoreModuleCNN()
         model.eval()

--- a/test/activation_based/test_ann2snn.py
+++ b/test/activation_based/test_ann2snn.py
@@ -1,0 +1,466 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from spikingjelly.activation_based import ann2snn, neuron
+from spikingjelly.activation_based.ann2snn import (
+    Converter,
+    HookFactory,
+    NeuronFactory,
+    ReLURule,
+    ThresholdOptimizer,
+)
+from spikingjelly.activation_based.ann2snn.modules import VoltageHook, VoltageScaler
+
+
+class SimpleCNN(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(1, 8, 3, padding=1)
+        self.bn = nn.BatchNorm2d(8)
+        self.relu = nn.ReLU()
+        self.pool = nn.AvgPool2d(2)
+        self.fc = nn.Linear(8 * 14 * 14, 10)
+
+    def forward(self, x):
+        x = self.pool(self.relu(self.bn(self.conv(x))))
+        x = x.view(x.size(0), -1)
+        return self.fc(x)
+
+
+class SimpleCNNNoBN(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(1, 8, 3, padding=1)
+        self.relu = nn.ReLU()
+        self.pool = nn.AvgPool2d(2)
+        self.fc = nn.Linear(8 * 14 * 14, 10)
+
+    def forward(self, x):
+        x = self.pool(self.relu(self.conv(x)))
+        x = x.view(x.size(0), -1)
+        return self.fc(x)
+
+
+def _make_loader(batch_size=2, channels=1, h=28, w=28):
+    imgs = torch.randn(batch_size, channels, h, w)
+    labels = torch.zeros(batch_size, dtype=torch.long)
+    return [(imgs, labels)]
+
+
+class TestVoltageHook:
+    def test_max_mode(self):
+        hook = VoltageHook(mode="Max")
+        x = torch.tensor([1.0, 2.0, 3.0])
+        hook(x)
+        assert hook.scale.item() == pytest.approx(3.0)
+
+    def test_percentile_mode(self):
+        hook = VoltageHook(mode="99.9%")
+        x = torch.randn(1000)
+        hook(x)
+        assert hook.scale.item() > 0
+
+    def test_scalar_mode(self):
+        hook = VoltageHook(mode=0.5)
+        hook(torch.tensor([10.0]))
+        assert hook.scale.item() == pytest.approx(5.0)
+
+    def test_ema_momentum(self):
+        hook = VoltageHook(momentum=0.5, mode="Max")
+        hook(torch.tensor([4.0]))
+        hook(torch.tensor([2.0]))
+        assert hook.scale.item() == pytest.approx(3.0)
+
+    def test_first_batch_no_ema(self):
+        hook = VoltageHook(momentum=0.1, mode="Max")
+        hook(torch.tensor([7.0]))
+        assert hook.scale.item() == pytest.approx(7.0)
+
+    def test_passthrough(self):
+        hook = VoltageHook(mode="Max")
+        x = torch.randn(3, 4)
+        out = hook(x)
+        assert torch.equal(out, x)
+
+
+class TestVoltageScaler:
+    def test_scaling(self):
+        scaler = VoltageScaler(2.5)
+        x = torch.tensor([1.0, 2.0])
+        result = scaler(x)
+        assert torch.allclose(result, torch.tensor([2.5, 5.0]))
+
+    def test_identity(self):
+        scaler = VoltageScaler(1.0)
+        x = torch.randn(3, 4)
+        assert torch.allclose(scaler(x), x)
+
+    def test_extra_repr(self):
+        scaler = VoltageScaler(3.14)
+        assert "3.14" in scaler.extra_repr()
+
+
+class TestReLURule:
+    def test_matches_relu(self):
+        rule = ReLURule()
+        mod = nn.ReLU()
+        modules = {"relu": mod}
+        node = SimpleNamespace(op="call_module", target="relu")
+        assert rule.match(node, modules)
+
+    def test_rejects_gelu(self):
+        rule = ReLURule()
+        modules = {"gelu": nn.GELU()}
+        node = SimpleNamespace(op="call_module", target="gelu")
+        assert not rule.match(node, modules)
+
+    def test_rejects_leaky_relu(self):
+        rule = ReLURule()
+        modules = {"lrelu": nn.LeakyReLU(0.1)}
+        node = SimpleNamespace(op="call_module", target="lrelu")
+        assert not rule.match(node, modules)
+
+    def test_rejects_function_node(self):
+        rule = ReLURule()
+        modules = {}
+        node = SimpleNamespace(op="call_function", target="relu")
+        assert not rule.match(node, modules)
+
+
+class TestPublicExports:
+    def test_all_contains_new_public_api(self):
+        assert set(ann2snn.__all__) == {
+            "Converter",
+            "download_url",
+            "ReLURule",
+            "NeuronFactory",
+            "HookFactory",
+            "ThresholdOptimizer",
+        }
+
+
+class TestNeuronFactory:
+    def test_default_creates_ifnode(self):
+        factory = NeuronFactory()
+        n = factory.create(scale=5.0)
+        assert isinstance(n, neuron.IFNode)
+        assert n.v_threshold == 1.0
+        assert n.v_reset is None
+
+    def test_custom_threshold(self):
+        factory = NeuronFactory(v_threshold=2.0)
+        n = factory.create(scale=5.0)
+        assert n.v_threshold == 2.0
+
+    def test_custom_neuron_type(self):
+        factory = NeuronFactory(neuron_type=neuron.LIFNode, tau=2.0)
+        n = factory.create(scale=1.0)
+        assert isinstance(n, neuron.LIFNode)
+
+
+class TestHookFactory:
+    def test_default_mode(self):
+        factory = HookFactory()
+        hook = factory.create()
+        assert hook.mode == "Max"
+        assert hook.momentum == 0.1
+
+    def test_custom_mode(self):
+        factory = HookFactory(mode="99.9%", momentum=0.5)
+        hook = factory.create()
+        assert hook.mode == "99.9%"
+        assert hook.momentum == 0.5
+
+
+class TestThresholdOptimizer:
+    def test_fixed_returns_scale(self):
+        opt = ThresholdOptimizer("fixed")
+        hook = VoltageHook(mode="Max")
+        hook(torch.tensor([5.0]))
+        assert opt.compute_threshold(hook) == pytest.approx(5.0)
+
+    def test_unknown_strategy_raises_when_computed(self):
+        opt = ThresholdOptimizer("nonexistent")
+        hook = VoltageHook(mode="Max")
+        hook(torch.tensor([5.0]))
+        with pytest.raises(NotImplementedError):
+            opt.compute_threshold(hook)
+
+    def test_default_is_fixed(self):
+        opt = ThresholdOptimizer()
+        assert opt.strategy == "fixed"
+
+    def test_subclass_can_store_custom_strategy(self):
+        class CustomOptimizer(ThresholdOptimizer):
+            def compute_threshold(self, hook):
+                assert self.strategy == "custom"
+                return 3.0
+
+        opt = CustomOptimizer("custom")
+        hook = VoltageHook(mode="Max")
+        hook(torch.tensor([5.0]))
+        assert opt.compute_threshold(hook) == pytest.approx(3.0)
+
+
+class TestConverterBackwardCompat:
+    def test_relu_model_converts(self):
+        model = SimpleCNN()
+        model.eval()
+        converter = Converter(dataloader=_make_loader(), mode="Max", fuse_flag=False)
+        snn = converter(model)
+        assert snn is not None
+
+    def test_output_shape_preserved(self):
+        model = SimpleCNN()
+        model.eval()
+        dummy = torch.randn(1, 1, 28, 28)
+        converter = Converter(dataloader=_make_loader(), mode="Max", fuse_flag=False)
+        snn = converter(model)
+        out = snn(dummy)
+        assert out.shape == (1, 10)
+
+    def test_fuse_conv_bn(self):
+        model = SimpleCNN()
+        model.eval()
+        converter = Converter(dataloader=_make_loader(), mode="Max", fuse_flag=True)
+        snn = converter(model)
+        assert snn is not None
+
+    def test_mode_max(self):
+        model = SimpleCNN()
+        model.eval()
+        converter = Converter(dataloader=_make_loader(), mode="max")
+        snn = converter(model)
+        assert snn is not None
+
+    def test_mode_robust(self):
+        model = SimpleCNN()
+        model.eval()
+        converter = Converter(dataloader=_make_loader(), mode="99.9%")
+        snn = converter(model)
+        assert snn is not None
+
+    def test_mode_scalar(self):
+        model = SimpleCNN()
+        model.eval()
+        converter = Converter(dataloader=_make_loader(), mode=0.5)
+        snn = converter(model)
+        assert snn is not None
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(NotImplementedError):
+            Converter(dataloader=[], mode="invalid")
+
+    def test_invalid_scalar_raises(self):
+        with pytest.raises(NotImplementedError):
+            Converter(dataloader=[], mode=1.5)
+
+    def test_invalid_scalar_zero_raises(self):
+        with pytest.raises(NotImplementedError):
+            Converter(dataloader=[], mode=0.0)
+
+
+class TestFuse:
+    def test_conv_bn_fusion_matches_eval_output(self):
+        model = SimpleCNN()
+        model.eval()
+        fx_model = torch.fx.symbolic_trace(model)
+        x = torch.randn(2, 1, 28, 28)
+        expected = fx_model(x)
+
+        fused = Converter.fuse(fx_model, fuse_flag=True)
+        result = fused(x)
+
+        assert torch.allclose(result, expected, atol=1e-5, rtol=1e-5)
+        assert not any(isinstance(m, nn.BatchNorm2d) for m in fused.modules())
+
+    def test_no_bn_model_fuse(self):
+        model = SimpleCNNNoBN()
+        model.eval()
+        converter = Converter(dataloader=_make_loader(), mode="Max", fuse_flag=True)
+        snn = converter(model)
+        assert snn is not None
+
+    def test_fuse_flag_false(self):
+        model = SimpleCNN()
+        model.eval()
+        converter = Converter(dataloader=_make_loader(), mode="Max", fuse_flag=False)
+        snn = converter(model)
+        assert snn is not None
+
+
+class TestRuleBasedConversion:
+    def test_custom_rules_list(self):
+        model = SimpleCNN()
+        model.eval()
+        converter = Converter(
+            dataloader=_make_loader(),
+            rules=[ReLURule()],
+            fuse_flag=False,
+        )
+        snn = converter(model)
+        assert snn is not None
+        assert any(isinstance(m, neuron.IFNode) for m in snn.modules())
+
+    def test_custom_neuron_factory(self):
+        model = SimpleCNN()
+        model.eval()
+        converter = Converter(
+            dataloader=_make_loader(),
+            neuron_factory=NeuronFactory(v_threshold=2.0),
+            fuse_flag=False,
+        )
+        snn = converter(model)
+        assert snn is not None
+        if_nodes = [m for m in snn.modules() if isinstance(m, neuron.IFNode)]
+        assert len(if_nodes) == 1
+        assert if_nodes[0].v_threshold == 2.0
+
+    def test_custom_neuron_threshold_updates_input_scaler(self):
+        model = SimpleCNNNoBN()
+        model.eval()
+        converter = Converter(
+            dataloader=_make_loader(),
+            neuron_factory=NeuronFactory(v_threshold=2.0),
+            threshold_optimizer=ThresholdOptimizer("fixed"),
+            fuse_flag=False,
+        )
+        snn = converter(model)
+
+        scalers = [m for m in snn.modules() if isinstance(m, VoltageScaler)]
+        if_nodes = [m for m in snn.modules() if isinstance(m, neuron.IFNode)]
+        assert len(scalers) == 2
+        assert len(if_nodes) == 1
+        assert scalers[0].scale.item() == pytest.approx(
+            if_nodes[0].v_threshold / scalers[1].scale.item()
+        )
+
+    def test_empty_rules_leaves_relu(self):
+        model = SimpleCNNNoBN()
+        model.eval()
+        converter = Converter(
+            dataloader=_make_loader(),
+            rules=[],
+            fuse_flag=False,
+        )
+        snn = converter(model)
+        assert any(isinstance(m, nn.ReLU) for m in snn.modules())
+        assert not any(isinstance(m, neuron.IFNode) for m in snn.modules())
+
+    def test_custom_rule_is_used(self):
+        class CountingRule(ReLURule):
+            def __init__(self):
+                self.match_count = 0
+                self.insert_count = 0
+                self.replace_count = 0
+
+            def match(self, node, modules):
+                matched = super().match(node, modules)
+                if matched:
+                    self.match_count += 1
+                return matched
+
+            def insert_hooks(self, *args, **kwargs):
+                self.insert_count += 1
+                return super().insert_hooks(*args, **kwargs)
+
+            def find_replacements(self, *args, **kwargs):
+                self.find_count = getattr(self, "find_count", 0) + 1
+                return super().find_replacements(*args, **kwargs)
+
+            def replace_with_neurons(self, *args, **kwargs):
+                self.replace_count += 1
+                return super().replace_with_neurons(*args, **kwargs)
+
+        rule = CountingRule()
+        model = SimpleCNNNoBN()
+        model.eval()
+        Converter(
+            dataloader=_make_loader(),
+            rules=[rule],
+            fuse_flag=False,
+        )(model)
+
+        assert rule.match_count >= 2
+        assert rule.insert_count == 1
+        assert rule.find_count == 1
+        assert rule.replace_count == 1
+
+    def test_threshold_optimizer_is_used(self):
+        class FixedScaleOptimizer:
+            def __init__(self):
+                self.called = False
+
+            def compute_threshold(self, hook):
+                self.called = True
+                return 2.0
+
+        optimizer = FixedScaleOptimizer()
+        model = SimpleCNNNoBN()
+        model.eval()
+        snn = Converter(
+            dataloader=_make_loader(),
+            threshold_optimizer=optimizer,
+            fuse_flag=False,
+        )(model)
+
+        assert optimizer.called
+        scalers = [m for m in snn.modules() if isinstance(m, VoltageScaler)]
+        assert len(scalers) == 2
+        assert scalers[0].scale.item() == pytest.approx(0.5)
+        assert scalers[1].scale.item() == pytest.approx(2.0)
+
+
+class TestReplaceByIfnodeDeprecation:
+    def test_set_voltagehook_static_legacy_api(self):
+        model = SimpleCNNNoBN()
+        model.eval()
+        ann = torch.fx.symbolic_trace(model)
+        ann_with_hook = Converter.set_voltagehook(ann, mode="99.9%", momentum=0.2)
+
+        hooks = [m for m in ann_with_hook.modules() if isinstance(m, VoltageHook)]
+        assert len(hooks) == 1
+        assert hooks[0].mode == "99.9%"
+        assert hooks[0].momentum == 0.2
+
+    def test_deprecation_warning(self):
+        model = SimpleCNN()
+        model.eval()
+        converter = Converter(dataloader=_make_loader(), fuse_flag=False)
+        ann = torch.fx.symbolic_trace(model)
+        ann_fused = converter.fuse(ann, fuse_flag=False)
+        ann_with_hook = converter.set_voltagehook(ann_fused)
+        for data in _make_loader():
+            ann_with_hook(data[0])
+        with pytest.warns(DeprecationWarning, match="replace_by_ifnode is deprecated"):
+            snn = Converter.replace_by_ifnode(ann_with_hook)
+        assert snn is not None
+
+
+class TestEndToEnd:
+    def test_snn_inference(self):
+        model = SimpleCNN()
+        model.eval()
+        converter = Converter(dataloader=_make_loader(), mode="Max", fuse_flag=True)
+        snn = converter(model)
+        img = torch.randn(1, 1, 28, 28)
+        T = 10
+        out = 0
+        for t in range(T):
+            for m in snn.modules():
+                if hasattr(m, "reset"):
+                    m.reset()
+            for _ in range(T):
+                out = out + snn(img)
+        assert out.shape == (1, 10)
+
+    def test_snn_no_bn(self):
+        model = SimpleCNNNoBN()
+        model.eval()
+        converter = Converter(dataloader=_make_loader(), mode="Max", fuse_flag=False)
+        snn = converter(model)
+        out = snn(torch.randn(1, 1, 28, 28))
+        assert out.shape == (1, 10)

--- a/test/activation_based/test_ann2snn.py
+++ b/test/activation_based/test_ann2snn.py
@@ -429,6 +429,30 @@ class TestRuleBasedConversion:
         assert scalers[0].scale.item() == pytest.approx(0.5)
         assert scalers[1].scale.item() == pytest.approx(2.0)
 
+    def test_tensor_neuron_threshold_updates_input_scaler(self):
+        class TensorThresholdFactory(NeuronFactory):
+            def create(self, scale):
+                n = super().create(scale)
+                n.v_threshold = torch.tensor(2.0)
+                return n
+
+        model = SimpleCNNNoBN()
+        model.eval()
+        snn = Converter(
+            dataloader=_make_loader(),
+            neuron_factory=TensorThresholdFactory(),
+            threshold_optimizer=ThresholdOptimizer("fixed"),
+            fuse_flag=False,
+        )(model)
+
+        scalers = [m for m in snn.modules() if isinstance(m, VoltageScaler)]
+        if_nodes = [m for m in snn.modules() if isinstance(m, neuron.IFNode)]
+        assert len(scalers) == 2
+        assert len(if_nodes) == 1
+        assert scalers[0].scale.item() == pytest.approx(
+            if_nodes[0].v_threshold.item() / scalers[1].scale.item()
+        )
+
     def test_module_names_with_underscores_convert(self):
         model = UnderscoreModuleCNN()
         model.eval()

--- a/test/activation_based/test_ann2snn.py
+++ b/test/activation_based/test_ann2snn.py
@@ -44,6 +44,22 @@ class SimpleCNNNoBN(nn.Module):
         return self.fc(x)
 
 
+class UnderscoreModuleCNN(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv_block = nn.Sequential(
+            nn.Conv2d(1, 8, 3, padding=1),
+            nn.ReLU(),
+            nn.AvgPool2d(2),
+        )
+        self.fc = nn.Linear(8 * 14 * 14, 10)
+
+    def forward(self, x):
+        x = self.conv_block(x)
+        x = x.view(x.size(0), -1)
+        return self.fc(x)
+
+
 def _make_loader(batch_size=2, channels=1, h=28, w=28):
     imgs = torch.randn(batch_size, channels, h, w)
     labels = torch.zeros(batch_size, dtype=torch.long)
@@ -413,6 +429,31 @@ class TestRuleBasedConversion:
         assert scalers[0].scale.item() == pytest.approx(0.5)
         assert scalers[1].scale.item() == pytest.approx(2.0)
 
+    def test_module_names_with_underscores_convert(self):
+        model = UnderscoreModuleCNN()
+        model.eval()
+        snn = Converter(dataloader=_make_loader(), fuse_flag=False)(model)
+
+        assert any(isinstance(m, neuron.IFNode) for m in snn.modules())
+        assert not any(isinstance(m, nn.ReLU) for m in snn.modules())
+        assert "conv_block.spiking_0.if_node" in dict(snn.named_modules())
+
+    def test_non_positive_threshold_raises(self):
+        class ZeroScaleOptimizer:
+            def compute_threshold(self, hook):
+                return 0.0
+
+        model = SimpleCNNNoBN()
+        model.eval()
+        converter = Converter(
+            dataloader=_make_loader(),
+            threshold_optimizer=ZeroScaleOptimizer(),
+            fuse_flag=False,
+        )
+
+        with pytest.raises(ValueError, match="Threshold must be > 0"):
+            converter(model)
+
 
 class TestReplaceByIfnodeDeprecation:
     def test_set_voltagehook_static_legacy_api(self):
@@ -449,12 +490,11 @@ class TestEndToEnd:
         img = torch.randn(1, 1, 28, 28)
         T = 10
         out = 0
-        for t in range(T):
-            for m in snn.modules():
-                if hasattr(m, "reset"):
-                    m.reset()
-            for _ in range(T):
-                out = out + snn(img)
+        for m in snn.modules():
+            if hasattr(m, "reset"):
+                m.reset()
+        for _ in range(T):
+            out = out + snn(img)
         assert out.shape == (1, 10)
 
     def test_snn_no_bn(self):

--- a/test/activation_based/test_ann2snn.py
+++ b/test/activation_based/test_ann2snn.py
@@ -318,6 +318,14 @@ class TestConverterBackwardCompat:
         snn = converter(model)
         assert snn is not None
 
+    def test_extract_batch_input_rejects_empty_sequence(self):
+        with pytest.raises(ValueError, match="empty list or tuple"):
+            Converter._extract_batch_input([])
+
+    def test_extract_batch_input_rejects_empty_dict(self):
+        with pytest.raises(ValueError, match="empty dictionary"):
+            Converter._extract_batch_input({})
+
 
 class TestFuse:
     def test_conv_bn_fusion_matches_eval_output(self):

--- a/test/activation_based/test_ann2snn.py
+++ b/test/activation_based/test_ann2snn.py
@@ -405,6 +405,39 @@ class TestRuleBasedConversion:
         assert rule.find_count == 1
         assert rule.replace_count == 1
 
+    def test_duplicate_activation_replacements_are_skipped(self):
+        class DuplicateActivationRule(ReLURule):
+            def __init__(self):
+                self.replace_count = 0
+
+            def find_replacements(self, fx_model, modules):
+                replacements = list(super().find_replacements(fx_model, modules))
+                if len(replacements) != 1:
+                    return iter(replacements)
+                activation_node, hook_node = replacements[0]
+                return iter(
+                    [
+                        (activation_node, hook_node),
+                        (activation_node, object()),
+                    ]
+                )
+
+            def replace_with_neurons(self, *args, **kwargs):
+                self.replace_count += 1
+                return super().replace_with_neurons(*args, **kwargs)
+
+        rule = DuplicateActivationRule()
+        model = SimpleCNNNoBN()
+        model.eval()
+        snn = Converter(
+            dataloader=_make_loader(),
+            rules=[rule],
+            fuse_flag=False,
+        )(model)
+
+        assert rule.replace_count == 1
+        assert any(isinstance(m, neuron.IFNode) for m in snn.modules())
+
     def test_threshold_optimizer_is_used(self):
         class FixedScaleOptimizer:
             def __init__(self):


### PR DESCRIPTION
## Summary

This PR restructures `spikingjelly.activation_based.ann2snn` so the
ANN-to-SNN conversion path is built from a small set of composable
components, then aligns the public docstrings with the bilingual
`API Language / 中文 / English` style required by `AGENTS.md`.

### Refactor (commit 1)

Extract the conversion logic into a rule / factory / threshold
pipeline:

- `factories.HookFactory` / `NeuronFactory` — build calibration
  hooks and spiking neurons with explicit configuration.
- `rules.ActivationRule` protocol + `ReLURule` — encapsulate
  activation matching, hook insertion, replacement search and neuron
  replacement. New conversion algorithms can plug in by implementing
  the protocol.
- `threshold.ThresholdOptimizer` — compute per-layer thresholds
  from the recorded `VoltageHook` scale (default `"fixed"`
  strategy preserves the original behaviour).

`Converter` now drives these components. The default rule / factories
/ optimizer reproduce the previous
`ReLU -> VoltageScaler(1/s) -> IFNode -> VoltageScaler(s)`
replacement, so existing callers see identical output. The legacy
`Converter.replace_by_ifnode` is preserved as a deprecated thin
wrapper around `replace_by_neurons`.

### Tests (commit 1)

Adds 45 unit tests in `test/activation_based/test_ann2snn.py`
covering rule matching, hook insertion, replacement, threshold
optimization and the full `Converter` flow. All 45 pass locally.

### Docs (commit 2)

Aligns the public docstrings of `__init__.py`, `factories.py`,
`rules.py` and `threshold.py` with the AGENTS.md guidelines:
`API Language` anchor, separate `中文` and `English` sections,
and explicit `:param:` / `:type:` / `:return:` / `:rtype:` /
`:raises:` fields. Also documents the new
`Converter.set_voltagehook` `rules` parameter and the new
`Converter.replace_by_neurons` entry point.

`modules.py` (VoltageHook / VoltageScaler) and `utils.py`
(download_url) already followed the style and were left untouched.

## Test plan

- [x] `pytest test/activation_based/test_ann2snn.py` → 45/45 pass
- [x] All 7 ann2snn modules import without warnings
- [x] 19 public docstrings parse cleanly with docutils (Sphinx roles
      aside)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable ANN→SNN conversion components: `NeuronFactory`, `HookFactory`, `ReLURule`, and `ThresholdOptimizer` are now publicly exposed.
  * `Converter` now supports rule-/factory-driven conversion via `replace_by_neurons`, with configurable neuron creation and threshold optimization.
  * Kept legacy `replace_by_ifnode`, now deprecated with a deprecation warning.
* **Documentation / Chores**
  * Expanded Sphinx-ready documentation for the `ann2snn` package.
  * Updated `.gitignore` to exclude `.codegraph/`.
* **Tests**
  * Added comprehensive pytest coverage for factories, rules, threshold computation, converter behavior, conversion edge cases, and deprecation warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->