### PR TITLE
Fix AttributeError in LIAFNode.__init__: remove dead assertion (closes #655)

### DIFF
--- a/spikingjelly/activation_based/neuron/lif_variants.py
+++ b/spikingjelly/activation_based/neuron/lif_variants.py
@@ -676,9 +676,6 @@ class LIAFNode(LIFNode):
         self.threshold_related = threshold_related
 
         assert self.backend == "torch", "LIAFNode only supports for backend='torch'!"
-        assert not self.single_step_cupy_fp32_inference, (
-            "LIAFNode does not support for single_step_cupy_fp32_inference!"
-        )
 
     @property
     def supported_backends(self):


### PR DESCRIPTION
Hi, I dug into this and confirmed the root cause, and it goes back further than I initially thought.

`LIAFNode.__init__` asserts on `self.single_step_cupy_fp32_inference`, but this attribute is never defined anywhere in `BaseNode.__init__` or `LIFNode.__init__` (the parent classes `LIAFNode` inherits from). I checked `base_node.py` and `lif.py` directly and found no trace of it.

I went further and checked the full git history, not just the current `lif_variants.py`, which only exists since the `neuron.py` → `neuron/` package refactor in commit cf9e25e4. Using `git log -S` on `single_step_cupy_fp32_inference` across the entire history, the only matches are the original line in the old monolithic `neuron.py` before the refactor split it into `neuron/lif_variants.py`, and a pure style/formatting commit that touched the assertion's syntax but not its logic.

There is no commit, ever, in this repo's history, that defines or assigns `self.single_step_cupy_fp32_inference`. So this isn't a regression from the recent refactor between version 0.0.0.0.12 and 0.0.0.0.14, it's a bug that has existed since `LIAFNode` was first introduced. It just went unnoticed because apparently no one had instantiated `LIAFNode` and hit this exact code path until now.

**Fix:** remove the obsolete assertion, since the attribute it checks has never existed anywhere in the class hierarchy.

I tested this against the original minimal repro from the issue, and the `AttributeError` is gone. I also tested a correct `LIAFNode` instantiation with its required args, `act` and `threshold_related`, in both `threshold_related=True` and `False` modes, and the forward pass works correctly in both cases. I ran the full `test/activation_based/` suite, 580 tests, excluding pre-existing GPU-only failures unrelated to this change since I'm on a CPU-only environment, and all of them pass.

One thing worth flagging: the exact repro in the issue, `neuron.LIAFNode()` with no arguments, will still raise a `TypeError`, since `act` and `threshold_related` are required positional arguments with no defaults. That's expected and by design, not a bug. I left the signature untouched and only fixed the actual crash.

The fix removes these three lines from `LIAFNode.__init__` in `spikingjelly/activation_based/neuron/lif_variants.py`, right after the existing backend assertion:

```diff
diff --git a/spikingjelly/activation_based/neuron/lif_variants.py b/spikingjelly/activation_based/neuron/lif_variants.py
index f7c5b13..f3c8adb 100644
--- a/spikingjelly/activation_based/neuron/lif_variants.py
+++ b/spikingjelly/activation_based/neuron/lif_variants.py
@@ -676,9 +676,6 @@ class LIAFNode(LIFNode):
         self.threshold_related = threshold_related
 
         assert self.backend == "torch", "LIAFNode only supports for backend='torch'!"
-        assert not self.single_step_cupy_fp32_inference, (
-            "LIAFNode does not support for single_step_cupy_fp32_inference!"
-        )
 
     @property
     def supported_backends(self):
```

Happy to adjust if there's missing context on why this assertion was added in the first place, but as far as I can tell from the history, the attribute it references was never actually wired up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated backend compatibility validation for this neuron configuration to enforce torch-only execution, replacing the prior restriction logic for a specific inference mode.

* **Bug Fixes**
  * Improved consistency of supported inference backends by aligning runtime checks with the neuron’s valid execution path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->