### PR TITLE
Add few-spike LAS primitives and TD step modes

### DIFF
--- a/docs/source/APIs/spikingjelly.activation_based.neuron.research.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.neuron.research.rst
@@ -104,4 +104,4 @@ Neurons with Input or Output Noise
    :members:
    :undoc-members:
    :show-inheritance:
-   :exclude-members:
+   :exclude-members: supported_backends, extra_repr

--- a/docs/source/APIs/spikingjelly.activation_based.neuron.research.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.neuron.research.rst
@@ -86,7 +86,7 @@ Few-Spike / LAS Neuron Primitives
    :members:
    :undoc-members:
    :show-inheritance:
-   :exclude-members: extra_repr
+   :exclude-members: supported_backends, extra_repr
 
 Neurons with Inter-layer Connection
 --------------------------------------------------

--- a/docs/source/APIs/spikingjelly.activation_based.neuron.research.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.neuron.research.rst
@@ -79,6 +79,15 @@ Neurons for Online Learning
    :show-inheritance:
    :exclude-members: supported_backends
 
+Few-Spike / LAS Neuron Primitives
+--------------------------------------------------
+
+.. automodule:: spikingjelly.activation_based.neuron.few_spike
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: extra_repr
+
 Neurons with Inter-layer Connection
 --------------------------------------------------
 

--- a/docs/source/APIs/spikingjelly.activation_based.neuron.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.neuron.rst
@@ -63,6 +63,8 @@ Integrate-and-fire (IF) Neurons
      - Simplified IF neuron.
    * - :class:`IFNode <spikingjelly.activation_based.neuron.integrate_and_fire.IFNode>`
      - IF neuron.
+   * - :class:`ActivationAwareIFNode <spikingjelly.activation_based.neuron.integrate_and_fire.ActivationAwareIFNode>`
+     - Activation-aware IF neuron for channel-wise threshold and offset control.
    * - :class:`NonSpikingIFNode <spikingjelly.activation_based.neuron.integrate_and_fire.NonSpikingIFNode>`
      - IF variant that does not emit spikes.
 
@@ -187,6 +189,20 @@ Neurons for Online Learning
      - LIF neuron for online training through time (OTTT).
    * - :class:`SLTTLIFNode <spikingjelly.activation_based.neuron.online_learning.SLTTLIFNode>`
      - LIF neuron for spatial learning through time (SLTT).
+
+Few-Spike / LAS Neuron Primitives
+--------------------------------------------------
+
+.. list-table::
+
+   * - :class:`FewSpikeTable <spikingjelly.activation_based.neuron.few_spike.FewSpikeTable>`
+     - Coding table for Few-Spike neuron dynamics.
+   * - :class:`FewSpikeNode <spikingjelly.activation_based.neuron.few_spike.FewSpikeNode>`
+     - Memoryless Few-Spike node with single-step and multi-step modes.
+   * - :class:`OutlierAwareThresholdNode <spikingjelly.activation_based.neuron.few_spike.OutlierAwareThresholdNode>`
+     - Outlier-aware Few-Spike thresholding node.
+   * - :class:`HGNode <spikingjelly.activation_based.neuron.few_spike.HGNode>`
+     - Hierarchically-gated Few-Spike node.
 
 Neurons with Inter-layer Connection
 --------------------------------------------------

--- a/spikingjelly/activation_based/ann2snn/operators.py
+++ b/spikingjelly/activation_based/ann2snn/operators.py
@@ -1746,8 +1746,10 @@ class TDMultiheadAttention(TDModule):
         神经形态硬件的 fully spike-driven MultiheadAttention。``bias=True``
         时 projection bias 由 ``TDLinear`` 在累积输入上处理，避免普通
         ``nn.Linear`` 直接作用在差分序列时产生重复累计 bias。
-        父模块的 ``step_mode`` 会同步到内部 q/k/v/out projection，确保 projection
-        通过标准 ``nn.Module.__call__`` 执行，兼容 PyTorch hooks / profiling。
+        父模块的 ``step_mode`` 会同步到内部 q/k/v/out projection。常规
+        ``forward`` 调用由父模块的 ``step_mode`` 分发；直接调用
+        ``single_step_forward`` 或 ``multi_step_forward`` 时，父模块会显式调用内部
+        projection 的对应 step 方法，而不依赖子模块当前 ``step_mode``。
 
         .. code-block:: python
 
@@ -1814,9 +1816,11 @@ class TDMultiheadAttention(TDModule):
         avoiding the repeated bias accumulation that would occur if ordinary
         ``nn.Linear`` were applied directly to differential sequences.
         The parent module's ``step_mode`` is synchronized to the internal
-        q/k/v/out projections, so projections execute through the standard
-        ``nn.Module.__call__`` path and remain compatible with PyTorch hooks /
-        profiling.
+        q/k/v/out projections. Regular ``forward`` calls are dispatched by the
+        parent ``step_mode``; when ``single_step_forward`` or
+        ``multi_step_forward`` is called directly, the parent explicitly invokes
+        the matching child projection step method instead of depending on the
+        child modules' current ``step_mode``.
 
         .. code-block:: python
 

--- a/spikingjelly/activation_based/ann2snn/operators.py
+++ b/spikingjelly/activation_based/ann2snn/operators.py
@@ -11,6 +11,8 @@ __all__ = [
     "TDLayerNorm",
     "TDGELU",
     "TDLinear",
+    "SNNMatrixOperator",
+    "SNNElementWiseProduct",
     "TDScaledDotProductAttention",
     "TDMultiheadAttention",
 ]
@@ -34,6 +36,32 @@ def _check_time_sequence(x_seq: torch.Tensor, module_name: str) -> None:
             f"{module_name} expects a non-empty time dimension, but got "
             f"shape {tuple(x_seq.shape)}."
         )
+
+
+def _check_pair_time_sequence(
+    a_seq: torch.Tensor,
+    b_seq: torch.Tensor,
+    a_name: str,
+    b_name: str,
+    module_name: str,
+) -> None:
+    _check_time_sequence(a_seq, module_name)
+    _check_time_sequence(b_seq, module_name)
+    if a_seq.shape[0] != b_seq.shape[0]:
+        raise ValueError(
+            f"{module_name} expects {a_name} and {b_name} to have the same "
+            f"time length, but got {a_seq.shape[0]} and {b_seq.shape[0]}."
+        )
+
+
+def _align_sequence_ranks(
+    a_seq: torch.Tensor, b_seq: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    while a_seq.dim() < b_seq.dim():
+        a_seq = a_seq.unsqueeze(1)
+    while b_seq.dim() < a_seq.dim():
+        b_seq = b_seq.unsqueeze(1)
+    return a_seq, b_seq
 
 
 def _check_attention_sequence(
@@ -725,9 +753,9 @@ class TDLinear(nn.Module):
         * **中文**
 
         Temporal-difference (TD) Linear 算子。输入必须是完整时间序列，
-        时间维固定为第 0 维，形状为 ``[T, ..., in_features]``。该模块先对
-        输入在时间维做累积，再执行 :func:`torch.nn.functional.linear`，最后
-        返回累积输出在时间维上的差分。
+        时间维固定为第 0 维，形状为 ``[T, ..., in_features]``。该模块返回
+        sequence-preserving affine 差分序列，使 ``Y.cumsum(dim=0)`` 等于对
+        ``X.cumsum(dim=0)`` 逐时间步执行 :func:`torch.nn.functional.linear`。
 
         返回值是浮点差分值，可能包含负值；它不是二值脉冲，也不表示 fully
         spike-driven Linear。输出 dtype 与 PyTorch Linear 一致；推荐使用
@@ -739,8 +767,9 @@ class TDLinear(nn.Module):
 
         该算子用于处理带 bias 的 affine projection。普通
         :class:`torch.nn.Linear` 直接作用在 TD 差分序列上会在时间累积后得到
-        ``T * bias``；TD Linear 在累积输入上执行 Linear 后再差分，使累计输出
-        保持 ``W @ x_cum + bias``。
+        ``T * bias``；TD Linear 使累计输出保持 ``W @ x_cum + bias``。当
+        ``bias=False`` 时，该算子退化为普通逐时间步 Linear；当 ``bias=True``
+        时，bias 只在第 0 个时间步进入差分序列。
 
         .. code-block:: python
 
@@ -767,9 +796,10 @@ class TDLinear(nn.Module):
 
         Temporal-difference (TD) Linear operator. The input must be a complete
         time sequence whose time dimension is fixed at dimension 0, with shape
-        ``[T, ..., in_features]``. This module first accumulates the input over
-        time, applies :func:`torch.nn.functional.linear`, and returns the
-        temporal difference of the cumulative outputs.
+        ``[T, ..., in_features]``. This module returns a sequence-preserving
+        affine differential sequence such that ``Y.cumsum(dim=0)`` matches
+        :func:`torch.nn.functional.linear` applied to ``X.cumsum(dim=0)`` at
+        every time step.
 
         The output contains floating-point differential values and may contain
         negative values. It is not a binary spike tensor and does not represent
@@ -785,7 +815,9 @@ class TDLinear(nn.Module):
         :class:`torch.nn.Linear` directly to a TD differential sequence would
         accumulate the bias as ``T * bias``. TD Linear applies Linear to the
         cumulative input and then differences the cumulative output, preserving
-        ``W @ x_cum + bias``.
+        ``W @ x_cum + bias``. When ``bias=False``, this operator degenerates to
+        ordinary per-time-step Linear. When ``bias=True``, the bias appears only
+        at the first time step of the differential sequence.
 
         .. code-block:: python
 
@@ -852,9 +884,11 @@ class TDLinear(nn.Module):
             Y[t] = Y_{cum}[t] - Y_{cum}[t-1]
 
         因此 ``Y.cumsum(dim=0)`` 与对 ``X.cumsum(dim=0)`` 逐时间步执行 ANN
-        Linear 的结果一致。输出是浮点差分值，可能为负，不是二值脉冲。当
-        ``T = 1`` 时，``Y[0]`` 直接等于对 ``X[0]`` 执行 Linear 的结果。
-        输出 dtype 与 PyTorch Linear 一致，且该算子对 autograd 透明。
+        Linear 的结果一致。若 ``bias`` 为 ``None``，该计算等价于直接对
+        ``X`` 逐时间步执行 Linear；若存在 bias，bias 只出现在 ``Y[0]`` 中，
+        避免累计后得到 ``T * bias``。输出是浮点差分值，可能为负，不是二值
+        脉冲。当 ``T = 1`` 时，``Y[0]`` 直接等于对 ``X[0]`` 执行 Linear 的
+        结果。输出 dtype 与 PyTorch Linear 一致，且该算子对 autograd 透明。
 
         :param x_seq: 输入时间序列，形状为 ``[T, ..., in_features]``，且
             ``T > 0``。
@@ -885,11 +919,14 @@ class TDLinear(nn.Module):
             Y[t] = Y_{cum}[t] - Y_{cum}[t-1]
 
         Thus, ``Y.cumsum(dim=0)`` matches ANN Linear applied to
-        ``X.cumsum(dim=0)`` at each time step. The output contains
-        floating-point differential values, may be negative, and is not a
-        binary spike tensor. When ``T = 1``, ``Y[0]`` is exactly Linear applied
-        to ``X[0]``. The output dtype follows PyTorch Linear, and the operator
-        is transparent to autograd.
+        ``X.cumsum(dim=0)`` at each time step. If ``bias`` is ``None``, this is
+        equivalent to applying Linear to ``X`` at each time step directly. If a
+        bias exists, the bias appears only in ``Y[0]``, avoiding ``T * bias``
+        after accumulation. The output contains floating-point differential
+        values, may be negative, and is not a binary spike tensor. When
+        ``T = 1``, ``Y[0]`` is exactly Linear applied to ``X[0]``. The output
+        dtype follows PyTorch Linear, and the operator is transparent to
+        autograd.
 
         :param x_seq: Input time sequence with shape
             ``[T, ..., in_features]`` and ``T > 0``.
@@ -902,6 +939,9 @@ class TDLinear(nn.Module):
         """
         _check_time_sequence(x_seq, "TDLinear")
 
+        if self.bias is None:
+            return F.linear(x_seq, self.weight, None)
+
         y_cum = F.linear(x_seq.cumsum(dim=0), self.weight, self.bias)
         return _temporal_difference(y_cum)
 
@@ -910,6 +950,304 @@ class TDLinear(nn.Module):
             f"in_features={self.in_features}, out_features={self.out_features}, "
             f"bias={self.bias is not None}"
         )
+
+
+class SNNMatrixOperator(nn.Module):
+    def __init__(self) -> None:
+        r"""
+        .. rubric:: API Language
+
+        :ref:`中文 <SNNMatrixOperator.__init__-cn>` |
+        :ref:`English <SNNMatrixOperator.__init__-en>`
+
+        ----
+
+        .. _SNNMatrixOperator.__init__-cn:
+
+        * **中文**
+
+        Sequence-preserving SNN 矩阵乘法算子。输入必须是两条完整时间序列，
+        时间维固定为第 0 维，形状分别为 ``[T, ..., M, N]`` 和
+        ``[T, ..., N, P]``。该模块先分别对两条输入在时间维做累积，再执行
+        :func:`torch.matmul`，最后返回累积输出在时间维上的差分。
+
+        该算子满足
+        ``Y.cumsum(dim=0) == torch.matmul(A.cumsum(dim=0), B.cumsum(dim=0))``。
+        因而它保留 cross-time terms，例如 ``A[0] @ B[1]`` 与
+        ``A[1] @ B[0]``；这不同于逐时间步执行 ``A[t] @ B[t]``。该算子是
+        LAS ``SNNMatrixOperater`` prefix recurrence 的 sequence-preserving
+        张量级形式，但不会在内部自动 ``sum(0)``。
+
+        输出是浮点差分值，可能包含负值；它不是二值脉冲，也不表示 fully
+        spike-driven matrix multiplication。dtype、device 与 broadcast 语义遵循
+        :func:`torch.matmul`。该算子无内部状态，多次 ``forward`` 之间不需要
+        调用 ``reset``。
+
+        ----
+
+        .. _SNNMatrixOperator.__init__-en:
+
+        * **English**
+
+        Sequence-preserving SNN matrix multiplication operator. The inputs must
+        be two complete time sequences whose time dimension is fixed at
+        dimension 0, with shapes ``[T, ..., M, N]`` and ``[T, ..., N, P]``.
+        This module accumulates both inputs over time, applies
+        :func:`torch.matmul`, and returns the temporal difference of the
+        cumulative outputs.
+
+        The operator satisfies
+        ``Y.cumsum(dim=0) == torch.matmul(A.cumsum(dim=0), B.cumsum(dim=0))``.
+        Therefore it preserves cross-time terms such as ``A[0] @ B[1]`` and
+        ``A[1] @ B[0]``; it is not equivalent to applying ``A[t] @ B[t]`` at
+        each time step independently. It is the sequence-preserving tensor
+        form of the LAS ``SNNMatrixOperater`` prefix recurrence, but it does
+        not implicitly call ``sum(0)``.
+
+        The output contains floating-point differential values and may contain
+        negative values. It is not a binary spike tensor and does not represent
+        fully spike-driven matrix multiplication. Dtype, device and broadcasting
+        semantics follow :func:`torch.matmul`. The operator is stateless, and
+        repeated ``forward`` calls do not require ``reset``.
+        """
+        super().__init__()
+
+    def forward(self, a_seq: torch.Tensor, b_seq: torch.Tensor) -> torch.Tensor:
+        r"""
+        .. rubric:: API Language
+
+        :ref:`中文 <SNNMatrixOperator.forward-cn>` |
+        :ref:`English <SNNMatrixOperator.forward-en>`
+
+        ----
+
+        .. _SNNMatrixOperator.forward-cn:
+
+        * **中文**
+
+        对两条完整时间序列执行 sequence-preserving SNN 矩阵乘法：
+
+        .. math::
+
+            A_{cum}[t] = \sum_{i=0}^{t} A[i]
+
+        .. math::
+
+            B_{cum}[t] = \sum_{i=0}^{t} B[i]
+
+        .. math::
+
+            Y_{cum}[t] = A_{cum}[t] B_{cum}[t]
+
+        .. math::
+
+            Y[0] = Y_{cum}[0], \quad
+            Y[t] = Y_{cum}[t] - Y_{cum}[t-1]
+
+        :param a_seq: 左输入序列，形状为 ``[T, ..., M, N]``，且 ``T > 0``。
+        :type a_seq: torch.Tensor
+        :param b_seq: 右输入序列，形状为 ``[T, ..., N, P]``，且 ``T > 0``。
+        :type b_seq: torch.Tensor
+        :return: 差分输出序列，形状为 ``[T, ..., M, P]``。
+        :rtype: torch.Tensor
+        :raises ValueError: 若输入少于 3 维、时间维为空或时间长度不一致。
+
+        ----
+
+        .. _SNNMatrixOperator.forward-en:
+
+        * **English**
+
+        Apply sequence-preserving SNN matrix multiplication to two complete time
+        sequences:
+
+        .. math::
+
+            A_{cum}[t] = \sum_{i=0}^{t} A[i]
+
+        .. math::
+
+            B_{cum}[t] = \sum_{i=0}^{t} B[i]
+
+        .. math::
+
+            Y_{cum}[t] = A_{cum}[t] B_{cum}[t]
+
+        .. math::
+
+            Y[0] = Y_{cum}[0], \quad
+            Y[t] = Y_{cum}[t] - Y_{cum}[t-1]
+
+        :param a_seq: Left input sequence with shape ``[T, ..., M, N]`` and
+            ``T > 0``.
+        :type a_seq: torch.Tensor
+        :param b_seq: Right input sequence with shape ``[T, ..., N, P]`` and
+            ``T > 0``.
+        :type b_seq: torch.Tensor
+        :return: Differential output sequence with shape ``[T, ..., M, P]``.
+        :rtype: torch.Tensor
+        :raises ValueError: If an input has fewer than 3 dimensions, the time
+            dimension is empty, or the time lengths differ.
+        """
+        if a_seq.dim() < 3:
+            raise ValueError(
+                "SNNMatrixOperator expects a_seq with shape [T, ..., M, N] "
+                f"and at least 3 dimensions, but got shape {tuple(a_seq.shape)}."
+            )
+        if b_seq.dim() < 3:
+            raise ValueError(
+                "SNNMatrixOperator expects b_seq with shape [T, ..., N, P] "
+                f"and at least 3 dimensions, but got shape {tuple(b_seq.shape)}."
+            )
+        _check_pair_time_sequence(a_seq, b_seq, "a_seq", "b_seq", "SNNMatrixOperator")
+
+        a_seq, b_seq = _align_sequence_ranks(a_seq, b_seq)
+        y_cum = torch.matmul(a_seq.cumsum(dim=0), b_seq.cumsum(dim=0))
+        return _temporal_difference(y_cum)
+
+
+class SNNElementWiseProduct(nn.Module):
+    def __init__(self) -> None:
+        r"""
+        .. rubric:: API Language
+
+        :ref:`中文 <SNNElementWiseProduct.__init__-cn>` |
+        :ref:`English <SNNElementWiseProduct.__init__-en>`
+
+        ----
+
+        .. _SNNElementWiseProduct.__init__-cn:
+
+        * **中文**
+
+        Sequence-preserving SNN 逐元素乘法算子。输入必须是两条完整时间序列，
+        时间维固定为第 0 维，形状为 ``[T, ...]``，非时间维遵循 PyTorch
+        broadcast 规则。该模块先分别对两条输入在时间维做累积，再执行逐元素
+        乘法，最后返回累积输出在时间维上的差分。
+
+        该算子满足 ``Y.cumsum(dim=0) == A.cumsum(dim=0) * B.cumsum(dim=0)``。
+        它是 LAS ``SNNMACOperater`` 核心乘法-累积语义的 sequence-preserving
+        张量级形式，但不会在内部自动 ``sum(0)``；需要单步聚合时由调用方显式
+        完成。
+
+        输出是浮点差分值，可能包含负值；它不是二值脉冲，也不表示 fully
+        spike-driven multiply-accumulate。dtype、device 与 broadcast 语义遵循
+        PyTorch 逐元素乘法。该算子无内部状态，多次 ``forward`` 之间不需要调用
+        ``reset``。
+
+        ----
+
+        .. _SNNElementWiseProduct.__init__-en:
+
+        * **English**
+
+        Sequence-preserving SNN element-wise product operator. The inputs must
+        be two complete time sequences whose time dimension is fixed at
+        dimension 0, with shape ``[T, ...]``. Non-time dimensions follow
+        PyTorch broadcasting rules. This module accumulates both inputs over
+        time, applies element-wise multiplication, and returns the temporal
+        difference of the cumulative outputs.
+
+        The operator satisfies
+        ``Y.cumsum(dim=0) == A.cumsum(dim=0) * B.cumsum(dim=0)``. It is the
+        sequence-preserving tensor form of the core multiply-accumulate
+        semantics in LAS ``SNNMACOperater``, but it does not implicitly call
+        ``sum(0)``; callers should aggregate explicitly when a single-step
+        output is required.
+
+        The output contains floating-point differential values and may contain
+        negative values. It is not a binary spike tensor and does not represent
+        fully spike-driven multiply-accumulate. Dtype, device and broadcasting
+        semantics follow PyTorch element-wise multiplication. The operator is
+        stateless, and repeated ``forward`` calls do not require ``reset``.
+        """
+        super().__init__()
+
+    def forward(self, a_seq: torch.Tensor, b_seq: torch.Tensor) -> torch.Tensor:
+        r"""
+        .. rubric:: API Language
+
+        :ref:`中文 <SNNElementWiseProduct.forward-cn>` |
+        :ref:`English <SNNElementWiseProduct.forward-en>`
+
+        ----
+
+        .. _SNNElementWiseProduct.forward-cn:
+
+        * **中文**
+
+        对两条完整时间序列执行 sequence-preserving SNN 逐元素乘法：
+
+        .. math::
+
+            A_{cum}[t] = \sum_{i=0}^{t} A[i]
+
+        .. math::
+
+            B_{cum}[t] = \sum_{i=0}^{t} B[i]
+
+        .. math::
+
+            Y_{cum}[t] = A_{cum}[t] \odot B_{cum}[t]
+
+        .. math::
+
+            Y[0] = Y_{cum}[0], \quad
+            Y[t] = Y_{cum}[t] - Y_{cum}[t-1]
+
+        :param a_seq: 左输入序列，形状为 ``[T, ...]``，且 ``T > 0``。
+        :type a_seq: torch.Tensor
+        :param b_seq: 右输入序列，形状为 ``[T, ...]``，且 ``T > 0``。
+        :type b_seq: torch.Tensor
+        :return: 差分输出序列，形状由 PyTorch broadcast 规则决定。
+        :rtype: torch.Tensor
+        :raises ValueError: 若输入少于 2 维、时间维为空或时间长度不一致。
+
+        ----
+
+        .. _SNNElementWiseProduct.forward-en:
+
+        * **English**
+
+        Apply sequence-preserving SNN element-wise product to two complete time
+        sequences:
+
+        .. math::
+
+            A_{cum}[t] = \sum_{i=0}^{t} A[i]
+
+        .. math::
+
+            B_{cum}[t] = \sum_{i=0}^{t} B[i]
+
+        .. math::
+
+            Y_{cum}[t] = A_{cum}[t] \odot B_{cum}[t]
+
+        .. math::
+
+            Y[0] = Y_{cum}[0], \quad
+            Y[t] = Y_{cum}[t] - Y_{cum}[t-1]
+
+        :param a_seq: Left input sequence with shape ``[T, ...]`` and
+            ``T > 0``.
+        :type a_seq: torch.Tensor
+        :param b_seq: Right input sequence with shape ``[T, ...]`` and
+            ``T > 0``.
+        :type b_seq: torch.Tensor
+        :return: Differential output sequence whose shape follows PyTorch
+            broadcasting rules.
+        :rtype: torch.Tensor
+        :raises ValueError: If an input has fewer than 2 dimensions, the time
+            dimension is empty, or the time lengths differ.
+        """
+        _check_pair_time_sequence(
+            a_seq, b_seq, "a_seq", "b_seq", "SNNElementWiseProduct"
+        )
+
+        a_seq, b_seq = _align_sequence_ranks(a_seq, b_seq)
+        y_cum = a_seq.cumsum(dim=0) * b_seq.cumsum(dim=0)
+        return _temporal_difference(y_cum)
 
 
 class TDScaledDotProductAttention(nn.Module):
@@ -1316,9 +1654,7 @@ class TDMultiheadAttention(nn.Module):
                 f"embed_dim={self.embed_dim}, but got {x_seq.shape[-1]}."
             )
         t, batch_size, seq_len, _ = x_seq.shape
-        x_seq = x_seq.reshape(
-            t, batch_size, seq_len, self.num_heads, self.head_dim
-        )
+        x_seq = x_seq.reshape(t, batch_size, seq_len, self.num_heads, self.head_dim)
         return x_seq.transpose(2, 3)
 
     def _merge_heads(self, x_seq: torch.Tensor) -> torch.Tensor:

--- a/spikingjelly/activation_based/ann2snn/operators.py
+++ b/spikingjelly/activation_based/ann2snn/operators.py
@@ -1086,8 +1086,8 @@ class TDLinear(TDModule):
             return F.linear(x_seq, self.weight, None)
 
         y_seq = F.linear(x_seq, self.weight, None)
-        y_seq[0] = y_seq[0] + self.bias
-        return y_seq
+        y_first = y_seq[:1] + self.bias
+        return torch.cat((y_first, y_seq[1:]), dim=0)
 
     def extra_repr(self) -> str:
         return (

--- a/spikingjelly/activation_based/ann2snn/operators.py
+++ b/spikingjelly/activation_based/ann2snn/operators.py
@@ -1088,21 +1088,6 @@ class TDLinear(TDModule):
         y_cum = F.linear(x_seq.cumsum(dim=0), self.weight, self.bias)
         return _temporal_difference(y_cum)
 
-    def forward(
-        self, x: torch.Tensor, step_mode: Optional[Literal["s", "m"]] = None
-    ) -> torch.Tensor:
-        if step_mode is None:
-            return super().forward(x)
-        if step_mode == "s":
-            return self.single_step_forward(x)
-        elif step_mode == "m":
-            return self.multi_step_forward(x)
-        else:
-            raise ValueError(
-                f"step_mode can only be {self.supported_step_mode()}, "
-                f'but got "{step_mode}"!'
-            )
-
     def extra_repr(self) -> str:
         return (
             f"in_features={self.in_features}, out_features={self.out_features}, "
@@ -1989,9 +1974,9 @@ class TDMultiheadAttention(TDModule):
             key_padding_mask, need_weights, average_attn_weights
         )
 
-        q = self._split_heads_single(self.q_proj(query, step_mode="s"))
-        k = self._split_heads_single(self.k_proj(key, step_mode="s"))
-        v = self._split_heads_single(self.v_proj(value, step_mode="s"))
+        q = self._split_heads_single(self.q_proj.single_step_forward(query))
+        k = self._split_heads_single(self.k_proj.single_step_forward(key))
+        v = self._split_heads_single(self.v_proj.single_step_forward(value))
         self._check_attention_leading_dims(q, k, v, "TDMultiheadAttention")
         if is_causal and attn_mask is not None:
             raise ValueError(
@@ -2007,7 +1992,7 @@ class TDMultiheadAttention(TDModule):
             dropout_p=0.0,
             is_causal=is_causal,
         )
-        out = self.out_proj(self._merge_heads_single(attn), step_mode="s")
+        out = self.out_proj.single_step_forward(self._merge_heads_single(attn))
         return out, None
 
     def multi_step_forward(
@@ -2120,9 +2105,9 @@ class TDMultiheadAttention(TDModule):
             key_padding_mask, need_weights, average_attn_weights
         )
 
-        q_seq = self._split_heads(self.q_proj(query_seq, step_mode="m"))
-        k_seq = self._split_heads(self.k_proj(key_seq, step_mode="m"))
-        v_seq = self._split_heads(self.v_proj(value_seq, step_mode="m"))
+        q_seq = self._split_heads(self.q_proj.multi_step_forward(query_seq))
+        k_seq = self._split_heads(self.k_proj.multi_step_forward(key_seq))
+        v_seq = self._split_heads(self.v_proj.multi_step_forward(value_seq))
         self._check_attention_leading_dims(q_seq, k_seq, v_seq, "TDMultiheadAttention")
         attn_mask = self._canonical_mha_attn_mask(attn_mask, q_seq.shape[1])
         attn_seq = _td_scaled_dot_product_attention(
@@ -2134,7 +2119,7 @@ class TDMultiheadAttention(TDModule):
             None,
             "TDMultiheadAttention",
         )
-        out_seq = self.out_proj(self._merge_heads(attn_seq), step_mode="m")
+        out_seq = self.out_proj.multi_step_forward(self._merge_heads(attn_seq))
         return out_seq, None
 
     def extra_repr(self) -> str:

--- a/spikingjelly/activation_based/ann2snn/operators.py
+++ b/spikingjelly/activation_based/ann2snn/operators.py
@@ -1993,6 +1993,11 @@ class TDMultiheadAttention(TDModule):
         k = self._split_heads_single(self.k_proj(key, step_mode="s"))
         v = self._split_heads_single(self.v_proj(value, step_mode="s"))
         self._check_attention_leading_dims(q, k, v, "TDMultiheadAttention")
+        if is_causal and attn_mask is not None:
+            raise ValueError(
+                "TDMultiheadAttention does not allow attn_mask when "
+                "is_causal=True; use one masking mode at a time."
+            )
         attn_mask = self._canonical_mha_attn_mask(attn_mask, q.shape[0])
         attn = F.scaled_dot_product_attention(
             q,

--- a/spikingjelly/activation_based/ann2snn/operators.py
+++ b/spikingjelly/activation_based/ann2snn/operators.py
@@ -1121,7 +1121,7 @@ class SNNMatrixOperator(TDModule):
         ``Y.cumsum(dim=0) == torch.matmul(A.cumsum(dim=0), B.cumsum(dim=0))``。
         因而它保留 cross-time terms，例如 ``A[0] @ B[1]`` 与
         ``A[1] @ B[0]``；这不同于逐时间步执行 ``A[t] @ B[t]``。该算子是
-        LAS ``SNNMatrixOperater`` prefix recurrence 的 sequence-preserving
+        LAS ``SNNMatrixOperator`` prefix recurrence 的 sequence-preserving
         张量级形式，但不会在内部自动 ``sum(0)``。
 
         输出是浮点差分值，可能包含负值；它不是二值脉冲，也不表示 fully
@@ -1152,7 +1152,7 @@ class SNNMatrixOperator(TDModule):
         Therefore it preserves cross-time terms such as ``A[0] @ B[1]`` and
         ``A[1] @ B[0]``; it is not equivalent to applying ``A[t] @ B[t]`` at
         each time step independently. It is the sequence-preserving tensor
-        form of the LAS ``SNNMatrixOperater`` prefix recurrence, but it does
+        form of the LAS ``SNNMatrixOperator`` prefix recurrence, but it does
         not implicitly call ``sum(0)``.
 
         The output contains floating-point differential values and may contain
@@ -1287,7 +1287,7 @@ class SNNElementWiseProduct(TDModule):
         逐元素乘法。
 
         该算子满足 ``Y.cumsum(dim=0) == A.cumsum(dim=0) * B.cumsum(dim=0)``。
-        它是 LAS ``SNNMACOperater`` 核心乘法-累积语义的 sequence-preserving
+        它是 LAS ``SNNMACOperator`` 核心乘法-累积语义的 sequence-preserving
         张量级形式，但不会在内部自动 ``sum(0)``；需要单步聚合时由调用方显式
         完成。
 
@@ -1317,7 +1317,7 @@ class SNNElementWiseProduct(TDModule):
         The operator satisfies
         ``Y.cumsum(dim=0) == A.cumsum(dim=0) * B.cumsum(dim=0)``. It is the
         sequence-preserving tensor form of the core multiply-accumulate
-        semantics in LAS ``SNNMACOperater``, but it does not implicitly call
+        semantics in LAS ``SNNMACOperator``, but it does not implicitly call
         ``sum(0)``; callers should aggregate explicitly when a single-step
         output is required.
 
@@ -1867,10 +1867,18 @@ class TDMultiheadAttention(TDModule):
         self.head_dim = embed_dim // num_heads
 
         factory_kwargs = {"device": device, "dtype": dtype}
-        self.q_proj = TDLinear(embed_dim, embed_dim, bias=bias, **factory_kwargs)
-        self.k_proj = TDLinear(embed_dim, embed_dim, bias=bias, **factory_kwargs)
-        self.v_proj = TDLinear(embed_dim, embed_dim, bias=bias, **factory_kwargs)
-        self.out_proj = TDLinear(embed_dim, embed_dim, bias=bias, **factory_kwargs)
+        self.q_proj = TDLinear(
+            embed_dim, embed_dim, bias=bias, step_mode=step_mode, **factory_kwargs
+        )
+        self.k_proj = TDLinear(
+            embed_dim, embed_dim, bias=bias, step_mode=step_mode, **factory_kwargs
+        )
+        self.v_proj = TDLinear(
+            embed_dim, embed_dim, bias=bias, step_mode=step_mode, **factory_kwargs
+        )
+        self.out_proj = TDLinear(
+            embed_dim, embed_dim, bias=bias, step_mode=step_mode, **factory_kwargs
+        )
         self.step_mode = step_mode
 
     @TDModule.step_mode.setter

--- a/spikingjelly/activation_based/ann2snn/operators.py
+++ b/spikingjelly/activation_based/ann2snn/operators.py
@@ -1877,6 +1877,28 @@ class TDMultiheadAttention(TDModule):
             self.v_proj.step_mode = value
             self.out_proj.step_mode = value
 
+    def _projection_step_modes(self) -> Tuple[str, str, str, str]:
+        return (
+            self.q_proj.step_mode,
+            self.k_proj.step_mode,
+            self.v_proj.step_mode,
+            self.out_proj.step_mode,
+        )
+
+    def _set_projection_step_mode(self, step_mode: str) -> None:
+        self.q_proj.step_mode = step_mode
+        self.k_proj.step_mode = step_mode
+        self.v_proj.step_mode = step_mode
+        self.out_proj.step_mode = step_mode
+
+    def _restore_projection_step_modes(self, modes: Tuple[str, str, str, str]) -> None:
+        (
+            self.q_proj.step_mode,
+            self.k_proj.step_mode,
+            self.v_proj.step_mode,
+            self.out_proj.step_mode,
+        ) = modes
+
     def _split_heads(self, x_seq: torch.Tensor) -> torch.Tensor:
         if x_seq.dim() != 4:
             raise ValueError(
@@ -1945,6 +1967,20 @@ class TDMultiheadAttention(TDModule):
                 "TDMultiheadAttention does not support average_attn_weights=False."
             )
 
+    def _check_attention_leading_dims(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        name: str,
+    ) -> None:
+        if q.shape[:-2] != k.shape[:-2] or q.shape[:-2] != v.shape[:-2]:
+            raise ValueError(
+                f"{name} requires query, key and value leading dimensions to "
+                f"match exactly before SDPA, but got {tuple(q.shape[:-2])}, "
+                f"{tuple(k.shape[:-2])} and {tuple(v.shape[:-2])}."
+            )
+
     def single_step_forward(
         self,
         query: torch.Tensor,
@@ -1960,19 +1996,25 @@ class TDMultiheadAttention(TDModule):
             key_padding_mask, need_weights, average_attn_weights
         )
 
-        q = self._split_heads_single(self.q_proj(query))
-        k = self._split_heads_single(self.k_proj(key))
-        v = self._split_heads_single(self.v_proj(value))
-        attn_mask = self._canonical_mha_attn_mask(attn_mask, q.shape[0])
-        attn = F.scaled_dot_product_attention(
-            q,
-            k,
-            v,
-            attn_mask=attn_mask,
-            dropout_p=0.0,
-            is_causal=is_causal,
-        )
-        out = self.out_proj(self._merge_heads_single(attn))
+        projection_modes = self._projection_step_modes()
+        self._set_projection_step_mode("s")
+        try:
+            q = self._split_heads_single(self.q_proj(query))
+            k = self._split_heads_single(self.k_proj(key))
+            v = self._split_heads_single(self.v_proj(value))
+            self._check_attention_leading_dims(q, k, v, "TDMultiheadAttention")
+            attn_mask = self._canonical_mha_attn_mask(attn_mask, q.shape[0])
+            attn = F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=attn_mask,
+                dropout_p=0.0,
+                is_causal=is_causal,
+            )
+            out = self.out_proj(self._merge_heads_single(attn))
+        finally:
+            self._restore_projection_step_modes(projection_modes)
         return out, None
 
     def multi_step_forward(
@@ -2085,20 +2127,28 @@ class TDMultiheadAttention(TDModule):
             key_padding_mask, need_weights, average_attn_weights
         )
 
-        q_seq = self._split_heads(self.q_proj(query_seq))
-        k_seq = self._split_heads(self.k_proj(key_seq))
-        v_seq = self._split_heads(self.v_proj(value_seq))
-        attn_mask = self._canonical_mha_attn_mask(attn_mask, q_seq.shape[1])
-        attn_seq = _td_scaled_dot_product_attention(
-            q_seq,
-            k_seq,
-            v_seq,
-            attn_mask,
-            is_causal,
-            None,
-            "TDMultiheadAttention",
-        )
-        out_seq = self.out_proj(self._merge_heads(attn_seq))
+        projection_modes = self._projection_step_modes()
+        self._set_projection_step_mode("m")
+        try:
+            q_seq = self._split_heads(self.q_proj(query_seq))
+            k_seq = self._split_heads(self.k_proj(key_seq))
+            v_seq = self._split_heads(self.v_proj(value_seq))
+            self._check_attention_leading_dims(
+                q_seq, k_seq, v_seq, "TDMultiheadAttention"
+            )
+            attn_mask = self._canonical_mha_attn_mask(attn_mask, q_seq.shape[1])
+            attn_seq = _td_scaled_dot_product_attention(
+                q_seq,
+                k_seq,
+                v_seq,
+                attn_mask,
+                is_causal,
+                None,
+                "TDMultiheadAttention",
+            )
+            out_seq = self.out_proj(self._merge_heads(attn_seq))
+        finally:
+            self._restore_projection_step_modes(projection_modes)
         return out_seq, None
 
     def extra_repr(self) -> str:

--- a/spikingjelly/activation_based/ann2snn/operators.py
+++ b/spikingjelly/activation_based/ann2snn/operators.py
@@ -5,8 +5,11 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from .. import base
+
 
 __all__ = [
+    "TDModule",
     "TDSoftmax",
     "TDLayerNorm",
     "TDGELU",
@@ -23,6 +26,94 @@ def _temporal_difference(y_cum: torch.Tensor) -> torch.Tensor:
     y_seq[0] = y_cum[0]
     y_seq[1:] = y_cum[1:] - y_cum[:-1]
     return y_seq
+
+
+def _resolve_dim(dim: int, ndim: int) -> int:
+    resolved = dim
+    if resolved < 0:
+        resolved += ndim
+    if resolved < 0 or resolved >= ndim:
+        raise ValueError(
+            f"dim must be in the range [{-ndim}, {ndim - 1}], "
+            f"but got {dim} for an input with {ndim} dimensions."
+        )
+    return resolved
+
+
+class TDModule(nn.Module, base.StepModule):
+    def __init__(self, step_mode: str = "m") -> None:
+        r"""
+        .. rubric:: API Language
+
+        :ref:`中文 <TDModule.__init__-cn>` |
+        :ref:`English <TDModule.__init__-en>`
+
+        ----
+
+        .. _TDModule.__init__-cn:
+
+        * **中文**
+
+        Temporal-difference / sequence-preserving 算子的基类。该类实现
+        :class:`spikingjelly.activation_based.base.StepModule` 的 ``step_mode``
+        分发，但不引入 memory 或 ``reset`` 语义。
+
+        ``step_mode="s"`` 时，输入被解释为单步 tensor，并调用对应的普通
+        PyTorch 算子；``step_mode="m"`` 时，输入第 0 维被解释为时间维，并
+        调用 TD / sequence-preserving 多步算子。子类必须实现
+        :meth:`single_step_forward` 和 :meth:`multi_step_forward`。子类
+        ``__init__`` 应调用 ``super().__init__(step_mode)`` 初始化步进模式。
+
+        :param step_mode: 步进模式，``"s"`` 或 ``"m"``。默认 ``"m"`` 保持既有
+            TD operator 行为。
+        :type step_mode: str
+        :raises ValueError: 当 ``step_mode`` 非法时，由
+            :class:`~spikingjelly.activation_based.base.StepModule` 的 setter
+            抛出；若子类绕过 setter 写入非法模式，``forward`` 也会抛出。
+
+        ----
+
+        .. _TDModule.__init__-en:
+
+        * **English**
+
+        Base class for temporal-difference / sequence-preserving operators. It
+        implements :class:`spikingjelly.activation_based.base.StepModule`
+        ``step_mode`` dispatch without introducing memory or ``reset``
+        semantics.
+
+        With ``step_mode="s"``, inputs are interpreted as single-step tensors
+        and the corresponding ordinary PyTorch operator is called. With
+        ``step_mode="m"``, dimension 0 is interpreted as the time dimension and
+        the TD / sequence-preserving multi-step operator is called. Subclasses
+        must implement :meth:`single_step_forward` and
+        :meth:`multi_step_forward`. Subclass ``__init__`` methods should call
+        ``super().__init__(step_mode)`` to initialize the step mode.
+
+        :param step_mode: Step mode, ``"s"`` or ``"m"``. The default ``"m"``
+            preserves existing TD operator behavior.
+        :type step_mode: str
+        :raises ValueError: Raised by
+            :class:`~spikingjelly.activation_based.base.StepModule`'s setter
+            when ``step_mode`` is invalid; ``forward`` also raises if a
+            subclass bypasses the setter and writes an invalid mode.
+        """
+        super().__init__()
+        self.step_mode = step_mode
+
+    def single_step_forward(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def multi_step_forward(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def forward(self, *args, **kwargs):
+        if self.step_mode == "s":
+            return self.single_step_forward(*args, **kwargs)
+        elif self.step_mode == "m":
+            return self.multi_step_forward(*args, **kwargs)
+        else:
+            raise ValueError(self.step_mode)
 
 
 def _check_time_sequence(x_seq: torch.Tensor, module_name: str) -> None:
@@ -116,8 +207,8 @@ def _td_scaled_dot_product_attention(
     return _temporal_difference(y_cum)
 
 
-class TDSoftmax(nn.Module):
-    def __init__(self, dim: int = -1) -> None:
+class TDSoftmax(TDModule):
+    def __init__(self, dim: int = -1, step_mode: str = "m") -> None:
         r"""
         .. rubric:: API Language
 
@@ -130,10 +221,12 @@ class TDSoftmax(nn.Module):
 
         * **中文**
 
-        Temporal-difference (TD) Softmax 算子。输入必须是完整时间序列，
-        时间维固定为第 0 维，形状为 ``[T, ...]``。该模块先对输入在时间维
-        做累积，再沿 ``dim`` 计算 ``torch.softmax``，最后返回累积输出在
-        时间维上的差分。
+        Temporal-difference (TD) Softmax 算子。``step_mode="m"`` 时输入
+        必须是完整时间序列，时间维固定为第 0 维，形状为 ``[T, ...]``；
+        模块先对输入在时间维做累积，再沿 ``dim`` 计算
+        ``torch.softmax``，最后返回累积输出在时间维上的差分。
+        ``step_mode="s"`` 时输入被解释为单步 tensor，并直接调用
+        ``torch.softmax``。
 
         返回值是浮点差分值，可能包含负值；它不是二值脉冲，也不表示 fully
         spike-driven Softmax。输出 dtype 与输入 dtype 相同；推荐使用
@@ -143,9 +236,9 @@ class TDSoftmax(nn.Module):
         该算子的机制来源于 `SpikeZIP-TF: Conversion is All You Need for
         Transformer-based SNN <https://arxiv.org/abs/2406.03470>`_ 中对
         Transformer 非线性算子的累积-差分等价转换思路。本文档中的 TD
-        Softmax 只实现张量级算子：它仍调用 ``torch.softmax``，需要完整时间
-        序列输入，不是逐时间步在线算子，也不是面向神经形态硬件的 fully
-        spike-driven Softmax。
+        Softmax 只实现张量级算子：在多步模式下它仍调用
+        ``torch.softmax``，需要完整时间序列输入，不是逐时间步在线算子，
+        也不是面向神经形态硬件的 fully spike-driven Softmax。
 
         .. code-block:: python
 
@@ -153,8 +246,11 @@ class TDSoftmax(nn.Module):
             x_seq = torch.randn(4, 2, 3)
             y_seq = op(x_seq)
 
-        :param dim: Softmax 归一化维度。不能为第 0 维，因为第 0 维保留为时间维。
+        :param dim: Softmax 归一化维度。``step_mode="m"`` 时不能为第 0 维，
+            因为第 0 维保留为时间维；``step_mode="s"`` 时可为任意合法维度。
         :type dim: int
+        :param step_mode: 步进模式，``"s"`` 或 ``"m"``。默认 ``"m"``。
+        :type step_mode: str
 
         ----
 
@@ -162,11 +258,13 @@ class TDSoftmax(nn.Module):
 
         * **English**
 
-        Temporal-difference (TD) Softmax operator. The input must be a complete
-        time sequence whose time dimension is fixed at dimension 0, with shape
-        ``[T, ...]``. This module first accumulates the input over time, applies
-        ``torch.softmax`` along ``dim`` to each cumulative input, and returns
-        the temporal difference of the cumulative outputs.
+        Temporal-difference (TD) Softmax operator. With ``step_mode="m"``, the
+        input must be a complete time sequence whose time dimension is fixed at
+        dimension 0, with shape ``[T, ...]``. This module first accumulates the
+        input over time, applies ``torch.softmax`` along ``dim`` to each
+        cumulative input, and returns the temporal difference of the cumulative
+        outputs. With ``step_mode="s"``, the input is interpreted as a
+        single-step tensor and ``torch.softmax`` is called directly.
 
         The output contains floating-point differential values and may contain
         negative values. It is not a binary spike tensor and does not represent a
@@ -178,10 +276,10 @@ class TDSoftmax(nn.Module):
         The mechanism follows the cumulative-difference equivalence idea for
         Transformer nonlinear operators in `SpikeZIP-TF: Conversion is All You
         Need for Transformer-based SNN <https://arxiv.org/abs/2406.03470>`_.
-        This implementation provides only a tensor-level operator: it still
-        calls ``torch.softmax``, requires a complete time sequence, is not a
-        step-wise online operator, and is not a fully spike-driven Softmax for
-        neuromorphic hardware.
+        This implementation provides only a tensor-level operator: in
+        multi-step mode it still calls ``torch.softmax``, requires a complete
+        time sequence, is not a step-wise online operator, and is not a fully
+        spike-driven Softmax for neuromorphic hardware.
 
         .. code-block:: python
 
@@ -189,14 +287,20 @@ class TDSoftmax(nn.Module):
             x_seq = torch.randn(4, 2, 3)
             y_seq = op(x_seq)
 
-        :param dim: Softmax normalization dimension. It must not be dimension 0,
-            which is reserved as the time dimension.
+        :param dim: Softmax normalization dimension. With ``step_mode="m"``, it
+            must not be dimension 0, which is reserved as the time dimension.
+            With ``step_mode="s"``, any valid dimension is allowed.
         :type dim: int
+        :param step_mode: Step mode, ``"s"`` or ``"m"``. The default is ``"m"``.
+        :type step_mode: str
         """
-        super().__init__()
+        super().__init__(step_mode)
         self.dim = dim
 
-    def forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+    def single_step_forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.softmax(x, dim=self.dim)
+
+    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
         r"""
         .. rubric:: API Language
 
@@ -274,14 +378,7 @@ class TDSoftmax(nn.Module):
         """
         _check_time_sequence(x_seq, "TDSoftmax")
 
-        dim = self.dim
-        if dim < 0:
-            dim += x_seq.dim()
-        if dim < 0 or dim >= x_seq.dim():
-            raise ValueError(
-                f"dim must be in the range [{-x_seq.dim()}, {x_seq.dim() - 1}], "
-                f"but got {self.dim} for an input with {x_seq.dim()} dimensions."
-            )
+        dim = _resolve_dim(self.dim, x_seq.dim())
         if dim == 0:
             raise ValueError(
                 "TDSoftmax reserves dimension 0 as the time dimension; "
@@ -295,7 +392,7 @@ class TDSoftmax(nn.Module):
         return f"dim={self.dim}"
 
 
-class TDLayerNorm(nn.Module):
+class TDLayerNorm(TDModule):
     def __init__(
         self,
         normalized_shape: Union[int, Sequence[int], torch.Size],
@@ -304,6 +401,7 @@ class TDLayerNorm(nn.Module):
         bias: bool = True,
         device: Optional[Union[torch.device, str]] = None,
         dtype: Optional[torch.dtype] = None,
+        step_mode: str = "m",
     ) -> None:
         r"""
         .. rubric:: API Language
@@ -317,11 +415,12 @@ class TDLayerNorm(nn.Module):
 
         * **中文**
 
-        Temporal-difference (TD) LayerNorm 算子。输入必须是完整时间序列，
-        时间维固定为第 0 维，形状为 ``[T, ...]``。该模块先对输入在时间维
-        做累积，再对每个累积输入执行
+        Temporal-difference (TD) LayerNorm 算子。``step_mode="m"`` 时输入
+        必须是完整时间序列，时间维固定为第 0 维，形状为 ``[T, ...]``；
+        模块先对输入在时间维做累积，再对每个累积输入执行
         :func:`torch.nn.functional.layer_norm`，最后返回累积输出在时间维上的
-        差分。
+        差分。``step_mode="s"`` 时输入被解释为单步 tensor，并直接调用
+        :func:`torch.nn.functional.layer_norm`。
 
         返回值是浮点差分值，可能包含负值；它不是二值脉冲，也不表示 fully
         spike-driven LayerNorm。输出 dtype 与输入 dtype 相同；推荐使用
@@ -332,7 +431,7 @@ class TDLayerNorm(nn.Module):
         该算子的机制来源于 `SpikeZIP-TF: Conversion is All You Need for
         Transformer-based SNN <https://arxiv.org/abs/2406.03470>`_ 中对
         Transformer 非线性算子的累积-差分等价转换思路。本文档中的 TD
-        LayerNorm 只实现张量级算子：它仍调用
+        LayerNorm 只实现张量级算子：在多步模式下它仍调用
         :func:`torch.nn.functional.layer_norm`，需要完整时间序列输入，不是逐
         时间步在线算子，也不是面向神经形态硬件的 fully spike-driven
         LayerNorm。
@@ -359,6 +458,8 @@ class TDLayerNorm(nn.Module):
         :type device: torch.device or str or None
         :param dtype: 参数初始化 dtype。
         :type dtype: torch.dtype or None
+        :param step_mode: 步进模式，``"s"`` 或 ``"m"``。默认 ``"m"``。
+        :type step_mode: str
 
         ----
 
@@ -366,11 +467,14 @@ class TDLayerNorm(nn.Module):
 
         * **English**
 
-        Temporal-difference (TD) LayerNorm operator. The input must be a
-        complete time sequence whose time dimension is fixed at dimension 0,
-        with shape ``[T, ...]``. This module first accumulates the input over
-        time, applies :func:`torch.nn.functional.layer_norm` to each cumulative
-        input, and returns the temporal difference of the cumulative outputs.
+        Temporal-difference (TD) LayerNorm operator. With ``step_mode="m"``,
+        the input must be a complete time sequence whose time dimension is
+        fixed at dimension 0, with shape ``[T, ...]``. This module first
+        accumulates the input over time, applies
+        :func:`torch.nn.functional.layer_norm` to each cumulative input, and
+        returns the temporal difference of the cumulative outputs. With
+        ``step_mode="s"``, the input is interpreted as a single-step tensor and
+        :func:`torch.nn.functional.layer_norm` is called directly.
 
         The output contains floating-point differential values and may contain
         negative values. It is not a binary spike tensor and does not represent a
@@ -383,8 +487,9 @@ class TDLayerNorm(nn.Module):
         The mechanism follows the cumulative-difference equivalence idea for
         Transformer nonlinear operators in `SpikeZIP-TF: Conversion is All You
         Need for Transformer-based SNN <https://arxiv.org/abs/2406.03470>`_.
-        This implementation provides only a tensor-level operator: it still
-        calls :func:`torch.nn.functional.layer_norm`, requires a complete time
+        This implementation provides only a tensor-level operator: in
+        multi-step mode it still calls
+        :func:`torch.nn.functional.layer_norm`, requires a complete time
         sequence, is not a step-wise online operator, and is not a fully
         spike-driven LayerNorm for neuromorphic hardware.
 
@@ -410,8 +515,10 @@ class TDLayerNorm(nn.Module):
         :type device: torch.device or str or None
         :param dtype: Dtype used to initialize parameters.
         :type dtype: torch.dtype or None
+        :param step_mode: Step mode, ``"s"`` or ``"m"``. The default is ``"m"``.
+        :type step_mode: str
         """
-        super().__init__()
+        super().__init__(step_mode)
         if isinstance(normalized_shape, int):
             normalized_shape = (normalized_shape,)
         else:
@@ -444,7 +551,16 @@ class TDLayerNorm(nn.Module):
             if self.bias is not None:
                 nn.init.zeros_(self.bias)
 
-    def forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+    def single_step_forward(self, x: torch.Tensor) -> torch.Tensor:
+        return F.layer_norm(
+            x,
+            self.normalized_shape,
+            self.weight,
+            self.bias,
+            self.eps,
+        )
+
+    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
         r"""
         .. rubric:: API Language
 
@@ -552,8 +668,12 @@ class TDLayerNorm(nn.Module):
         )
 
 
-class TDGELU(nn.Module):
-    def __init__(self, approximate: Literal["none", "tanh"] = "none") -> None:
+class TDGELU(TDModule):
+    def __init__(
+        self,
+        approximate: Literal["none", "tanh"] = "none",
+        step_mode: str = "m",
+    ) -> None:
         r"""
         .. rubric:: API Language
 
@@ -567,9 +687,11 @@ class TDGELU(nn.Module):
         * **中文**
 
         Temporal-difference (TD) GELU（Gaussian Error Linear Unit）算子。
-        输入必须是完整时间序列，时间维固定为第 0 维，形状为 ``[T, ...]``。
-        该模块先对输入在时间维做累积，再对每个累积输入执行
-        :func:`torch.nn.functional.gelu`，最后返回累积输出在时间维上的差分。
+        ``step_mode="m"`` 时输入必须是完整时间序列，时间维固定为第 0 维，
+        形状为 ``[T, ...]``；模块先对输入在时间维做累积，再对每个累积输入
+        执行 :func:`torch.nn.functional.gelu`，最后返回累积输出在时间维上的
+        差分。``step_mode="s"`` 时输入被解释为单步 tensor，并直接调用
+        :func:`torch.nn.functional.gelu`。
 
         返回值是浮点差分值，可能包含负值；它不是二值脉冲，也不表示 fully
         spike-driven GELU。输出 dtype 与输入 dtype 相同；推荐使用
@@ -582,9 +704,9 @@ class TDGELU(nn.Module):
         该算子的机制来源于 `SpikeZIP-TF: Conversion is All You Need for
         Transformer-based SNN <https://arxiv.org/abs/2406.03470>`_ 中对
         Transformer 非线性算子的累积-差分等价转换思路。本文档中的 TD GELU
-        只实现张量级算子：它仍调用 :func:`torch.nn.functional.gelu`，需要
-        完整时间序列输入，不是逐时间步在线算子，也不是面向神经形态硬件的
-        fully spike-driven GELU。
+        只实现张量级算子：在多步模式下它仍调用
+        :func:`torch.nn.functional.gelu`，需要完整时间序列输入，不是逐时间步
+        在线算子，也不是面向神经形态硬件的 fully spike-driven GELU。
 
         .. code-block:: python
 
@@ -595,6 +717,8 @@ class TDGELU(nn.Module):
         :param approximate: GELU 近似模式，与 :class:`torch.nn.GELU` 的
             ``approximate`` 语义一致。
         :type approximate: Literal["none", "tanh"]
+        :param step_mode: 步进模式，``"s"`` 或 ``"m"``。默认 ``"m"``。
+        :type step_mode: str
         :raises ValueError: 若 ``approximate`` 不是 ``"none"`` 或 ``"tanh"``。
 
         ----
@@ -604,11 +728,13 @@ class TDGELU(nn.Module):
         * **English**
 
         Temporal-difference (TD) GELU (Gaussian Error Linear Unit) operator.
-        The input must be a complete time sequence whose time dimension is
-        fixed at dimension 0, with shape ``[T, ...]``. This module first
-        accumulates the input over time, applies
+        With ``step_mode="m"``, the input must be a complete time sequence
+        whose time dimension is fixed at dimension 0, with shape ``[T, ...]``.
+        This module first accumulates the input over time, applies
         :func:`torch.nn.functional.gelu` to each cumulative input, and returns
-        the temporal difference of the cumulative outputs.
+        the temporal difference of the cumulative outputs. With
+        ``step_mode="s"``, the input is interpreted as a single-step tensor and
+        :func:`torch.nn.functional.gelu` is called directly.
 
         The output contains floating-point differential values and may contain
         negative values. It is not a binary spike tensor and does not represent a
@@ -624,10 +750,10 @@ class TDGELU(nn.Module):
         The mechanism follows the cumulative-difference equivalence idea for
         Transformer nonlinear operators in `SpikeZIP-TF: Conversion is All You
         Need for Transformer-based SNN <https://arxiv.org/abs/2406.03470>`_.
-        This implementation provides only a tensor-level operator: it still
-        calls :func:`torch.nn.functional.gelu`, requires a complete time
-        sequence, is not a step-wise online operator, and is not a fully
-        spike-driven GELU for neuromorphic hardware.
+        This implementation provides only a tensor-level operator: in
+        multi-step mode it still calls :func:`torch.nn.functional.gelu`,
+        requires a complete time sequence, is not a step-wise online operator,
+        and is not a fully spike-driven GELU for neuromorphic hardware.
 
         .. code-block:: python
 
@@ -638,9 +764,11 @@ class TDGELU(nn.Module):
         :param approximate: GELU approximation mode, with the same semantics as
             ``approximate`` in :class:`torch.nn.GELU`.
         :type approximate: Literal["none", "tanh"]
+        :param step_mode: Step mode, ``"s"`` or ``"m"``. The default is ``"m"``.
+        :type step_mode: str
         :raises ValueError: If ``approximate`` is not ``"none"`` or ``"tanh"``.
         """
-        super().__init__()
+        super().__init__(step_mode)
         if approximate not in ("none", "tanh"):
             raise ValueError(
                 "TDGELU: approximate must be 'none' or 'tanh', "
@@ -648,7 +776,10 @@ class TDGELU(nn.Module):
             )
         self.approximate = approximate
 
-    def forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+    def single_step_forward(self, x: torch.Tensor) -> torch.Tensor:
+        return F.gelu(x, approximate=self.approximate)
+
+    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
         r"""
         .. rubric:: API Language
 
@@ -732,7 +863,7 @@ class TDGELU(nn.Module):
         return f"approximate={self.approximate!r}"
 
 
-class TDLinear(nn.Module):
+class TDLinear(TDModule):
     def __init__(
         self,
         in_features: int,
@@ -740,6 +871,7 @@ class TDLinear(nn.Module):
         bias: bool = True,
         device: Optional[Union[torch.device, str]] = None,
         dtype: Optional[torch.dtype] = None,
+        step_mode: str = "m",
     ) -> None:
         r"""
         **API Language:**
@@ -752,10 +884,12 @@ class TDLinear(nn.Module):
 
         * **中文**
 
-        Temporal-difference (TD) Linear 算子。输入必须是完整时间序列，
-        时间维固定为第 0 维，形状为 ``[T, ..., in_features]``。该模块返回
-        sequence-preserving affine 差分序列，使 ``Y.cumsum(dim=0)`` 等于对
-        ``X.cumsum(dim=0)`` 逐时间步执行 :func:`torch.nn.functional.linear`。
+        Temporal-difference (TD) Linear 算子。``step_mode="m"`` 时输入必须
+        是完整时间序列，时间维固定为第 0 维，形状为
+        ``[T, ..., in_features]``；模块返回 sequence-preserving affine
+        差分序列，使 ``Y.cumsum(dim=0)`` 等于对 ``X.cumsum(dim=0)`` 逐时间
+        步执行 :func:`torch.nn.functional.linear`。``step_mode="s"`` 时输入
+        被解释为单步 tensor，并直接调用 :func:`torch.nn.functional.linear`。
 
         返回值是浮点差分值，可能包含负值；它不是二值脉冲，也不表示 fully
         spike-driven Linear。输出 dtype 与 PyTorch Linear 一致；推荐使用
@@ -787,6 +921,8 @@ class TDLinear(nn.Module):
         :type device: torch.device or str or None
         :param dtype: 参数初始化 dtype。
         :type dtype: torch.dtype or None
+        :param step_mode: 步进模式，``"s"`` 或 ``"m"``。默认 ``"m"``。
+        :type step_mode: str
 
         ----
 
@@ -794,12 +930,14 @@ class TDLinear(nn.Module):
 
         * **English**
 
-        Temporal-difference (TD) Linear operator. The input must be a complete
-        time sequence whose time dimension is fixed at dimension 0, with shape
-        ``[T, ..., in_features]``. This module returns a sequence-preserving
-        affine differential sequence such that ``Y.cumsum(dim=0)`` matches
-        :func:`torch.nn.functional.linear` applied to ``X.cumsum(dim=0)`` at
-        every time step.
+        Temporal-difference (TD) Linear operator. With ``step_mode="m"``, the
+        input must be a complete time sequence whose time dimension is fixed at
+        dimension 0, with shape ``[T, ..., in_features]``. This module returns a
+        sequence-preserving affine differential sequence such that
+        ``Y.cumsum(dim=0)`` matches :func:`torch.nn.functional.linear` applied
+        to ``X.cumsum(dim=0)`` at every time step. With ``step_mode="s"``, the
+        input is interpreted as a single-step tensor and
+        :func:`torch.nn.functional.linear` is called directly.
 
         The output contains floating-point differential values and may contain
         negative values. It is not a binary spike tensor and does not represent
@@ -835,8 +973,10 @@ class TDLinear(nn.Module):
         :type device: torch.device or str or None
         :param dtype: Dtype used to initialize parameters.
         :type dtype: torch.dtype or None
+        :param step_mode: Step mode, ``"s"`` or ``"m"``. The default is ``"m"``.
+        :type step_mode: str
         """
-        super().__init__()
+        super().__init__(step_mode)
         factory_kwargs = {"device": device, "dtype": dtype}
         self.in_features = in_features
         self.out_features = out_features
@@ -856,7 +996,10 @@ class TDLinear(nn.Module):
             bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
             nn.init.uniform_(self.bias, -bound, bound)
 
-    def forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+    def single_step_forward(self, x: torch.Tensor) -> torch.Tensor:
+        return F.linear(x, self.weight, self.bias)
+
+    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
         r"""
         **API Language:**
         :ref:`中文 <TDLinear.forward-cn>` |
@@ -952,8 +1095,8 @@ class TDLinear(nn.Module):
         )
 
 
-class SNNMatrixOperator(nn.Module):
-    def __init__(self) -> None:
+class SNNMatrixOperator(TDModule):
+    def __init__(self, step_mode: str = "m") -> None:
         r"""
         .. rubric:: API Language
 
@@ -966,10 +1109,12 @@ class SNNMatrixOperator(nn.Module):
 
         * **中文**
 
-        Sequence-preserving SNN 矩阵乘法算子。输入必须是两条完整时间序列，
-        时间维固定为第 0 维，形状分别为 ``[T, ..., M, N]`` 和
-        ``[T, ..., N, P]``。该模块先分别对两条输入在时间维做累积，再执行
-        :func:`torch.matmul`，最后返回累积输出在时间维上的差分。
+        Sequence-preserving SNN 矩阵乘法算子。``step_mode="m"`` 时输入必须
+        是两条完整时间序列，时间维固定为第 0 维，形状分别为
+        ``[T, ..., M, N]`` 和 ``[T, ..., N, P]``；模块先分别对两条输入在时间
+        维做累积，再执行 :func:`torch.matmul`，最后返回累积输出在时间维上的
+        差分。``step_mode="s"`` 时输入被解释为单步 tensor，并直接调用
+        :func:`torch.matmul`。
 
         该算子满足
         ``Y.cumsum(dim=0) == torch.matmul(A.cumsum(dim=0), B.cumsum(dim=0))``。
@@ -983,18 +1128,23 @@ class SNNMatrixOperator(nn.Module):
         :func:`torch.matmul`。该算子无内部状态，多次 ``forward`` 之间不需要
         调用 ``reset``。
 
+        :param step_mode: 步进模式，``"s"`` 或 ``"m"``。默认 ``"m"``。
+        :type step_mode: str
+
         ----
 
         .. _SNNMatrixOperator.__init__-en:
 
         * **English**
 
-        Sequence-preserving SNN matrix multiplication operator. The inputs must
-        be two complete time sequences whose time dimension is fixed at
-        dimension 0, with shapes ``[T, ..., M, N]`` and ``[T, ..., N, P]``.
-        This module accumulates both inputs over time, applies
-        :func:`torch.matmul`, and returns the temporal difference of the
-        cumulative outputs.
+        Sequence-preserving SNN matrix multiplication operator. With
+        ``step_mode="m"``, the inputs must be two complete time sequences whose
+        time dimension is fixed at dimension 0, with shapes
+        ``[T, ..., M, N]`` and ``[T, ..., N, P]``. This module accumulates both
+        inputs over time, applies :func:`torch.matmul`, and returns the
+        temporal difference of the cumulative outputs. With ``step_mode="s"``,
+        the inputs are interpreted as single-step tensors and
+        :func:`torch.matmul` is called directly.
 
         The operator satisfies
         ``Y.cumsum(dim=0) == torch.matmul(A.cumsum(dim=0), B.cumsum(dim=0))``.
@@ -1009,10 +1159,18 @@ class SNNMatrixOperator(nn.Module):
         fully spike-driven matrix multiplication. Dtype, device and broadcasting
         semantics follow :func:`torch.matmul`. The operator is stateless, and
         repeated ``forward`` calls do not require ``reset``.
-        """
-        super().__init__()
 
-    def forward(self, a_seq: torch.Tensor, b_seq: torch.Tensor) -> torch.Tensor:
+        :param step_mode: Step mode, ``"s"`` or ``"m"``. The default is ``"m"``.
+        :type step_mode: str
+        """
+        super().__init__(step_mode)
+
+    def single_step_forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return torch.matmul(a, b)
+
+    def multi_step_forward(
+        self, a_seq: torch.Tensor, b_seq: torch.Tensor
+    ) -> torch.Tensor:
         r"""
         .. rubric:: API Language
 
@@ -1106,8 +1264,8 @@ class SNNMatrixOperator(nn.Module):
         return _temporal_difference(y_cum)
 
 
-class SNNElementWiseProduct(nn.Module):
-    def __init__(self) -> None:
+class SNNElementWiseProduct(TDModule):
+    def __init__(self, step_mode: str = "m") -> None:
         r"""
         .. rubric:: API Language
 
@@ -1120,10 +1278,12 @@ class SNNElementWiseProduct(nn.Module):
 
         * **中文**
 
-        Sequence-preserving SNN 逐元素乘法算子。输入必须是两条完整时间序列，
-        时间维固定为第 0 维，形状为 ``[T, ...]``，非时间维遵循 PyTorch
-        broadcast 规则。该模块先分别对两条输入在时间维做累积，再执行逐元素
-        乘法，最后返回累积输出在时间维上的差分。
+        Sequence-preserving SNN 逐元素乘法算子。``step_mode="m"`` 时输入
+        必须是两条完整时间序列，时间维固定为第 0 维，形状为 ``[T, ...]``，
+        非时间维遵循 PyTorch broadcast 规则；模块先分别对两条输入在时间维做
+        累积，再执行逐元素乘法，最后返回累积输出在时间维上的差分。
+        ``step_mode="s"`` 时输入被解释为单步 tensor，并直接执行 PyTorch
+        逐元素乘法。
 
         该算子满足 ``Y.cumsum(dim=0) == A.cumsum(dim=0) * B.cumsum(dim=0)``。
         它是 LAS ``SNNMACOperater`` 核心乘法-累积语义的 sequence-preserving
@@ -1135,18 +1295,23 @@ class SNNElementWiseProduct(nn.Module):
         PyTorch 逐元素乘法。该算子无内部状态，多次 ``forward`` 之间不需要调用
         ``reset``。
 
+        :param step_mode: 步进模式，``"s"`` 或 ``"m"``。默认 ``"m"``。
+        :type step_mode: str
+
         ----
 
         .. _SNNElementWiseProduct.__init__-en:
 
         * **English**
 
-        Sequence-preserving SNN element-wise product operator. The inputs must
-        be two complete time sequences whose time dimension is fixed at
-        dimension 0, with shape ``[T, ...]``. Non-time dimensions follow
-        PyTorch broadcasting rules. This module accumulates both inputs over
-        time, applies element-wise multiplication, and returns the temporal
-        difference of the cumulative outputs.
+        Sequence-preserving SNN element-wise product operator. With
+        ``step_mode="m"``, the inputs must be two complete time sequences whose
+        time dimension is fixed at dimension 0, with shape ``[T, ...]``.
+        Non-time dimensions follow PyTorch broadcasting rules. This module
+        accumulates both inputs over time, applies element-wise multiplication,
+        and returns the temporal difference of the cumulative outputs. With
+        ``step_mode="s"``, the inputs are interpreted as single-step tensors
+        and PyTorch element-wise multiplication is applied directly.
 
         The operator satisfies
         ``Y.cumsum(dim=0) == A.cumsum(dim=0) * B.cumsum(dim=0)``. It is the
@@ -1160,10 +1325,18 @@ class SNNElementWiseProduct(nn.Module):
         fully spike-driven multiply-accumulate. Dtype, device and broadcasting
         semantics follow PyTorch element-wise multiplication. The operator is
         stateless, and repeated ``forward`` calls do not require ``reset``.
-        """
-        super().__init__()
 
-    def forward(self, a_seq: torch.Tensor, b_seq: torch.Tensor) -> torch.Tensor:
+        :param step_mode: Step mode, ``"s"`` or ``"m"``. The default is ``"m"``.
+        :type step_mode: str
+        """
+        super().__init__(step_mode)
+
+    def single_step_forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return a * b
+
+    def multi_step_forward(
+        self, a_seq: torch.Tensor, b_seq: torch.Tensor
+    ) -> torch.Tensor:
         r"""
         .. rubric:: API Language
 
@@ -1250,11 +1423,12 @@ class SNNElementWiseProduct(nn.Module):
         return _temporal_difference(y_cum)
 
 
-class TDScaledDotProductAttention(nn.Module):
+class TDScaledDotProductAttention(TDModule):
     def __init__(
         self,
         is_causal: bool = False,
         scale: Optional[float] = None,
+        step_mode: str = "m",
     ) -> None:
         r"""
         .. rubric:: API Language
@@ -1268,13 +1442,14 @@ class TDScaledDotProductAttention(nn.Module):
 
         * **中文**
 
-        Temporal-difference (TD) scaled dot-product attention 算子。输入必须
-        是完整时间序列，时间维固定为第 0 维。``query_seq`` 的形状为
-        ``[T, ..., L, E]``，``key_seq`` 的形状为 ``[T, ..., S, E]``，
-        ``value_seq`` 的形状为 ``[T, ..., S, Ev]``。该模块先分别对
-        query、key、value 在时间维做累积，再调用
+        Temporal-difference (TD) scaled dot-product attention 算子。
+        ``step_mode="m"`` 时输入必须是完整时间序列，时间维固定为第 0 维。
+        ``query_seq`` 的形状为 ``[T, ..., L, E]``，``key_seq`` 的形状为
+        ``[T, ..., S, E]``，``value_seq`` 的形状为 ``[T, ..., S, Ev]``；
+        模块先分别对 query、key、value 在时间维做累积，再调用
         :func:`torch.nn.functional.scaled_dot_product_attention`，最后返回
-        累积输出在时间维上的差分。
+        累积输出在时间维上的差分。``step_mode="s"`` 时输入被解释为单步
+        tensor，并直接调用 PyTorch SDPA。
 
         返回值是浮点差分值，可能包含负值；它不是二值脉冲，也不表示 fully
         spike-driven attention。dtype、device 与 mask broadcast 语义遵循
@@ -1288,9 +1463,9 @@ class TDScaledDotProductAttention(nn.Module):
         该算子的机制来源于 `SpikeZIP-TF: Conversion is All You Need for
         Transformer-based SNN <https://arxiv.org/abs/2406.03470>`_ 中对
         Transformer 算子的累积-差分等价转换思路。本文档中的 TD scaled
-        dot-product attention 只实现张量级最小 primitive：它仍调用 PyTorch
-        SDPA，需要完整时间序列输入，不是逐时间步在线算子，也不是面向神经
-        形态硬件的 fully spike-driven attention。本实现固定
+        dot-product attention 只实现张量级最小 primitive：在多步模式下它仍
+        调用 PyTorch SDPA，需要完整时间序列输入，不是逐时间步在线算子，也
+        不是面向神经形态硬件的 fully spike-driven attention。本实现固定
         ``dropout_p=0.0``，且不暴露 ``enable_gqa``。组合 TD Transformer
         block 时，普通带 bias 的 :class:`torch.nn.Linear` 不能直接作用在差分
         序列上，因为累计后 bias 会被重复累加；应使用 ``bias=False`` 或专门的
@@ -1309,6 +1484,8 @@ class TDScaledDotProductAttention(nn.Module):
         :type is_causal: bool
         :param scale: attention scale。若为 ``None``，使用 PyTorch SDPA 默认值。
         :type scale: Optional[float]
+        :param step_mode: 步进模式，``"s"`` 或 ``"m"``。默认 ``"m"``。
+        :type step_mode: str
 
         ----
 
@@ -1316,14 +1493,16 @@ class TDScaledDotProductAttention(nn.Module):
 
         * **English**
 
-        Temporal-difference (TD) scaled dot-product attention operator. The
-        inputs must be complete time sequences whose time dimension is fixed at
-        dimension 0. ``query_seq`` has shape ``[T, ..., L, E]``, ``key_seq``
-        has shape ``[T, ..., S, E]``, and ``value_seq`` has shape
-        ``[T, ..., S, Ev]``. This module first accumulates query, key, and
-        value over time, calls
+        Temporal-difference (TD) scaled dot-product attention operator. With
+        ``step_mode="m"``, the inputs must be complete time sequences whose
+        time dimension is fixed at dimension 0. ``query_seq`` has shape
+        ``[T, ..., L, E]``, ``key_seq`` has shape ``[T, ..., S, E]``, and
+        ``value_seq`` has shape ``[T, ..., S, Ev]``. This module first
+        accumulates query, key, and value over time, calls
         :func:`torch.nn.functional.scaled_dot_product_attention`, and returns
-        the temporal difference of the cumulative outputs.
+        the temporal difference of the cumulative outputs. With
+        ``step_mode="s"``, the inputs are interpreted as single-step tensors
+        and PyTorch SDPA is called directly.
 
         The output contains floating-point differential values and may contain
         negative values. It is not a binary spike tensor and does not represent
@@ -1339,10 +1518,11 @@ class TDScaledDotProductAttention(nn.Module):
         The mechanism follows the cumulative-difference equivalence idea for
         Transformer operators in `SpikeZIP-TF: Conversion is All You Need for
         Transformer-based SNN <https://arxiv.org/abs/2406.03470>`_. This
-        implementation provides only a tensor-level minimal primitive: it still
-        calls PyTorch SDPA, requires a complete time sequence, is not a
-        step-wise online operator, and is not fully spike-driven attention for
-        neuromorphic hardware. This implementation fixes ``dropout_p=0.0`` and
+        implementation provides only a tensor-level minimal primitive: in
+        multi-step mode it still calls PyTorch SDPA, requires a complete time
+        sequence, is not a step-wise online operator, and is not fully
+        spike-driven attention for neuromorphic hardware. This implementation
+        fixes ``dropout_p=0.0`` and
         does not expose ``enable_gqa``. When composing TD Transformer blocks,
         ordinary :class:`torch.nn.Linear` layers with bias must not be applied
         directly to differential sequences, because the bias would be
@@ -1362,12 +1542,36 @@ class TDScaledDotProductAttention(nn.Module):
         :param scale: Attention scale. If ``None``, use the PyTorch SDPA
             default.
         :type scale: Optional[float]
+        :param step_mode: Step mode, ``"s"`` or ``"m"``. The default is ``"m"``.
+        :type step_mode: str
         """
-        super().__init__()
+        super().__init__(step_mode)
         self.is_causal = is_causal
         self.scale = scale
 
-    def forward(
+    def single_step_forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if self.is_causal and attn_mask is not None:
+            raise ValueError(
+                "TDScaledDotProductAttention does not allow attn_mask when "
+                "is_causal=True; use one masking mode at a time."
+            )
+        return F.scaled_dot_product_attention(
+            query,
+            key,
+            value,
+            attn_mask=attn_mask,
+            dropout_p=0.0,
+            is_causal=self.is_causal,
+            scale=self.scale,
+        )
+
+    def multi_step_forward(
         self,
         query_seq: torch.Tensor,
         key_seq: torch.Tensor,
@@ -1493,7 +1697,7 @@ class TDScaledDotProductAttention(nn.Module):
         return f"is_causal={self.is_causal}, scale={self.scale}"
 
 
-class TDMultiheadAttention(nn.Module):
+class TDMultiheadAttention(TDModule):
     def __init__(
         self,
         embed_dim: int,
@@ -1503,6 +1707,7 @@ class TDMultiheadAttention(nn.Module):
         batch_first: bool = True,
         device: Optional[Union[torch.device, str]] = None,
         dtype: Optional[torch.dtype] = None,
+        step_mode: str = "m",
     ) -> None:
         r"""
         **API Language:**
@@ -1515,11 +1720,13 @@ class TDMultiheadAttention(nn.Module):
 
         * **中文**
 
-        Temporal-difference (TD) MultiheadAttention 的窄子集实现。输入必须是
-        完整时间序列，时间维固定为第 0 维，形状为
-        ``[T, batch, seq, embed_dim]``。该模块使用 ``TDLinear`` 生成 q/k/v
-        projection，执行 TD scaled dot-product attention，再用 ``TDLinear``
-        执行输出 projection。
+        Temporal-difference (TD) MultiheadAttention 的窄子集实现。
+        ``step_mode="m"`` 时输入必须是完整时间序列，时间维固定为第 0 维，
+        形状为 ``[T, batch, seq, embed_dim]``；该模块使用 ``TDLinear`` 生成
+        q/k/v projection，执行 TD scaled dot-product attention，再用
+        ``TDLinear`` 执行输出 projection。``step_mode="s"`` 时输入被解释为
+        单步 tensor，形状为 ``[batch, seq, embed_dim]``，并退化为普通
+        MultiheadAttention 数值路径。
 
         返回值是 ``(attn_output_seq, None)``，用于匹配
         :class:`torch.nn.MultiheadAttention` 在 ``need_weights=False`` 时的
@@ -1538,6 +1745,9 @@ class TDMultiheadAttention(nn.Module):
         神经形态硬件的 fully spike-driven MultiheadAttention。``bias=True``
         时 projection bias 由 ``TDLinear`` 在累积输入上处理，避免普通
         ``nn.Linear`` 直接作用在差分序列时产生重复累计 bias。
+        父模块的 ``step_mode`` 显式决定内部 q/k/v/out projection 调用
+        ``single_step_forward`` 还是 ``multi_step_forward``；因此父模块的
+        模式不依赖子 ``TDLinear`` 当前保存的 ``step_mode``。
 
         .. code-block:: python
 
@@ -1560,6 +1770,8 @@ class TDMultiheadAttention(nn.Module):
         :type device: torch.device or str or None
         :param dtype: 参数初始化 dtype。
         :type dtype: torch.dtype or None
+        :param step_mode: 步进模式，``"s"`` 或 ``"m"``。默认 ``"m"``。
+        :type step_mode: str
         :raises ValueError: 若 ``embed_dim`` 不能被 ``num_heads`` 整除、或传入
             当前不支持的 ``dropout`` / ``batch_first``。
 
@@ -1569,11 +1781,15 @@ class TDMultiheadAttention(nn.Module):
 
         * **English**
 
-        Narrow temporal-difference (TD) MultiheadAttention implementation. The
-        input must be a complete time sequence whose time dimension is fixed at
-        dimension 0, with shape ``[T, batch, seq, embed_dim]``. This module uses
-        ``TDLinear`` for q/k/v projections, applies TD scaled dot-product
-        attention, and then applies a ``TDLinear`` output projection.
+        Narrow temporal-difference (TD) MultiheadAttention implementation. With
+        ``step_mode="m"``, the input must be a complete time sequence whose
+        time dimension is fixed at dimension 0, with shape
+        ``[T, batch, seq, embed_dim]``. This module uses ``TDLinear`` for q/k/v
+        projections, applies TD scaled dot-product attention, and then applies
+        a ``TDLinear`` output projection. With ``step_mode="s"``, the input is
+        interpreted as a single-step tensor with shape
+        ``[batch, seq, embed_dim]`` and the module degenerates to the ordinary
+        MultiheadAttention numeric path.
 
         The return value is ``(attn_output_seq, None)`` to match the tuple
         structure of :class:`torch.nn.MultiheadAttention` when
@@ -1597,6 +1813,10 @@ class TDMultiheadAttention(nn.Module):
         projection biases are handled by ``TDLinear`` on cumulative inputs,
         avoiding the repeated bias accumulation that would occur if ordinary
         ``nn.Linear`` were applied directly to differential sequences.
+        The parent module's ``step_mode`` explicitly decides whether q/k/v/out
+        projections call ``single_step_forward`` or ``multi_step_forward``;
+        therefore the parent mode does not depend on the child ``TDLinear``
+        modules' stored ``step_mode`` values.
 
         .. code-block:: python
 
@@ -1619,10 +1839,12 @@ class TDMultiheadAttention(nn.Module):
         :type device: torch.device or str or None
         :param dtype: Dtype used to initialize parameters.
         :type dtype: torch.dtype or None
+        :param step_mode: Step mode, ``"s"`` or ``"m"``. The default is ``"m"``.
+        :type step_mode: str
         :raises ValueError: If ``embed_dim`` is not divisible by ``num_heads``,
             or unsupported ``dropout`` / ``batch_first`` is passed.
         """
-        super().__init__()
+        super().__init__(step_mode)
         if embed_dim % num_heads != 0:
             raise ValueError("embed_dim must be divisible by num_heads.")
         if dropout != 0.0:
@@ -1662,6 +1884,26 @@ class TDMultiheadAttention(nn.Module):
         x_seq = x_seq.transpose(2, 3).contiguous()
         return x_seq.reshape(t, batch_size, seq_len, self.embed_dim)
 
+    def _split_heads_single(self, x: torch.Tensor) -> torch.Tensor:
+        if x.dim() != 3:
+            raise ValueError(
+                "TDMultiheadAttention expects single-step input with shape "
+                f"[batch, seq, embed_dim], but got {tuple(x.shape)}."
+            )
+        if x.shape[-1] != self.embed_dim:
+            raise ValueError(
+                "TDMultiheadAttention expects the last dimension to match "
+                f"embed_dim={self.embed_dim}, but got {x.shape[-1]}."
+            )
+        batch_size, seq_len, _ = x.shape
+        x = x.reshape(batch_size, seq_len, self.num_heads, self.head_dim)
+        return x.transpose(1, 2)
+
+    def _merge_heads_single(self, x: torch.Tensor) -> torch.Tensor:
+        batch_size, _, seq_len, _ = x.shape
+        x = x.transpose(1, 2).contiguous()
+        return x.reshape(batch_size, seq_len, self.embed_dim)
+
     def _canonical_mha_attn_mask(
         self,
         attn_mask: Optional[torch.Tensor],
@@ -1675,7 +1917,52 @@ class TDMultiheadAttention(nn.Module):
             return attn_mask.reshape(batch_size, self.num_heads, *attn_mask.shape[1:])
         return attn_mask
 
-    def forward(
+    def _check_forward_options(
+        self,
+        key_padding_mask: Optional[torch.Tensor],
+        need_weights: bool,
+        average_attn_weights: bool,
+    ) -> None:
+        if need_weights:
+            raise ValueError("TDMultiheadAttention only supports need_weights=False.")
+        if key_padding_mask is not None:
+            raise ValueError("TDMultiheadAttention does not support key_padding_mask.")
+        if not average_attn_weights:
+            raise ValueError(
+                "TDMultiheadAttention does not support average_attn_weights=False."
+            )
+
+    def single_step_forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        key_padding_mask: Optional[torch.Tensor] = None,
+        need_weights: bool = False,
+        attn_mask: Optional[torch.Tensor] = None,
+        average_attn_weights: bool = True,
+        is_causal: bool = False,
+    ) -> Tuple[torch.Tensor, None]:
+        self._check_forward_options(
+            key_padding_mask, need_weights, average_attn_weights
+        )
+
+        q = self._split_heads_single(self.q_proj.single_step_forward(query))
+        k = self._split_heads_single(self.k_proj.single_step_forward(key))
+        v = self._split_heads_single(self.v_proj.single_step_forward(value))
+        attn_mask = self._canonical_mha_attn_mask(attn_mask, q.shape[0])
+        attn = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=attn_mask,
+            dropout_p=0.0,
+            is_causal=is_causal,
+        )
+        out = self.out_proj.single_step_forward(self._merge_heads_single(attn))
+        return out, None
+
+    def multi_step_forward(
         self,
         query_seq: torch.Tensor,
         key_seq: torch.Tensor,
@@ -1781,18 +2068,13 @@ class TDMultiheadAttention(nn.Module):
         :raises ValueError: If unsupported masks/options or invalid shapes are
             passed.
         """
-        if need_weights:
-            raise ValueError("TDMultiheadAttention only supports need_weights=False.")
-        if key_padding_mask is not None:
-            raise ValueError("TDMultiheadAttention does not support key_padding_mask.")
-        if not average_attn_weights:
-            raise ValueError(
-                "TDMultiheadAttention does not support average_attn_weights=False."
-            )
+        self._check_forward_options(
+            key_padding_mask, need_weights, average_attn_weights
+        )
 
-        q_seq = self._split_heads(self.q_proj(query_seq))
-        k_seq = self._split_heads(self.k_proj(key_seq))
-        v_seq = self._split_heads(self.v_proj(value_seq))
+        q_seq = self._split_heads(self.q_proj.multi_step_forward(query_seq))
+        k_seq = self._split_heads(self.k_proj.multi_step_forward(key_seq))
+        v_seq = self._split_heads(self.v_proj.multi_step_forward(value_seq))
         attn_mask = self._canonical_mha_attn_mask(attn_mask, q_seq.shape[1])
         attn_seq = _td_scaled_dot_product_attention(
             q_seq,
@@ -1803,7 +2085,7 @@ class TDMultiheadAttention(nn.Module):
             None,
             "TDMultiheadAttention",
         )
-        out_seq = self.out_proj(self._merge_heads(attn_seq))
+        out_seq = self.out_proj.multi_step_forward(self._merge_heads(attn_seq))
         return out_seq, None
 
     def extra_repr(self) -> str:

--- a/spikingjelly/activation_based/ann2snn/operators.py
+++ b/spikingjelly/activation_based/ann2snn/operators.py
@@ -1745,9 +1745,8 @@ class TDMultiheadAttention(TDModule):
         神经形态硬件的 fully spike-driven MultiheadAttention。``bias=True``
         时 projection bias 由 ``TDLinear`` 在累积输入上处理，避免普通
         ``nn.Linear`` 直接作用在差分序列时产生重复累计 bias。
-        父模块的 ``step_mode`` 显式决定内部 q/k/v/out projection 调用
-        ``single_step_forward`` 还是 ``multi_step_forward``；因此父模块的
-        模式不依赖子 ``TDLinear`` 当前保存的 ``step_mode``。
+        父模块的 ``step_mode`` 会同步到内部 q/k/v/out projection，确保 projection
+        通过标准 ``nn.Module.__call__`` 执行，兼容 PyTorch hooks / profiling。
 
         .. code-block:: python
 
@@ -1813,10 +1812,10 @@ class TDMultiheadAttention(TDModule):
         projection biases are handled by ``TDLinear`` on cumulative inputs,
         avoiding the repeated bias accumulation that would occur if ordinary
         ``nn.Linear`` were applied directly to differential sequences.
-        The parent module's ``step_mode`` explicitly decides whether q/k/v/out
-        projections call ``single_step_forward`` or ``multi_step_forward``;
-        therefore the parent mode does not depend on the child ``TDLinear``
-        modules' stored ``step_mode`` values.
+        The parent module's ``step_mode`` is synchronized to the internal
+        q/k/v/out projections, so projections execute through the standard
+        ``nn.Module.__call__`` path and remain compatible with PyTorch hooks /
+        profiling.
 
         .. code-block:: python
 
@@ -1867,6 +1866,16 @@ class TDMultiheadAttention(TDModule):
         self.k_proj = TDLinear(embed_dim, embed_dim, bias=bias, **factory_kwargs)
         self.v_proj = TDLinear(embed_dim, embed_dim, bias=bias, **factory_kwargs)
         self.out_proj = TDLinear(embed_dim, embed_dim, bias=bias, **factory_kwargs)
+        self.step_mode = step_mode
+
+    @TDModule.step_mode.setter
+    def step_mode(self, value: str):
+        base.StepModule.step_mode.fset(self, value)
+        if hasattr(self, "q_proj"):
+            self.q_proj.step_mode = value
+            self.k_proj.step_mode = value
+            self.v_proj.step_mode = value
+            self.out_proj.step_mode = value
 
     def _split_heads(self, x_seq: torch.Tensor) -> torch.Tensor:
         if x_seq.dim() != 4:
@@ -1951,9 +1960,9 @@ class TDMultiheadAttention(TDModule):
             key_padding_mask, need_weights, average_attn_weights
         )
 
-        q = self._split_heads_single(self.q_proj.single_step_forward(query))
-        k = self._split_heads_single(self.k_proj.single_step_forward(key))
-        v = self._split_heads_single(self.v_proj.single_step_forward(value))
+        q = self._split_heads_single(self.q_proj(query))
+        k = self._split_heads_single(self.k_proj(key))
+        v = self._split_heads_single(self.v_proj(value))
         attn_mask = self._canonical_mha_attn_mask(attn_mask, q.shape[0])
         attn = F.scaled_dot_product_attention(
             q,
@@ -1963,7 +1972,7 @@ class TDMultiheadAttention(TDModule):
             dropout_p=0.0,
             is_causal=is_causal,
         )
-        out = self.out_proj.single_step_forward(self._merge_heads_single(attn))
+        out = self.out_proj(self._merge_heads_single(attn))
         return out, None
 
     def multi_step_forward(
@@ -2076,9 +2085,9 @@ class TDMultiheadAttention(TDModule):
             key_padding_mask, need_weights, average_attn_weights
         )
 
-        q_seq = self._split_heads(self.q_proj.multi_step_forward(query_seq))
-        k_seq = self._split_heads(self.k_proj.multi_step_forward(key_seq))
-        v_seq = self._split_heads(self.v_proj.multi_step_forward(value_seq))
+        q_seq = self._split_heads(self.q_proj(query_seq))
+        k_seq = self._split_heads(self.k_proj(key_seq))
+        v_seq = self._split_heads(self.v_proj(value_seq))
         attn_mask = self._canonical_mha_attn_mask(attn_mask, q_seq.shape[1])
         attn_seq = _td_scaled_dot_product_attention(
             q_seq,
@@ -2089,7 +2098,7 @@ class TDMultiheadAttention(TDModule):
             None,
             "TDMultiheadAttention",
         )
-        out_seq = self.out_proj.multi_step_forward(self._merge_heads(attn_seq))
+        out_seq = self.out_proj(self._merge_heads(attn_seq))
         return out_seq, None
 
     def extra_repr(self) -> str:

--- a/spikingjelly/activation_based/ann2snn/operators.py
+++ b/spikingjelly/activation_based/ann2snn/operators.py
@@ -1085,8 +1085,9 @@ class TDLinear(TDModule):
         if self.bias is None:
             return F.linear(x_seq, self.weight, None)
 
-        y_cum = F.linear(x_seq.cumsum(dim=0), self.weight, self.bias)
-        return _temporal_difference(y_cum)
+        y_seq = F.linear(x_seq, self.weight, None)
+        y_seq[0] = y_seq[0] + self.bias
+        return y_seq
 
     def extra_repr(self) -> str:
         return (

--- a/spikingjelly/activation_based/ann2snn/operators.py
+++ b/spikingjelly/activation_based/ann2snn/operators.py
@@ -1845,6 +1845,10 @@ class TDMultiheadAttention(TDModule):
             or unsupported ``dropout`` / ``batch_first`` is passed.
         """
         super().__init__(step_mode)
+        if embed_dim <= 0:
+            raise ValueError("embed_dim must be positive.")
+        if num_heads <= 0:
+            raise ValueError("num_heads must be positive.")
         if embed_dim % num_heads != 0:
             raise ValueError("embed_dim must be divisible by num_heads.")
         if dropout != 0.0:

--- a/spikingjelly/activation_based/ann2snn/operators.py
+++ b/spikingjelly/activation_based/ann2snn/operators.py
@@ -1088,6 +1088,21 @@ class TDLinear(TDModule):
         y_cum = F.linear(x_seq.cumsum(dim=0), self.weight, self.bias)
         return _temporal_difference(y_cum)
 
+    def forward(
+        self, x: torch.Tensor, step_mode: Optional[Literal["s", "m"]] = None
+    ) -> torch.Tensor:
+        if step_mode is None:
+            return super().forward(x)
+        if step_mode == "s":
+            return self.single_step_forward(x)
+        elif step_mode == "m":
+            return self.multi_step_forward(x)
+        else:
+            raise ValueError(
+                f"step_mode can only be {self.supported_step_mode()}, "
+                f'but got "{step_mode}"!'
+            )
+
     def extra_repr(self) -> str:
         return (
             f"in_features={self.in_features}, out_features={self.out_features}, "
@@ -1877,28 +1892,6 @@ class TDMultiheadAttention(TDModule):
             self.v_proj.step_mode = value
             self.out_proj.step_mode = value
 
-    def _projection_step_modes(self) -> Tuple[str, str, str, str]:
-        return (
-            self.q_proj.step_mode,
-            self.k_proj.step_mode,
-            self.v_proj.step_mode,
-            self.out_proj.step_mode,
-        )
-
-    def _set_projection_step_mode(self, step_mode: str) -> None:
-        self.q_proj.step_mode = step_mode
-        self.k_proj.step_mode = step_mode
-        self.v_proj.step_mode = step_mode
-        self.out_proj.step_mode = step_mode
-
-    def _restore_projection_step_modes(self, modes: Tuple[str, str, str, str]) -> None:
-        (
-            self.q_proj.step_mode,
-            self.k_proj.step_mode,
-            self.v_proj.step_mode,
-            self.out_proj.step_mode,
-        ) = modes
-
     def _split_heads(self, x_seq: torch.Tensor) -> torch.Tensor:
         if x_seq.dim() != 4:
             raise ValueError(
@@ -1996,25 +1989,20 @@ class TDMultiheadAttention(TDModule):
             key_padding_mask, need_weights, average_attn_weights
         )
 
-        projection_modes = self._projection_step_modes()
-        self._set_projection_step_mode("s")
-        try:
-            q = self._split_heads_single(self.q_proj(query))
-            k = self._split_heads_single(self.k_proj(key))
-            v = self._split_heads_single(self.v_proj(value))
-            self._check_attention_leading_dims(q, k, v, "TDMultiheadAttention")
-            attn_mask = self._canonical_mha_attn_mask(attn_mask, q.shape[0])
-            attn = F.scaled_dot_product_attention(
-                q,
-                k,
-                v,
-                attn_mask=attn_mask,
-                dropout_p=0.0,
-                is_causal=is_causal,
-            )
-            out = self.out_proj(self._merge_heads_single(attn))
-        finally:
-            self._restore_projection_step_modes(projection_modes)
+        q = self._split_heads_single(self.q_proj(query, step_mode="s"))
+        k = self._split_heads_single(self.k_proj(key, step_mode="s"))
+        v = self._split_heads_single(self.v_proj(value, step_mode="s"))
+        self._check_attention_leading_dims(q, k, v, "TDMultiheadAttention")
+        attn_mask = self._canonical_mha_attn_mask(attn_mask, q.shape[0])
+        attn = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=attn_mask,
+            dropout_p=0.0,
+            is_causal=is_causal,
+        )
+        out = self.out_proj(self._merge_heads_single(attn), step_mode="s")
         return out, None
 
     def multi_step_forward(
@@ -2127,28 +2115,21 @@ class TDMultiheadAttention(TDModule):
             key_padding_mask, need_weights, average_attn_weights
         )
 
-        projection_modes = self._projection_step_modes()
-        self._set_projection_step_mode("m")
-        try:
-            q_seq = self._split_heads(self.q_proj(query_seq))
-            k_seq = self._split_heads(self.k_proj(key_seq))
-            v_seq = self._split_heads(self.v_proj(value_seq))
-            self._check_attention_leading_dims(
-                q_seq, k_seq, v_seq, "TDMultiheadAttention"
-            )
-            attn_mask = self._canonical_mha_attn_mask(attn_mask, q_seq.shape[1])
-            attn_seq = _td_scaled_dot_product_attention(
-                q_seq,
-                k_seq,
-                v_seq,
-                attn_mask,
-                is_causal,
-                None,
-                "TDMultiheadAttention",
-            )
-            out_seq = self.out_proj(self._merge_heads(attn_seq))
-        finally:
-            self._restore_projection_step_modes(projection_modes)
+        q_seq = self._split_heads(self.q_proj(query_seq, step_mode="m"))
+        k_seq = self._split_heads(self.k_proj(key_seq, step_mode="m"))
+        v_seq = self._split_heads(self.v_proj(value_seq, step_mode="m"))
+        self._check_attention_leading_dims(q_seq, k_seq, v_seq, "TDMultiheadAttention")
+        attn_mask = self._canonical_mha_attn_mask(attn_mask, q_seq.shape[1])
+        attn_seq = _td_scaled_dot_product_attention(
+            q_seq,
+            k_seq,
+            v_seq,
+            attn_mask,
+            is_causal,
+            None,
+            "TDMultiheadAttention",
+        )
+        out_seq = self.out_proj(self._merge_heads(attn_seq), step_mode="m")
         return out_seq, None
 
     def extra_repr(self) -> str:

--- a/spikingjelly/activation_based/neuron/__init__.py
+++ b/spikingjelly/activation_based/neuron/__init__.py
@@ -7,6 +7,7 @@ from .psn import *
 from .adapt import *
 from .nonlinear_if import *
 from .flexsn import *
+from .few_spike import *
 
 # research-specific neurons
 from .dsr import *

--- a/spikingjelly/activation_based/neuron/few_spike.py
+++ b/spikingjelly/activation_based/neuron/few_spike.py
@@ -218,15 +218,15 @@ class FewSpikeNode(nn.Module, base.StepModule):
     ) -> torch.Tensor:
         v = gate
         y_seq = []
-        y = None
-        for theta_k, h_k, d_k in zip(theta.unbind(0), h.unbind(0), d.unbind(0)):
+        y = torch.zeros_like(gate) if not return_sequence else None
+        for theta_k, h_k, d_k in zip(
+            theta.unbind(0), h.unbind(0), d.unbind(0), strict=True
+        ):
             z = self.surrogate_function(v - theta_k)
             weighted_spike = d_k * z
             if return_sequence:
                 y_seq.append(weighted_spike)
             else:
-                if y is None:
-                    y = torch.zeros_like(gate)
                 y = y + weighted_spike
             v = v - h_k * z
         if return_sequence:
@@ -436,7 +436,7 @@ class OutlierAwareThresholdNode(FewSpikeNode):
         mask = magnitude <= self.split_threshold
         v = magnitude
         y_seq = []
-        y = None
+        y = torch.zeros_like(gate) if not return_sequence else None
         for theta_k, h_k, d_k, outlier_theta_k, outlier_h_k, outlier_d_k in zip(
             self.theta.unbind(0),
             self.h.unbind(0),
@@ -444,14 +444,13 @@ class OutlierAwareThresholdNode(FewSpikeNode):
             self.outlier_theta.unbind(0),
             self.outlier_h.unbind(0),
             self.outlier_d.unbind(0),
+            strict=True,
         ):
             z = self.surrogate_function(v - torch.where(mask, theta_k, outlier_theta_k))
             weighted_spike = torch.where(mask, d_k, outlier_d_k) * z
             if return_sequence:
                 y_seq.append(weighted_spike)
             else:
-                if y is None:
-                    y = torch.zeros_like(gate)
                 y = y + weighted_spike
             v = v - torch.where(mask, h_k, outlier_h_k) * z
         if return_sequence:
@@ -577,7 +576,7 @@ class HGNode(FewSpikeNode):
         region_ids = torch.bucketize(gate.detach(), self.gate_thresholds)
         v = gate
         y_seq = []
-        y = None
+        y = torch.zeros_like(gate) if not return_sequence else None
         for k in range(self.K):
             theta_k = self.region_theta[:, k][region_ids]
             h_k = self.region_h[:, k][region_ids]
@@ -587,8 +586,6 @@ class HGNode(FewSpikeNode):
             if return_sequence:
                 y_seq.append(weighted_spike)
             else:
-                if y is None:
-                    y = torch.zeros_like(gate)
                 y = y + weighted_spike
             v = v - h_k * z
         if return_sequence:

--- a/spikingjelly/activation_based/neuron/few_spike.py
+++ b/spikingjelly/activation_based/neuron/few_spike.py
@@ -45,6 +45,10 @@ def _check_table_length(name: str, table: "FewSpikeTable", K: int):
         raise ValueError(f"{name}.K must be {K}, but got {table.K}.")
 
 
+def _table_tensor_to_reference(tensor: torch.Tensor, reference: torch.Tensor):
+    return tensor.to(device=reference.device, dtype=reference.dtype).detach().clone()
+
+
 class FewSpikeTable:
     def __init__(
         self,
@@ -66,7 +70,8 @@ class FewSpikeTable:
         ``theta``、``h``、``d`` 会被注册为 buffer，因此会跟随模块的
         ``device`` 和 ``dtype`` 迁移。
 
-        :param theta: 长度为 ``K`` 的阈值序列，形状为 ``[K]``。
+        :param theta: 长度为 ``K`` 的阈值序列，形状为 ``[K]``。该类不强制
+            ``theta`` 单调；调用方应传入与目标 Few-Spike 编码表一致的顺序。
         :type theta: Union[torch.Tensor, Sequence[float]]
         :param h: 长度为 ``K`` 的膜电位扣减序列，形状为 ``[K]``。
         :type h: Union[torch.Tensor, Sequence[float]]
@@ -88,6 +93,8 @@ class FewSpikeTable:
         conversions.
 
         :param theta: Threshold sequence with length ``K`` and shape ``[K]``.
+            This class does not enforce monotonic ``theta``; callers should pass
+            the order used by the target Few-Spike coding table.
         :type theta: Union[torch.Tensor, Sequence[float]]
         :param h: Membrane subtraction sequence with length ``K`` and shape ``[K]``.
         :type h: Union[torch.Tensor, Sequence[float]]
@@ -167,7 +174,7 @@ class FewSpikeNode(nn.Module, base.StepModule):
         :param table: Few-Spike 编码表 / Few-Spike coding table.
         :type table: FewSpikeTable
         :param surrogate_function: 替代梯度函数 / surrogate function for spike generation.
-        :type surrogate_function: surrogate.SurrogateFunctionBase
+        :type surrogate_function: Optional[surrogate.SurrogateFunctionBase]
         :param step_mode: 步进模式，``"s"`` 或 ``"m"`` / step mode, ``"s"`` or ``"m"``.
         :type step_mode: str
         :raises TypeError: 当 ``table`` 不是 :class:`FewSpikeTable` 时抛出 /
@@ -368,10 +375,12 @@ class OutlierAwareThresholdNode(FewSpikeNode):
         :param clamp_value: 可选的对称截断幅值。若不为 ``None``，必须大于等于 ``split_threshold``。
         :type clamp_value: Optional[float]
         :param surrogate_function: 替代梯度函数。
-        :type surrogate_function: surrogate.SurrogateFunctionBase
+        :type surrogate_function: Optional[surrogate.SurrogateFunctionBase]
         :param step_mode: 步进模式，``"s"`` 或 ``"m"``。
         :type step_mode: str
         :raises ValueError: 当 table 长度不一致或阈值参数非法时抛出。
+        :raises TypeError: 当 ``table`` 或 ``outlier_table`` 不是
+            :class:`FewSpikeTable` 时抛出。
 
         ----
 
@@ -404,11 +413,13 @@ class OutlierAwareThresholdNode(FewSpikeNode):
             it must be no smaller than ``split_threshold``.
         :type clamp_value: Optional[float]
         :param surrogate_function: Surrogate function.
-        :type surrogate_function: surrogate.SurrogateFunctionBase
+        :type surrogate_function: Optional[surrogate.SurrogateFunctionBase]
         :param step_mode: Step mode, ``"s"`` or ``"m"``.
         :type step_mode: str
         :raises ValueError: Raised when table lengths are inconsistent or threshold
             arguments are invalid.
+        :raises TypeError: Raised when ``table`` or ``outlier_table`` is not a
+            :class:`FewSpikeTable`.
         """
         if not isinstance(table, FewSpikeTable):
             raise TypeError(
@@ -427,9 +438,18 @@ class OutlierAwareThresholdNode(FewSpikeNode):
             if clamp_value < split_threshold:
                 raise ValueError("clamp_value must be no smaller than split_threshold.")
         super().__init__(table, surrogate_function, step_mode)
-        self.register_buffer("outlier_theta", outlier_table.theta.clone())
-        self.register_buffer("outlier_h", outlier_table.h.clone())
-        self.register_buffer("outlier_d", outlier_table.d.clone())
+        self.register_buffer(
+            "outlier_theta",
+            _table_tensor_to_reference(outlier_table.theta, table.theta),
+        )
+        self.register_buffer(
+            "outlier_h",
+            _table_tensor_to_reference(outlier_table.h, table.h),
+        )
+        self.register_buffer(
+            "outlier_d",
+            _table_tensor_to_reference(outlier_table.d, table.d),
+        )
         self.split_threshold = split_threshold
         self.clamp_value = clamp_value
 
@@ -489,9 +509,9 @@ class HGNode(FewSpikeNode):
 
         通用 hierarchically-gated Few-Spike 节点。``gate_thresholds`` 按升序把 gate input
         划分为 ``len(tables)`` 个区间：第一个 table 处理 ``x <= gate_thresholds[0]``，
-        中间 table 处理相邻阈值之间的元素，最后一个 table 处理
-        ``x > gate_thresholds[-1]``。所有 table 的 ``K`` 必须一致。单步模式输入输出形状
-        为 ``[...]``；多步模式输入形状必须为 ``[K, ...]``，输出形状为 ``[K, ...]``。
+        中间 table 处理 ``(gate_thresholds[i-1], gate_thresholds[i]]``，最后一个 table
+        处理 ``x > gate_thresholds[-1]``。所有 table 的 ``K`` 必须一致。单步模式输入输出
+        形状为 ``[...]``；多步模式输入形状必须为 ``[K, ...]``，输出形状为 ``[K, ...]``。
 
         该类提供区域路由形式的通用层级门控，不声明与 LAS 中某个具体 fitted activation
         模块完全等价。需要复现特定 LAS 非线性时，应使用与该非线性对应的 table 和阈值。
@@ -501,7 +521,7 @@ class HGNode(FewSpikeNode):
         :param gate_thresholds: 升序一维阈值序列，长度必须为 ``len(tables) - 1``。
         :type gate_thresholds: Union[torch.Tensor, Sequence[float]]
         :param surrogate_function: 替代梯度函数。
-        :type surrogate_function: surrogate.SurrogateFunctionBase
+        :type surrogate_function: Optional[surrogate.SurrogateFunctionBase]
         :param step_mode: 步进模式，``"s"`` 或 ``"m"``。
         :type step_mode: str
         :raises ValueError: 当 table 数量、阈值数量、阈值顺序或 table 长度非法时抛出。
@@ -515,8 +535,9 @@ class HGNode(FewSpikeNode):
 
         Generic hierarchically-gated Few-Spike node. ``gate_thresholds`` partitions the
         gate input into ``len(tables)`` regions in ascending order: the first table
-        handles ``x <= gate_thresholds[0]``, middle tables handle adjacent
-        threshold intervals, and the last table handles ``x > gate_thresholds[-1]``.
+        handles ``x <= gate_thresholds[0]``, middle tables handle
+        ``(gate_thresholds[i-1], gate_thresholds[i]]``, and the last table
+        handles ``x > gate_thresholds[-1]``.
         All tables must have the same ``K``. Single-step input and output shape is
         ``[...]``; multi-step input must have shape ``[K, ...]`` and output shape is
         ``[K, ...]``.
@@ -532,7 +553,7 @@ class HGNode(FewSpikeNode):
             ``len(tables) - 1``.
         :type gate_thresholds: Union[torch.Tensor, Sequence[float]]
         :param surrogate_function: Surrogate function.
-        :type surrogate_function: surrogate.SurrogateFunctionBase
+        :type surrogate_function: Optional[surrogate.SurrogateFunctionBase]
         :param step_mode: Step mode, ``"s"`` or ``"m"``.
         :type step_mode: str
         :raises ValueError: Raised when table count, threshold count, threshold
@@ -571,13 +592,40 @@ class HGNode(FewSpikeNode):
         if thresholds.numel() > 1 and not torch.all(thresholds[1:] > thresholds[:-1]):
             raise ValueError("gate_thresholds must be strictly increasing.")
 
-        super().__init__(tables[0], surrogate_function, step_mode)
+        nn.Module.__init__(self)
+        if surrogate_function is None:
+            surrogate_function = surrogate.Sigmoid()
+        self.surrogate_function = surrogate_function
+        self.step_mode = step_mode
+        reference_theta = tables[0].theta
+        reference_h = tables[0].h
+        reference_d = tables[0].d
         self.register_buffer(
-            "region_theta", torch.stack([table.theta for table in tables])
+            "region_theta",
+            torch.stack(
+                [
+                    _table_tensor_to_reference(table.theta, reference_theta)
+                    for table in tables
+                ]
+            ),
         )
-        self.register_buffer("region_h", torch.stack([table.h for table in tables]))
-        self.register_buffer("region_d", torch.stack([table.d for table in tables]))
+        self.register_buffer(
+            "region_h",
+            torch.stack(
+                [_table_tensor_to_reference(table.h, reference_h) for table in tables]
+            ),
+        )
+        self.register_buffer(
+            "region_d",
+            torch.stack(
+                [_table_tensor_to_reference(table.d, reference_d) for table in tables]
+            ),
+        )
         self.register_buffer("gate_thresholds", thresholds)
+
+    @property
+    def K(self) -> int:
+        return self.region_theta.shape[1]
 
     def _forward_from_gate(
         self, gate: torch.Tensor, return_sequence: bool

--- a/spikingjelly/activation_based/neuron/few_spike.py
+++ b/spikingjelly/activation_based/neuron/few_spike.py
@@ -219,9 +219,7 @@ class FewSpikeNode(nn.Module, base.StepModule):
         v = gate
         y_seq = []
         y = torch.zeros_like(gate) if not return_sequence else None
-        for theta_k, h_k, d_k in zip(
-            theta.unbind(0), h.unbind(0), d.unbind(0), strict=True
-        ):
+        for theta_k, h_k, d_k in zip(theta.unbind(0), h.unbind(0), d.unbind(0)):
             z = self.surrogate_function(v - theta_k)
             weighted_spike = d_k * z
             if return_sequence:
@@ -444,7 +442,6 @@ class OutlierAwareThresholdNode(FewSpikeNode):
             self.outlier_theta.unbind(0),
             self.outlier_h.unbind(0),
             self.outlier_d.unbind(0),
-            strict=True,
         ):
             z = self.surrogate_function(v - torch.where(mask, theta_k, outlier_theta_k))
             weighted_spike = torch.where(mask, d_k, outlier_d_k) * z
@@ -553,7 +550,10 @@ class HGNode(FewSpikeNode):
                 device=tables[0].theta.device,
             )
         else:
-            thresholds = _as_float_1d_tensor("gate_thresholds", gate_thresholds)
+            thresholds = _as_float_1d_tensor("gate_thresholds", gate_thresholds).to(
+                device=tables[0].theta.device,
+                dtype=tables[0].theta.dtype,
+            )
         if thresholds.numel() != len(tables) - 1:
             raise ValueError(
                 "gate_thresholds must have length len(tables) - 1, but got "

--- a/spikingjelly/activation_based/neuron/few_spike.py
+++ b/spikingjelly/activation_based/neuron/few_spike.py
@@ -1,3 +1,4 @@
+import math
 from typing import Sequence, Union, Optional
 
 import torch
@@ -7,10 +8,10 @@ from .. import base, surrogate
 
 
 __all__ = [
-    "FewSpikeTable",
     "FewSpikeNode",
-    "OutlierAwareThresholdNode",
+    "FewSpikeTable",
     "HGNode",
+    "OutlierAwareThresholdNode",
 ]
 
 
@@ -409,20 +410,28 @@ class OutlierAwareThresholdNode(FewSpikeNode):
         :raises ValueError: Raised when table lengths are inconsistent or threshold
             arguments are invalid.
         """
+        if not isinstance(table, FewSpikeTable):
+            raise TypeError(
+                f"table must be FewSpikeTable, but got {type(table).__name__}."
+            )
         _check_table_length("outlier_table", outlier_table, table.K)
-        if split_threshold < 0:
-            raise ValueError("split_threshold must be non-negative.")
+        split_threshold = float(split_threshold)
+        if not math.isfinite(split_threshold) or split_threshold < 0:
+            raise ValueError("split_threshold must be a finite non-negative value.")
         if clamp_value is not None:
-            if clamp_value <= 0:
-                raise ValueError("clamp_value must be positive when it is not None.")
+            clamp_value = float(clamp_value)
+            if not math.isfinite(clamp_value) or clamp_value <= 0:
+                raise ValueError(
+                    "clamp_value must be finite and positive when it is not None."
+                )
             if clamp_value < split_threshold:
                 raise ValueError("clamp_value must be no smaller than split_threshold.")
         super().__init__(table, surrogate_function, step_mode)
         self.register_buffer("outlier_theta", outlier_table.theta.clone())
         self.register_buffer("outlier_h", outlier_table.h.clone())
         self.register_buffer("outlier_d", outlier_table.d.clone())
-        self.split_threshold = float(split_threshold)
-        self.clamp_value = None if clamp_value is None else float(clamp_value)
+        self.split_threshold = split_threshold
+        self.clamp_value = clamp_value
 
     def _forward_from_gate(
         self, gate: torch.Tensor, return_sequence: bool

--- a/spikingjelly/activation_based/neuron/few_spike.py
+++ b/spikingjelly/activation_based/neuron/few_spike.py
@@ -159,7 +159,7 @@ class FewSpikeNode(nn.Module, base.StepModule):
     def __init__(
         self,
         table: FewSpikeTable,
-        surrogate_function: surrogate.SurrogateFunctionBase = surrogate.Sigmoid(),
+        surrogate_function: Optional[surrogate.SurrogateFunctionBase] = None,
         step_mode: str = "s",
     ):
         r"""
@@ -182,6 +182,8 @@ class FewSpikeNode(nn.Module, base.StepModule):
         self.register_buffer("theta", table.theta.clone())
         self.register_buffer("h", table.h.clone())
         self.register_buffer("d", table.d.clone())
+        if surrogate_function is None:
+            surrogate_function = surrogate.Sigmoid()
         self.surrogate_function = surrogate_function
         self.step_mode = step_mode
 
@@ -217,16 +219,16 @@ class FewSpikeNode(nn.Module, base.StepModule):
         v = gate
         y_seq = []
         y = None
-        for k in range(theta.numel()):
-            z = self.surrogate_function(v - theta[k])
-            weighted_spike = d[k] * z
+        for theta_k, h_k, d_k in zip(theta.unbind(0), h.unbind(0), d.unbind(0)):
+            z = self.surrogate_function(v - theta_k)
+            weighted_spike = d_k * z
             if return_sequence:
                 y_seq.append(weighted_spike)
             else:
                 if y is None:
                     y = torch.zeros_like(gate)
                 y = y + weighted_spike
-            v = v - h[k] * z
+            v = v - h_k * z
         if return_sequence:
             return torch.stack(y_seq, dim=0)
         return y
@@ -335,7 +337,7 @@ class OutlierAwareThresholdNode(FewSpikeNode):
         outlier_table: FewSpikeTable,
         split_threshold: float,
         clamp_value: Optional[float] = None,
-        surrogate_function: surrogate.SurrogateFunctionBase = surrogate.Sigmoid(),
+        surrogate_function: Optional[surrogate.SurrogateFunctionBase] = None,
         step_mode: str = "s",
     ):
         r"""
@@ -431,19 +433,31 @@ class OutlierAwareThresholdNode(FewSpikeNode):
             gate = gate.clamp(min=-self.clamp_value, max=self.clamp_value)
         signs = torch.sign(gate).detach()
         magnitude = gate.abs()
-        normal = self._run_table(magnitude, self.theta, self.h, self.d, return_sequence)
-        outlier = self._run_table(
-            magnitude,
-            self.outlier_theta,
-            self.outlier_h,
-            self.outlier_d,
-            return_sequence,
-        )
         mask = magnitude <= self.split_threshold
+        v = magnitude
+        y_seq = []
+        y = None
+        for theta_k, h_k, d_k, outlier_theta_k, outlier_h_k, outlier_d_k in zip(
+            self.theta.unbind(0),
+            self.h.unbind(0),
+            self.d.unbind(0),
+            self.outlier_theta.unbind(0),
+            self.outlier_h.unbind(0),
+            self.outlier_d.unbind(0),
+        ):
+            z = self.surrogate_function(v - torch.where(mask, theta_k, outlier_theta_k))
+            weighted_spike = torch.where(mask, d_k, outlier_d_k) * z
+            if return_sequence:
+                y_seq.append(weighted_spike)
+            else:
+                if y is None:
+                    y = torch.zeros_like(gate)
+                y = y + weighted_spike
+            v = v - torch.where(mask, h_k, outlier_h_k) * z
         if return_sequence:
-            mask = mask.unsqueeze(0)
             signs = signs.unsqueeze(0)
-        return torch.where(mask, normal, outlier) * signs
+            return torch.stack(y_seq, dim=0) * signs
+        return y * signs
 
     def extra_repr(self) -> str:
         return super().extra_repr() + (
@@ -456,7 +470,7 @@ class HGNode(FewSpikeNode):
         self,
         tables: Sequence[FewSpikeTable],
         gate_thresholds: TensorLike1D,
-        surrogate_function: surrogate.SurrogateFunctionBase = surrogate.Sigmoid(),
+        surrogate_function: Optional[surrogate.SurrogateFunctionBase] = None,
         step_mode: str = "s",
     ):
         r"""
@@ -561,25 +575,24 @@ class HGNode(FewSpikeNode):
         self, gate: torch.Tensor, return_sequence: bool
     ) -> torch.Tensor:
         region_ids = torch.bucketize(gate.detach(), self.gate_thresholds)
-        y = self._run_table(
-            gate,
-            self.region_theta[0],
-            self.region_h[0],
-            self.region_d[0],
-            return_sequence,
-        )
-        for i in range(1, self.region_theta.shape[0]):
-            region_y = self._run_table(
-                gate,
-                self.region_theta[i],
-                self.region_h[i],
-                self.region_d[i],
-                return_sequence,
-            )
-            mask = region_ids == i
+        v = gate
+        y_seq = []
+        y = None
+        for k in range(self.K):
+            theta_k = self.region_theta[:, k][region_ids]
+            h_k = self.region_h[:, k][region_ids]
+            d_k = self.region_d[:, k][region_ids]
+            z = self.surrogate_function(v - theta_k)
+            weighted_spike = d_k * z
             if return_sequence:
-                mask = mask.unsqueeze(0)
-            y = torch.where(mask, region_y, y)
+                y_seq.append(weighted_spike)
+            else:
+                if y is None:
+                    y = torch.zeros_like(gate)
+                y = y + weighted_spike
+            v = v - h_k * z
+        if return_sequence:
+            return torch.stack(y_seq, dim=0)
         return y
 
     def extra_repr(self) -> str:

--- a/spikingjelly/activation_based/neuron/few_spike.py
+++ b/spikingjelly/activation_based/neuron/few_spike.py
@@ -1,0 +1,589 @@
+from typing import Sequence, Union, Optional
+
+import torch
+import torch.nn as nn
+
+from .. import base, surrogate
+
+
+__all__ = [
+    "FewSpikeTable",
+    "FewSpikeNode",
+    "OutlierAwareThresholdNode",
+    "HGNode",
+]
+
+
+TensorLike1D = Union[torch.Tensor, Sequence[float]]
+
+
+def _as_float_1d_tensor(name: str, value: TensorLike1D) -> torch.Tensor:
+    tensor = torch.as_tensor(value)
+    if tensor.dim() != 1:
+        shape = tuple(tensor.shape)
+        raise ValueError(
+            f"{name} must be a 1-D tensor or sequence, but got shape {shape}."
+        )
+    if tensor.numel() == 0:
+        raise ValueError(f"{name} must be non-empty.")
+    if torch.is_complex(tensor):
+        raise TypeError(f"{name} must be a real-valued tensor or sequence.")
+    if not torch.is_floating_point(tensor):
+        tensor = tensor.to(torch.get_default_dtype())
+    if not torch.isfinite(tensor).all():
+        raise ValueError(f"{name} must contain only finite values.")
+    return tensor.detach().clone()
+
+
+def _check_table_length(name: str, table: "FewSpikeTable", K: int):
+    if not isinstance(table, FewSpikeTable):
+        raise TypeError(
+            f"{name} must be FewSpikeTable, but got {type(table).__name__}."
+        )
+    if table.K != K:
+        raise ValueError(f"{name}.K must be {K}, but got {table.K}.")
+
+
+class FewSpikeTable:
+    def __init__(
+        self,
+        theta: TensorLike1D,
+        h: TensorLike1D,
+        d: TensorLike1D,
+    ):
+        r"""
+        **API Language** - :ref:`中文 <FewSpikeTable.__init__-cn>` | :ref:`English <FewSpikeTable.__init__-en>`
+
+        ----
+
+        .. _FewSpikeTable.__init__-cn:
+
+        * **中文**
+
+        Few-Spike 神经元的编码表。该对象只保存一维浮点配置，不是
+        :class:`torch.nn.Module`。当它传入 :class:`FewSpikeNode` 或其子类时，
+        ``theta``、``h``、``d`` 会被注册为 buffer，因此会跟随模块的
+        ``device`` 和 ``dtype`` 迁移。
+
+        :param theta: 长度为 ``K`` 的阈值序列，形状为 ``[K]``。
+        :type theta: Union[torch.Tensor, Sequence[float]]
+        :param h: 长度为 ``K`` 的膜电位扣减序列，形状为 ``[K]``。
+        :type h: Union[torch.Tensor, Sequence[float]]
+        :param d: 长度为 ``K`` 的输出权重序列，形状为 ``[K]``。
+        :type d: Union[torch.Tensor, Sequence[float]]
+        :raises ValueError: 当任一参数不是一维、为空、shape 不一致或包含非有限值时抛出。
+        :raises TypeError: 当任一参数为复数张量或复数序列时抛出。
+
+        ----
+
+        .. _FewSpikeTable.__init__-en:
+
+        * **English**
+
+        Coding table for Few-Spike neurons. This object only stores 1-D floating
+        point configuration and is not a :class:`torch.nn.Module`. When passed to
+        :class:`FewSpikeNode` or its subclasses, ``theta``, ``h`` and ``d`` are
+        registered as buffers, so they follow module ``device`` and ``dtype``
+        conversions.
+
+        :param theta: Threshold sequence with length ``K`` and shape ``[K]``.
+        :type theta: Union[torch.Tensor, Sequence[float]]
+        :param h: Membrane subtraction sequence with length ``K`` and shape ``[K]``.
+        :type h: Union[torch.Tensor, Sequence[float]]
+        :param d: Output weight sequence with length ``K`` and shape ``[K]``.
+        :type d: Union[torch.Tensor, Sequence[float]]
+        :raises ValueError: Raised when any argument is not 1-D, is empty,
+            has inconsistent shape, or contains non-finite values.
+        :raises TypeError: Raised when any argument is complex-valued.
+        """
+        self.theta = _as_float_1d_tensor("theta", theta)
+        self.h = _as_float_1d_tensor("h", h)
+        self.d = _as_float_1d_tensor("d", d)
+        if self.theta.shape != self.h.shape or self.theta.shape != self.d.shape:
+            raise ValueError(
+                "theta, h and d must have the same shape, but got "
+                f"{tuple(self.theta.shape)}, {tuple(self.h.shape)}, "
+                f"{tuple(self.d.shape)}."
+            )
+
+    @property
+    def K(self) -> int:
+        return self.theta.numel()
+
+
+class FewSpikeNode(nn.Module, base.StepModule):
+    r"""
+    **API Language** - :ref:`中文 <FewSpikeNode-cn>` | :ref:`English <FewSpikeNode-en>`
+
+    ----
+
+    .. _FewSpikeNode-cn:
+
+    * **中文**
+
+    Memoryless Few-Spike 神经元。该模块支持 ``step_mode="s"`` 和
+    ``step_mode="m"``，但不继承 :class:`MemoryModule` 或 ``BaseNode``，也不保存
+    跨 ``forward`` 的膜电位状态。
+
+    单步模式输入 ``x`` 的形状为 ``[...]``，表示已经聚合好的 gate input / 初始膜电位；
+    输出形状为 ``[...]``。多步模式输入 ``x_seq`` 的形状必须为 ``[K, ...]``，第 0 维
+    长度必须等于编码表长度 ``K``；模块先计算 ``x_seq.sum(0)`` 作为初始膜电位，再输出
+    weighted spike sequence，形状为 ``[K, ...]``。多步模式不会在输出端自动聚合。
+
+    输入必须为浮点 tensor。编码表参数注册为 buffer，会随模块 ``to(device/dtype)`` 迁移；
+    若输入 dtype 与 buffer dtype 不同，遵循 PyTorch 的 dtype promotion 规则。
+
+    ----
+
+    .. _FewSpikeNode-en:
+
+    * **English**
+
+    A memoryless Few-Spike neuron. This module supports ``step_mode="s"`` and
+    ``step_mode="m"``, but does not inherit :class:`MemoryModule` or ``BaseNode``
+    and does not store membrane potential across ``forward`` calls.
+
+    In single-step mode, input ``x`` has shape ``[...]`` and is interpreted as an
+    already accumulated gate input / initial membrane potential; output shape is
+    ``[...]``. In multi-step mode, input ``x_seq`` must have shape ``[K, ...]``
+    whose leading dimension equals the coding table length ``K``; the module first
+    uses ``x_seq.sum(0)`` as the initial membrane potential and returns a weighted
+    spike sequence with shape ``[K, ...]``. Multi-step mode does not aggregate the
+    output sequence.
+
+    Inputs must be floating point tensors. Coding table parameters are registered
+    as buffers and follow module ``to(device/dtype)`` conversions. If the input
+    dtype differs from the buffer dtype, PyTorch dtype promotion rules apply.
+    """
+
+    def __init__(
+        self,
+        table: FewSpikeTable,
+        surrogate_function: surrogate.SurrogateFunctionBase = surrogate.Sigmoid(),
+        step_mode: str = "s",
+    ):
+        r"""
+        :param table: Few-Spike 编码表 / Few-Spike coding table.
+        :type table: FewSpikeTable
+        :param surrogate_function: 替代梯度函数 / surrogate function for spike generation.
+        :type surrogate_function: surrogate.SurrogateFunctionBase
+        :param step_mode: 步进模式，``"s"`` 或 ``"m"`` / step mode, ``"s"`` or ``"m"``.
+        :type step_mode: str
+        :raises TypeError: 当 ``table`` 不是 :class:`FewSpikeTable` 时抛出 /
+            raised when ``table`` is not :class:`FewSpikeTable`.
+        :raises ValueError: 当 ``step_mode`` 非法时抛出 /
+            raised when ``step_mode`` is invalid.
+        """
+        super().__init__()
+        if not isinstance(table, FewSpikeTable):
+            raise TypeError(
+                f"table must be FewSpikeTable, but got {type(table).__name__}."
+            )
+        self.register_buffer("theta", table.theta.clone())
+        self.register_buffer("h", table.h.clone())
+        self.register_buffer("d", table.d.clone())
+        self.surrogate_function = surrogate_function
+        self.step_mode = step_mode
+
+    @property
+    def K(self) -> int:
+        return self.theta.numel()
+
+    def _check_input(self, x: torch.Tensor, name: str):
+        if not isinstance(x, torch.Tensor):
+            raise TypeError(f"{name} must be a torch.Tensor.")
+        if not torch.is_floating_point(x):
+            raise TypeError(f"{name} must be a floating point tensor.")
+
+    def _check_multi_step_input(self, x_seq: torch.Tensor):
+        self._check_input(x_seq, "x_seq")
+        if x_seq.dim() < 1:
+            raise ValueError(
+                "x_seq must have at least one dimension and shape [K, ...]."
+            )
+        if x_seq.shape[0] != self.K:
+            raise ValueError(
+                f"x_seq.shape[0] must equal K={self.K}, but got {x_seq.shape[0]}."
+            )
+
+    def _run_table(
+        self,
+        gate: torch.Tensor,
+        theta: torch.Tensor,
+        h: torch.Tensor,
+        d: torch.Tensor,
+        return_sequence: bool,
+    ) -> torch.Tensor:
+        v = gate
+        y_seq = []
+        y = None
+        for k in range(theta.numel()):
+            z = self.surrogate_function(v - theta[k])
+            weighted_spike = d[k] * z
+            if return_sequence:
+                y_seq.append(weighted_spike)
+            else:
+                if y is None:
+                    y = torch.zeros_like(gate)
+                y = y + weighted_spike
+            v = v - h[k] * z
+        if return_sequence:
+            return torch.stack(y_seq, dim=0)
+        return y
+
+    def _forward_from_gate(
+        self, gate: torch.Tensor, return_sequence: bool
+    ) -> torch.Tensor:
+        return self._run_table(gate, self.theta, self.h, self.d, return_sequence)
+
+    def single_step_forward(self, x: torch.Tensor) -> torch.Tensor:
+        r"""
+        **API Language** - :ref:`中文 <FewSpikeNode.single_step_forward-cn>` | :ref:`English <FewSpikeNode.single_step_forward-en>`
+
+        ----
+
+        .. _FewSpikeNode.single_step_forward-cn:
+
+        * **中文**
+
+        单步前向传播。``x`` 的形状为 ``[...]``，表示聚合后的 gate input；
+        返回形状为 ``[...]`` 的数值输出。
+
+        :param x: 浮点输入张量，形状为 ``[...]``。
+        :type x: torch.Tensor
+        :return: 单步输出张量，形状为 ``[...]``。
+        :rtype: torch.Tensor
+        :raises TypeError: 当 ``x`` 不是浮点 tensor 时抛出。
+
+        ----
+
+        .. _FewSpikeNode.single_step_forward-en:
+
+        * **English**
+
+        Single-step forward. ``x`` has shape ``[...]`` and is interpreted as the
+        accumulated gate input; returns a numeric output with shape ``[...]``.
+
+        :param x: Floating point input tensor with shape ``[...]``.
+        :type x: torch.Tensor
+        :return: Single-step output tensor with shape ``[...]``.
+        :rtype: torch.Tensor
+        :raises TypeError: Raised when ``x`` is not a floating point tensor.
+        """
+        self._check_input(x, "x")
+        return self._forward_from_gate(x, return_sequence=False)
+
+    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+        r"""
+        **API Language** - :ref:`中文 <FewSpikeNode.multi_step_forward-cn>` | :ref:`English <FewSpikeNode.multi_step_forward-en>`
+
+        ----
+
+        .. _FewSpikeNode.multi_step_forward-cn:
+
+        * **中文**
+
+        多步前向传播。``x_seq`` 的形状必须为 ``[K, ...]``。模块先对时间维求和得到
+        初始膜电位，再返回形状为 ``[K, ...]`` 的 weighted spike sequence。返回值不是
+        binary raw spikes，也不会在输出端自动 ``sum(0)``。
+
+        :param x_seq: 浮点输入序列，形状为 ``[K, ...]``。
+        :type x_seq: torch.Tensor
+        :return: weighted spike sequence，形状为 ``[K, ...]``。
+        :rtype: torch.Tensor
+        :raises TypeError: 当 ``x_seq`` 不是浮点 tensor 时抛出。
+        :raises ValueError: 当 ``x_seq.shape[0] != K`` 时抛出。
+
+        ----
+
+        .. _FewSpikeNode.multi_step_forward-en:
+
+        * **English**
+
+        Multi-step forward. ``x_seq`` must have shape ``[K, ...]``. The module
+        first sums the time dimension to get the initial membrane potential and
+        then returns a weighted spike sequence with shape ``[K, ...]``. The return
+        value is not binary raw spikes and is not automatically aggregated by
+        ``sum(0)``.
+
+        :param x_seq: Floating point input sequence with shape ``[K, ...]``.
+        :type x_seq: torch.Tensor
+        :return: Weighted spike sequence with shape ``[K, ...]``.
+        :rtype: torch.Tensor
+        :raises TypeError: Raised when ``x_seq`` is not a floating point tensor.
+        :raises ValueError: Raised when ``x_seq.shape[0] != K``.
+        """
+        self._check_multi_step_input(x_seq)
+        return self._forward_from_gate(x_seq.sum(dim=0), return_sequence=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.step_mode == "s":
+            return self.single_step_forward(x)
+        elif self.step_mode == "m":
+            return self.multi_step_forward(x)
+        else:
+            raise ValueError(self.step_mode)
+
+    def extra_repr(self) -> str:
+        return f"K={self.K}, step_mode={self.step_mode}"
+
+
+class OutlierAwareThresholdNode(FewSpikeNode):
+    def __init__(
+        self,
+        table: FewSpikeTable,
+        outlier_table: FewSpikeTable,
+        split_threshold: float,
+        clamp_value: Optional[float] = None,
+        surrogate_function: surrogate.SurrogateFunctionBase = surrogate.Sigmoid(),
+        step_mode: str = "s",
+    ):
+        r"""
+        **API Language** - :ref:`中文 <OutlierAwareThresholdNode.__init__-cn>` | :ref:`English <OutlierAwareThresholdNode.__init__-en>`
+
+        ----
+
+        .. _OutlierAwareThresholdNode.__init__-cn:
+
+        * **中文**
+
+        通用 outlier-aware thresholding Few-Spike 节点。输入 gate 先按 ``clamp_value`` 截断
+        （若提供），再分解为 ``sign`` 和幅值。幅值 ``<= split_threshold`` 的元素使用
+        ``table``，幅值 ``> split_threshold`` 的元素使用 ``outlier_table``，最后恢复
+        ``sign``；因此 gate 为 0 的元素输出为 0。单步模式输入输出形状为 ``[...]``；
+        多步模式输入形状必须为 ``[K, ...]``，输出形状为 ``[K, ...]``。两个 table 的
+        ``K`` 必须相同。
+
+        该类复现 LAS 中 OAT 分支的 sign / clamp / split 结构，但不内置 LAS 的
+        ``mtn`` 表生成或 fast floor-quantized 路径。若需要与 LAS 数值完全一致，应显式
+        传入对应的 :class:`FewSpikeTable`。
+
+        :param table: normal 分支编码表。
+        :type table: FewSpikeTable
+        :param outlier_table: outlier 分支编码表。
+        :type outlier_table: FewSpikeTable
+        :param split_threshold: normal 与 outlier 分支的非负幅值分界。
+        :type split_threshold: float
+        :param clamp_value: 可选的对称截断幅值。若不为 ``None``，必须大于等于 ``split_threshold``。
+        :type clamp_value: Optional[float]
+        :param surrogate_function: 替代梯度函数。
+        :type surrogate_function: surrogate.SurrogateFunctionBase
+        :param step_mode: 步进模式，``"s"`` 或 ``"m"``。
+        :type step_mode: str
+        :raises ValueError: 当 table 长度不一致或阈值参数非法时抛出。
+
+        ----
+
+        .. _OutlierAwareThresholdNode.__init__-en:
+
+        * **English**
+
+        Generic outlier-aware thresholding Few-Spike node. The input gate is first clamped
+        by ``clamp_value`` when provided, then decomposed into ``sign`` and
+        magnitude. Elements with magnitude ``<= split_threshold`` use ``table``;
+        elements with magnitude ``> split_threshold`` use ``outlier_table``; the
+        sign is restored afterward, so zero-valued gate elements map to zero output.
+        Single-step input and output shape is ``[...]``; multi-step input must have
+        shape ``[K, ...]`` and output shape is ``[K, ...]``. Both tables must have
+        the same ``K``.
+
+        This class reproduces the sign / clamp / split structure of LAS OAT
+        branches, but does not include LAS ``mtn`` table generation or the fast
+        floor-quantized path. Pass matching :class:`FewSpikeTable` objects explicitly
+        when exact LAS numeric behavior is required.
+
+        :param table: Coding table for the normal branch.
+        :type table: FewSpikeTable
+        :param outlier_table: Coding table for the outlier branch.
+        :type outlier_table: FewSpikeTable
+        :param split_threshold: Non-negative magnitude threshold between normal
+            and outlier branches.
+        :type split_threshold: float
+        :param clamp_value: Optional symmetric clamp magnitude. If not ``None``,
+            it must be no smaller than ``split_threshold``.
+        :type clamp_value: Optional[float]
+        :param surrogate_function: Surrogate function.
+        :type surrogate_function: surrogate.SurrogateFunctionBase
+        :param step_mode: Step mode, ``"s"`` or ``"m"``.
+        :type step_mode: str
+        :raises ValueError: Raised when table lengths are inconsistent or threshold
+            arguments are invalid.
+        """
+        _check_table_length("outlier_table", outlier_table, table.K)
+        if split_threshold < 0:
+            raise ValueError("split_threshold must be non-negative.")
+        if clamp_value is not None:
+            if clamp_value <= 0:
+                raise ValueError("clamp_value must be positive when it is not None.")
+            if clamp_value < split_threshold:
+                raise ValueError("clamp_value must be no smaller than split_threshold.")
+        super().__init__(table, surrogate_function, step_mode)
+        self.register_buffer("outlier_theta", outlier_table.theta.clone())
+        self.register_buffer("outlier_h", outlier_table.h.clone())
+        self.register_buffer("outlier_d", outlier_table.d.clone())
+        self.split_threshold = float(split_threshold)
+        self.clamp_value = None if clamp_value is None else float(clamp_value)
+
+    def _forward_from_gate(
+        self, gate: torch.Tensor, return_sequence: bool
+    ) -> torch.Tensor:
+        if self.clamp_value is not None:
+            gate = gate.clamp(min=-self.clamp_value, max=self.clamp_value)
+        signs = torch.sign(gate).detach()
+        magnitude = gate.abs()
+        normal = self._run_table(magnitude, self.theta, self.h, self.d, return_sequence)
+        outlier = self._run_table(
+            magnitude,
+            self.outlier_theta,
+            self.outlier_h,
+            self.outlier_d,
+            return_sequence,
+        )
+        mask = magnitude <= self.split_threshold
+        if return_sequence:
+            mask = mask.unsqueeze(0)
+            signs = signs.unsqueeze(0)
+        return torch.where(mask, normal, outlier) * signs
+
+    def extra_repr(self) -> str:
+        return super().extra_repr() + (
+            f", split_threshold={self.split_threshold}, clamp_value={self.clamp_value}"
+        )
+
+
+class HGNode(FewSpikeNode):
+    def __init__(
+        self,
+        tables: Sequence[FewSpikeTable],
+        gate_thresholds: TensorLike1D,
+        surrogate_function: surrogate.SurrogateFunctionBase = surrogate.Sigmoid(),
+        step_mode: str = "s",
+    ):
+        r"""
+        **API Language** - :ref:`中文 <HGNode.__init__-cn>` | :ref:`English <HGNode.__init__-en>`
+
+        ----
+
+        .. _HGNode.__init__-cn:
+
+        * **中文**
+
+        通用 hierarchically-gated Few-Spike 节点。``gate_thresholds`` 按升序把 gate input
+        划分为 ``len(tables)`` 个区间：第一个 table 处理 ``x <= gate_thresholds[0]``，
+        中间 table 处理相邻阈值之间的元素，最后一个 table 处理
+        ``x > gate_thresholds[-1]``。所有 table 的 ``K`` 必须一致。单步模式输入输出形状
+        为 ``[...]``；多步模式输入形状必须为 ``[K, ...]``，输出形状为 ``[K, ...]``。
+
+        该类提供区域路由形式的通用层级门控，不声明与 LAS 中某个具体 fitted activation
+        模块完全等价。需要复现特定 LAS 非线性时，应使用与该非线性对应的 table 和阈值。
+
+        :param tables: 每个 gate 区间对应的编码表序列，长度至少为 1。
+        :type tables: Sequence[FewSpikeTable]
+        :param gate_thresholds: 升序一维阈值序列，长度必须为 ``len(tables) - 1``。
+        :type gate_thresholds: Union[torch.Tensor, Sequence[float]]
+        :param surrogate_function: 替代梯度函数。
+        :type surrogate_function: surrogate.SurrogateFunctionBase
+        :param step_mode: 步进模式，``"s"`` 或 ``"m"``。
+        :type step_mode: str
+        :raises ValueError: 当 table 数量、阈值数量、阈值顺序或 table 长度非法时抛出。
+        :raises TypeError: 当 ``tables`` 中存在非 :class:`FewSpikeTable` 对象时抛出。
+
+        ----
+
+        .. _HGNode.__init__-en:
+
+        * **English**
+
+        Generic hierarchically-gated Few-Spike node. ``gate_thresholds`` partitions the
+        gate input into ``len(tables)`` regions in ascending order: the first table
+        handles ``x <= gate_thresholds[0]``, middle tables handle adjacent
+        threshold intervals, and the last table handles ``x > gate_thresholds[-1]``.
+        All tables must have the same ``K``. Single-step input and output shape is
+        ``[...]``; multi-step input must have shape ``[K, ...]`` and output shape is
+        ``[K, ...]``.
+
+        This class provides a generic region-routing hierarchical gate and does not
+        claim exact equivalence to a specific LAS fitted activation module. To
+        reproduce a specific LAS nonlinearity, use tables and thresholds matching
+        that nonlinearity.
+
+        :param tables: Coding tables for gate regions, with length at least 1.
+        :type tables: Sequence[FewSpikeTable]
+        :param gate_thresholds: Ascending 1-D threshold sequence with length
+            ``len(tables) - 1``.
+        :type gate_thresholds: Union[torch.Tensor, Sequence[float]]
+        :param surrogate_function: Surrogate function.
+        :type surrogate_function: surrogate.SurrogateFunctionBase
+        :param step_mode: Step mode, ``"s"`` or ``"m"``.
+        :type step_mode: str
+        :raises ValueError: Raised when table count, threshold count, threshold
+            order, or table lengths are invalid.
+        :raises TypeError: Raised when an item in ``tables`` is not
+            :class:`FewSpikeTable`.
+        """
+        if len(tables) == 0:
+            raise ValueError("tables must contain at least one FewSpikeTable.")
+        for i, table in enumerate(tables):
+            if not isinstance(table, FewSpikeTable):
+                raise TypeError(
+                    f"tables[{i}] must be FewSpikeTable, "
+                    f"but got {type(table).__name__}."
+                )
+        K = tables[0].K
+        for i, table in enumerate(tables[1:], start=1):
+            _check_table_length(f"tables[{i}]", table, K)
+
+        if len(tables) == 1 and torch.as_tensor(gate_thresholds).numel() == 0:
+            thresholds = torch.empty(
+                0,
+                dtype=tables[0].theta.dtype,
+                device=tables[0].theta.device,
+            )
+        else:
+            thresholds = _as_float_1d_tensor("gate_thresholds", gate_thresholds)
+        if thresholds.numel() != len(tables) - 1:
+            raise ValueError(
+                "gate_thresholds must have length len(tables) - 1, but got "
+                f"{thresholds.numel()} for {len(tables)} tables."
+            )
+        if thresholds.numel() > 1 and not torch.all(thresholds[1:] > thresholds[:-1]):
+            raise ValueError("gate_thresholds must be strictly increasing.")
+
+        super().__init__(tables[0], surrogate_function, step_mode)
+        self.register_buffer(
+            "region_theta", torch.stack([table.theta for table in tables])
+        )
+        self.register_buffer("region_h", torch.stack([table.h for table in tables]))
+        self.register_buffer("region_d", torch.stack([table.d for table in tables]))
+        self.register_buffer("gate_thresholds", thresholds)
+
+    def _forward_from_gate(
+        self, gate: torch.Tensor, return_sequence: bool
+    ) -> torch.Tensor:
+        region_ids = torch.bucketize(gate.detach(), self.gate_thresholds)
+        y = self._run_table(
+            gate,
+            self.region_theta[0],
+            self.region_h[0],
+            self.region_d[0],
+            return_sequence,
+        )
+        for i in range(1, self.region_theta.shape[0]):
+            region_y = self._run_table(
+                gate,
+                self.region_theta[i],
+                self.region_h[i],
+                self.region_d[i],
+                return_sequence,
+            )
+            mask = region_ids == i
+            if return_sequence:
+                mask = mask.unsqueeze(0)
+            y = torch.where(mask, region_y, y)
+        return y
+
+    def extra_repr(self) -> str:
+        return super().extra_repr() + (
+            f", regions={self.region_theta.shape[0]}, "
+            f"gate_thresholds={self.gate_thresholds}"
+        )

--- a/test/activation_based/test_ann2snn_operators.py
+++ b/test/activation_based/test_ann2snn_operators.py
@@ -1532,6 +1532,12 @@ class TestTDMultiheadAttention:
             assert torch.isfinite(parameter.grad).all()
 
     def test_rejects_invalid_constructor_arguments(self):
+        with pytest.raises(ValueError, match="embed_dim must be positive"):
+            TDMultiheadAttention(embed_dim=0, num_heads=2)
+        with pytest.raises(ValueError, match="num_heads must be positive"):
+            TDMultiheadAttention(embed_dim=8, num_heads=0)
+        with pytest.raises(ValueError, match="num_heads must be positive"):
+            TDMultiheadAttention(embed_dim=8, num_heads=-2)
         with pytest.raises(ValueError, match="divisible"):
             TDMultiheadAttention(embed_dim=7, num_heads=2)
         with pytest.raises(ValueError, match="dropout=0.0"):

--- a/test/activation_based/test_ann2snn_operators.py
+++ b/test/activation_based/test_ann2snn_operators.py
@@ -1406,6 +1406,32 @@ class TestTDMultiheadAttention:
 
         assert torch.allclose(y_seq[0], y, atol=1e-5, rtol=1e-5)
 
+    def test_direct_step_entrypoints_force_projection_step_modes(self):
+        x = torch.randn(2, 4, 8)
+        op = TDMultiheadAttention(embed_dim=8, num_heads=2)
+
+        y, _ = op.single_step_forward(x, x, x)
+        expected = _ann_mha_reference(op, x, x, x)
+
+        assert torch.allclose(y, expected, atol=1e-5, rtol=1e-5)
+        assert op.step_mode == "m"
+        assert op.q_proj.step_mode == "m"
+        assert op.k_proj.step_mode == "m"
+        assert op.v_proj.step_mode == "m"
+        assert op.out_proj.step_mode == "m"
+
+        functional.set_step_mode(op, "s")
+        x_seq = x.unsqueeze(0)
+        y_seq, _ = op.multi_step_forward(x_seq, x_seq, x_seq)
+        expected_seq = _mha_cumulative_reference(op, x_seq, x_seq, x_seq)
+
+        assert torch.allclose(y_seq, expected_seq, atol=1e-5, rtol=1e-5)
+        assert op.step_mode == "s"
+        assert op.q_proj.step_mode == "s"
+        assert op.k_proj.step_mode == "s"
+        assert op.v_proj.step_mode == "s"
+        assert op.out_proj.step_mode == "s"
+
     def test_parent_step_mode_propagates_to_projection_modules_and_uses_hooks(self):
         x = torch.randn(2, 4, 8)
         op = TDMultiheadAttention(embed_dim=8, num_heads=2)
@@ -1562,6 +1588,24 @@ class TestTDMultiheadAttention:
 
         with pytest.raises(ValueError, match="\\[T, batch, seq, embed_dim\\]"):
             op(torch.randn(4, 5, 8), torch.randn(4, 5, 8), torch.randn(4, 5, 8))
+
+    def test_rejects_mismatched_attention_batch_dimensions(self):
+        op = TDMultiheadAttention(embed_dim=8, num_heads=2)
+
+        with pytest.raises(ValueError, match="leading dimensions"):
+            op(
+                torch.randn(4, 2, 3, 8),
+                torch.randn(4, 1, 5, 8),
+                torch.randn(4, 1, 5, 8),
+            )
+
+        functional.set_step_mode(op, "s")
+        with pytest.raises(ValueError, match="leading dimensions"):
+            op(
+                torch.randn(2, 3, 8),
+                torch.randn(1, 5, 8),
+                torch.randn(1, 5, 8),
+            )
 
     def test_rejects_unsupported_forward_options(self):
         op = TDMultiheadAttention(embed_dim=8, num_heads=2)

--- a/test/activation_based/test_ann2snn_operators.py
+++ b/test/activation_based/test_ann2snn_operators.py
@@ -1623,6 +1623,27 @@ class TestTDMultiheadAttention:
             )
         with pytest.raises(ValueError, match="average_attn_weights=False"):
             op(x_seq, x_seq, x_seq, need_weights=False, average_attn_weights=False)
+        with pytest.raises(ValueError, match="attn_mask when is_causal=True"):
+            op(
+                x_seq,
+                x_seq,
+                x_seq,
+                need_weights=False,
+                attn_mask=torch.zeros(5, 5),
+                is_causal=True,
+            )
+
+        functional.set_step_mode(op, "s")
+        x = torch.randn(2, 5, 8)
+        with pytest.raises(ValueError, match="attn_mask when is_causal=True"):
+            op(
+                x,
+                x,
+                x,
+                need_weights=False,
+                attn_mask=torch.zeros(5, 5),
+                is_causal=True,
+            )
 
     def test_extra_repr(self):
         op = TDMultiheadAttention(embed_dim=8, num_heads=2)

--- a/test/activation_based/test_ann2snn_operators.py
+++ b/test/activation_based/test_ann2snn_operators.py
@@ -1390,6 +1390,10 @@ class TestTDMultiheadAttention:
         x = torch.randn(2, 4, 8)
         op = TDMultiheadAttention(embed_dim=8, num_heads=2, step_mode="s")
 
+        assert op.q_proj.step_mode == "s"
+        assert op.k_proj.step_mode == "s"
+        assert op.v_proj.step_mode == "s"
+        assert op.out_proj.step_mode == "s"
         y, weights = op(x, x, x, need_weights=False)
         expected = _ann_mha_reference(op, x, x, x)
 

--- a/test/activation_based/test_ann2snn_operators.py
+++ b/test/activation_based/test_ann2snn_operators.py
@@ -1438,7 +1438,7 @@ class TestTDMultiheadAttention:
         hook_calls = []
 
         op.q_proj.register_forward_hook(
-            lambda module, inputs, output: hook_calls.append(module.step_mode)
+            lambda module, inputs, output: hook_calls.append(output.shape)
         )
         op.step_mode = "s"
         assert op.q_proj.step_mode == "s"
@@ -1449,7 +1449,7 @@ class TestTDMultiheadAttention:
         expected = _ann_mha_reference(op, x, x, x)
 
         assert torch.allclose(y, expected, atol=1e-5, rtol=1e-5)
-        assert hook_calls == ["s"]
+        assert hook_calls == [x.shape]
 
         functional.set_step_mode(op, "m")
         assert op.q_proj.step_mode == "m"

--- a/test/activation_based/test_ann2snn_operators.py
+++ b/test/activation_based/test_ann2snn_operators.py
@@ -1432,14 +1432,10 @@ class TestTDMultiheadAttention:
         assert op.v_proj.step_mode == "s"
         assert op.out_proj.step_mode == "s"
 
-    def test_parent_step_mode_propagates_to_projection_modules_and_uses_hooks(self):
+    def test_parent_step_mode_propagates_to_projection_modules(self):
         x = torch.randn(2, 4, 8)
         op = TDMultiheadAttention(embed_dim=8, num_heads=2)
-        hook_calls = []
 
-        op.q_proj.register_forward_hook(
-            lambda module, inputs, output: hook_calls.append(output.shape)
-        )
         op.step_mode = "s"
         assert op.q_proj.step_mode == "s"
         assert op.k_proj.step_mode == "s"
@@ -1449,7 +1445,6 @@ class TestTDMultiheadAttention:
         expected = _ann_mha_reference(op, x, x, x)
 
         assert torch.allclose(y, expected, atol=1e-5, rtol=1e-5)
-        assert hook_calls == [x.shape]
 
         functional.set_step_mode(op, "m")
         assert op.q_proj.step_mode == "m"

--- a/test/activation_based/test_ann2snn_operators.py
+++ b/test/activation_based/test_ann2snn_operators.py
@@ -1406,18 +1406,30 @@ class TestTDMultiheadAttention:
 
         assert torch.allclose(y_seq[0], y, atol=1e-5, rtol=1e-5)
 
-    def test_parent_step_mode_does_not_depend_on_projection_step_modes(self):
-        # The parent explicitly calls projection single/multi-step methods, so
-        # parent step_mode alone controls this composite operator's path.
+    def test_parent_step_mode_propagates_to_projection_modules_and_uses_hooks(self):
         x = torch.randn(2, 4, 8)
         op = TDMultiheadAttention(embed_dim=8, num_heads=2)
+        hook_calls = []
 
+        op.q_proj.register_forward_hook(
+            lambda module, inputs, output: hook_calls.append(module.step_mode)
+        )
         op.step_mode = "s"
-        assert op.q_proj.step_mode == "m"
+        assert op.q_proj.step_mode == "s"
+        assert op.k_proj.step_mode == "s"
+        assert op.v_proj.step_mode == "s"
+        assert op.out_proj.step_mode == "s"
         y, _ = op(x, x, x)
         expected = _ann_mha_reference(op, x, x, x)
 
         assert torch.allclose(y, expected, atol=1e-5, rtol=1e-5)
+        assert hook_calls == ["s"]
+
+        functional.set_step_mode(op, "m")
+        assert op.q_proj.step_mode == "m"
+        assert op.k_proj.step_mode == "m"
+        assert op.v_proj.step_mode == "m"
+        assert op.out_proj.step_mode == "m"
 
     def test_cross_attention_matches_ann_mha(self):
         query_seq = torch.randn(4, 2, 3, 8)

--- a/test/activation_based/test_ann2snn_operators.py
+++ b/test/activation_based/test_ann2snn_operators.py
@@ -2,9 +2,11 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from spikingjelly.activation_based import base, functional
 from spikingjelly.activation_based.ann2snn.operators import (
     SNNElementWiseProduct,
     SNNMatrixOperator,
+    TDModule,
     TDGELU,
     TDLayerNorm,
     TDLinear,
@@ -88,6 +90,44 @@ def _snn_matrix_loop_reference(a_seq, b_seq):
     return torch.stack(y_seq)
 
 
+def _ann_mha_reference(td_op, query, key, value, **kwargs):
+    ann_op = torch.nn.MultiheadAttention(
+        td_op.embed_dim,
+        td_op.num_heads,
+        dropout=0.0,
+        bias=td_op.q_proj.bias is not None,
+        batch_first=True,
+    )
+    _copy_td_mha_to_ann(td_op, ann_op)
+    return ann_op(query, key, value, need_weights=False, **kwargs)[0]
+
+
+def test_td_modules_support_step_mode_switching():
+    modules = [
+        TDSoftmax(),
+        TDLayerNorm(3),
+        TDGELU(),
+        TDLinear(3, 4),
+        SNNMatrixOperator(),
+        SNNElementWiseProduct(),
+        TDScaledDotProductAttention(),
+        TDMultiheadAttention(embed_dim=4, num_heads=2),
+    ]
+
+    for module in modules:
+        assert isinstance(module, TDModule)
+        assert isinstance(module, base.StepModule)
+        assert module.step_mode == "m"
+
+        functional.set_step_mode(module, "s")
+        assert module.step_mode == "s"
+        functional.set_step_mode(module, "m")
+        assert module.step_mode == "m"
+
+        with pytest.raises(ValueError, match="step_mode can only be"):
+            module.step_mode = "bogus"
+
+
 class TestTDSoftmax:
     def test_shape_is_preserved(self):
         x_seq = torch.randn(4, 2, 3)
@@ -132,6 +172,31 @@ class TestTDSoftmax:
 
         assert y_seq.shape == x_seq.shape
         assert torch.allclose(y_seq[0], torch.softmax(x_seq[0], dim=-1))
+
+    def test_single_step_mode_matches_softmax(self):
+        x = torch.randn(2, 3)
+        op = TDSoftmax(dim=0, step_mode="s")
+
+        y = op(x)
+
+        assert torch.allclose(y, torch.softmax(x, dim=0))
+
+    def test_single_step_softmax_scalar_matches_torch(self):
+        x = torch.tensor(1.0)
+        op = TDSoftmax(dim=0, step_mode="s")
+
+        y = op(x)
+
+        assert torch.allclose(y, torch.softmax(x, dim=0))
+
+    def test_one_step_multi_step_matches_single_step(self):
+        x = torch.randn(2, 3)
+        op = TDSoftmax(dim=-1)
+
+        y_seq = op(x.unsqueeze(0))
+        functional.set_step_mode(op, "s")
+
+        assert torch.allclose(y_seq[0], op(x))
 
     def test_gradients_flow(self):
         x_seq = torch.randn(3, 4, requires_grad=True)
@@ -265,6 +330,24 @@ class TestTDLayerNorm:
 
         assert y_seq.shape == x_seq.shape
         assert torch.allclose(y_seq[0], expected)
+
+    def test_single_step_mode_matches_layer_norm(self):
+        x = torch.randn(2, 3)
+        op = TDLayerNorm(normalized_shape=3, step_mode="s")
+
+        y = op(x)
+        expected = F.layer_norm(x, op.normalized_shape, op.weight, op.bias, op.eps)
+
+        assert torch.allclose(y, expected)
+
+    def test_one_step_multi_step_matches_single_step(self):
+        x = torch.randn(2, 3)
+        op = TDLayerNorm(normalized_shape=3)
+
+        y_seq = op(x.unsqueeze(0))
+        functional.set_step_mode(op, "s")
+
+        assert torch.allclose(y_seq[0], op(x))
 
     def test_gradients_flow_to_input_and_affine_parameters(self):
         x_seq = torch.randn(3, 4, requires_grad=True)
@@ -400,6 +483,23 @@ class TestTDGELU:
         assert y_seq.shape == x_seq.shape
         assert torch.allclose(y_seq[0], expected)
 
+    def test_single_step_mode_matches_gelu(self):
+        x = torch.randn(2, 3)
+        op = TDGELU(approximate="tanh", step_mode="s")
+
+        y = op(x)
+
+        assert torch.allclose(y, F.gelu(x, approximate="tanh"))
+
+    def test_one_step_multi_step_matches_single_step(self):
+        x = torch.randn(2, 3)
+        op = TDGELU(approximate="tanh")
+
+        y_seq = op(x.unsqueeze(0))
+        functional.set_step_mode(op, "s")
+
+        assert torch.allclose(y_seq[0], op(x))
+
     def test_gradients_flow(self):
         x_seq = torch.randn(3, 4)
         op = TDGELU()
@@ -512,6 +612,24 @@ class TestTDLinear:
         assert y_seq.shape == (1, 2, 5)
         assert torch.allclose(y_seq[0], expected, atol=1e-6, rtol=1e-6)
 
+    def test_single_step_mode_matches_linear(self):
+        x = torch.randn(2, 3)
+        op = TDLinear(3, 5, step_mode="s")
+
+        y = op(x)
+        expected = F.linear(x, op.weight, op.bias)
+
+        assert torch.allclose(y, expected, atol=1e-6, rtol=1e-6)
+
+    def test_one_step_multi_step_matches_single_step(self):
+        x = torch.randn(2, 3)
+        op = TDLinear(3, 5)
+
+        y_seq = op(x.unsqueeze(0))
+        functional.set_step_mode(op, "s")
+
+        assert torch.allclose(y_seq[0], op(x), atol=1e-6, rtol=1e-6)
+
     def test_bias_is_not_repeatedly_accumulated(self):
         x_seq = torch.zeros(4, 2, 3)
         op = TDLinear(3, 5)
@@ -623,6 +741,25 @@ class TestSNNMatrixOperator:
 
         assert torch.allclose(y_seq.cumsum(dim=0), expected, atol=1e-6, rtol=1e-6)
 
+    def test_single_step_mode_matches_matmul(self):
+        a = torch.randn(2, 3, 4)
+        b = torch.randn(2, 4, 6)
+        op = SNNMatrixOperator(step_mode="s")
+
+        y = op(a, b)
+
+        assert torch.allclose(y, torch.matmul(a, b))
+
+    def test_one_step_multi_step_matches_single_step(self):
+        a = torch.randn(2, 3, 4)
+        b = torch.randn(2, 4, 6)
+        op = SNNMatrixOperator()
+
+        y_seq = op(a.unsqueeze(0), b.unsqueeze(0))
+        functional.set_step_mode(op, "s")
+
+        assert torch.allclose(y_seq[0], op(a, b))
+
     def test_preserves_cross_time_terms(self):
         a_seq = torch.tensor([[[[1.0]]], [[[2.0]]]])
         b_seq = torch.tensor([[[[3.0]]], [[[5.0]]]])
@@ -733,6 +870,25 @@ class TestSNNElementWiseProduct:
 
         assert torch.allclose(y_seq.sum(dim=0), expected, atol=1e-6, rtol=1e-6)
 
+    def test_single_step_mode_matches_product(self):
+        a = torch.randn(2, 3)
+        b = torch.randn(2, 3)
+        op = SNNElementWiseProduct(step_mode="s")
+
+        y = op(a, b)
+
+        assert torch.allclose(y, a * b)
+
+    def test_one_step_multi_step_matches_single_step(self):
+        a = torch.randn(2, 3)
+        b = torch.randn(2, 3)
+        op = SNNElementWiseProduct()
+
+        y_seq = op(a.unsqueeze(0), b.unsqueeze(0))
+        functional.set_step_mode(op, "s")
+
+        assert torch.allclose(y_seq[0], op(a, b))
+
     def test_supports_broadcast(self):
         a_seq = torch.randn(4, 2, 3)
         b_seq = torch.randn(4, 1, 3)
@@ -821,6 +977,65 @@ def test_few_spike_tdlinear_few_spike_sequence_smoke():
     assert torch.isfinite(x_seq.grad).all()
 
 
+def test_td_mlp_switches_between_single_and_multi_step_modes():
+    model = torch.nn.Sequential(
+        TDLinear(4, 6),
+        TDGELU(),
+        TDLinear(6, 3),
+    )
+
+    functional.set_step_mode(model, "s")
+    x = torch.randn(2, 4)
+    y = model(x)
+    expected = model[2].single_step_forward(
+        model[1].single_step_forward(model[0].single_step_forward(x))
+    )
+
+    assert y.shape == (2, 3)
+    assert torch.allclose(y, expected, atol=1e-6, rtol=1e-6)
+
+    functional.set_step_mode(model, "m")
+    x_seq = torch.randn(5, 2, 4)
+    y_seq = model(x_seq)
+    functional.set_step_mode(model, "s")
+    expected_from_total = model(x_seq.sum(dim=0))
+
+    assert y_seq.shape == (5, 2, 3)
+    assert torch.allclose(y_seq.sum(dim=0), expected_from_total, atol=1e-6, rtol=1e-6)
+
+
+def test_few_spike_tdlinear_few_spike_switches_step_modes():
+    table = neuron.FewSpikeTable(
+        theta=torch.tensor([0.25, 0.5, 0.75]),
+        h=torch.tensor([0.1, 0.1, 0.1]),
+        d=torch.tensor([1.0, 2.0, 4.0]),
+    )
+    model = torch.nn.Sequential(
+        neuron.FewSpikeNode(
+            table, surrogate_function=surrogate.Sigmoid(), step_mode="m"
+        ),
+        TDLinear(4, 5),
+        neuron.FewSpikeNode(
+            table, surrogate_function=surrogate.Sigmoid(), step_mode="m"
+        ),
+    )
+
+    functional.set_step_mode(model, "s")
+    x = torch.randn(2, 4)
+    y = model(x)
+
+    assert y.shape == (2, 5)
+
+    functional.set_step_mode(model, "m")
+    x_seq = torch.randn(table.K, 2, 4)
+    y_seq = model(x_seq)
+    functional.set_step_mode(model, "s")
+    expected_from_total = model(x_seq.sum(dim=0))
+
+    assert y_seq.shape == (table.K, 2, 5)
+    assert torch.allclose(y_seq.sum(dim=0), expected_from_total, atol=1e-5, rtol=1e-5)
+
+
 class TestTDScaledDotProductAttention:
     # CUDA SDPA kernels can differ from the reference cumulative comparison by
     # a few ulps, especially after cumsum and temporal differencing. Keep this
@@ -896,6 +1111,28 @@ class TestTDScaledDotProductAttention:
 
         assert y_seq.shape == (1, 2, 3, 7)
         assert torch.allclose(y_seq[0], expected, atol=1e-6, rtol=1e-6)
+
+    def test_single_step_mode_matches_sdpa(self):
+        q = torch.randn(2, 3, 4)
+        k = torch.randn(2, 5, 4)
+        v = torch.randn(2, 5, 7)
+        op = TDScaledDotProductAttention(step_mode="s")
+
+        y = op(q, k, v)
+        expected = F.scaled_dot_product_attention(q, k, v, dropout_p=0.0)
+
+        assert torch.allclose(y, expected, atol=1e-6, rtol=1e-6)
+
+    def test_one_step_multi_step_matches_single_step(self):
+        q = torch.randn(2, 3, 4)
+        k = torch.randn(2, 5, 4)
+        v = torch.randn(2, 5, 7)
+        op = TDScaledDotProductAttention()
+
+        y_seq = op(q.unsqueeze(0), k.unsqueeze(0), v.unsqueeze(0))
+        functional.set_step_mode(op, "s")
+
+        assert torch.allclose(y_seq[0], op(q, k, v), atol=1e-6, rtol=1e-6)
 
     def test_multi_head_style_shape(self):
         q_seq = torch.randn(4, 2, 3, 5, 4)
@@ -1148,6 +1385,39 @@ class TestTDMultiheadAttention:
         expected = _mha_cumulative_reference(op, x_seq, x_seq, x_seq)
 
         assert torch.allclose(y_seq, expected, atol=1e-5, rtol=1e-5)
+
+    def test_single_step_mode_matches_ann_mha(self):
+        x = torch.randn(2, 4, 8)
+        op = TDMultiheadAttention(embed_dim=8, num_heads=2, step_mode="s")
+
+        y, weights = op(x, x, x, need_weights=False)
+        expected = _ann_mha_reference(op, x, x, x)
+
+        assert weights is None
+        assert torch.allclose(y, expected, atol=1e-5, rtol=1e-5)
+
+    def test_one_step_multi_step_matches_single_step(self):
+        x = torch.randn(2, 4, 8)
+        op = TDMultiheadAttention(embed_dim=8, num_heads=2)
+
+        y_seq, _ = op(x.unsqueeze(0), x.unsqueeze(0), x.unsqueeze(0))
+        functional.set_step_mode(op, "s")
+        y, _ = op(x, x, x)
+
+        assert torch.allclose(y_seq[0], y, atol=1e-5, rtol=1e-5)
+
+    def test_parent_step_mode_does_not_depend_on_projection_step_modes(self):
+        # The parent explicitly calls projection single/multi-step methods, so
+        # parent step_mode alone controls this composite operator's path.
+        x = torch.randn(2, 4, 8)
+        op = TDMultiheadAttention(embed_dim=8, num_heads=2)
+
+        op.step_mode = "s"
+        assert op.q_proj.step_mode == "m"
+        y, _ = op(x, x, x)
+        expected = _ann_mha_reference(op, x, x, x)
+
+        assert torch.allclose(y, expected, atol=1e-5, rtol=1e-5)
 
     def test_cross_attention_matches_ann_mha(self):
         query_seq = torch.randn(4, 2, 3, 8)

--- a/test/activation_based/test_ann2snn_operators.py
+++ b/test/activation_based/test_ann2snn_operators.py
@@ -3,6 +3,8 @@ import torch
 import torch.nn.functional as F
 
 from spikingjelly.activation_based.ann2snn.operators import (
+    SNNElementWiseProduct,
+    SNNMatrixOperator,
     TDGELU,
     TDLayerNorm,
     TDLinear,
@@ -10,6 +12,7 @@ from spikingjelly.activation_based.ann2snn.operators import (
     TDScaledDotProductAttention,
     TDSoftmax,
 )
+from spikingjelly.activation_based import neuron, surrogate
 
 
 def _copy_td_mha_to_ann(td_op, ann_op):
@@ -58,6 +61,31 @@ def _mha_cumulative_reference(td_op, query_seq, key_seq, value_seq, **kwargs):
             for t in range(query_seq.shape[0])
         ]
     )
+
+
+def _temporal_difference(y_cum):
+    y_seq = torch.empty_like(y_cum)
+    y_seq[0] = y_cum[0]
+    y_seq[1:] = y_cum[1:] - y_cum[:-1]
+    return y_seq
+
+
+def _snn_matrix_loop_reference(a_seq, b_seq):
+    a_sum = None
+    b_sum = None
+    y_seq = []
+    for t in range(a_seq.shape[0]):
+        if t == 0:
+            a_sum = a_seq[t]
+            b_sum = b_seq[t]
+            y_t = torch.matmul(a_sum, b_sum)
+        else:
+            prev = torch.matmul(a_sum, b_sum)
+            a_sum = a_sum + a_seq[t]
+            b_sum = b_sum + b_seq[t]
+            y_t = torch.matmul(a_sum, b_sum) - prev
+        y_seq.append(y_t)
+    return torch.stack(y_seq)
 
 
 class TestTDSoftmax:
@@ -456,6 +484,15 @@ class TestTDLinear:
 
         assert torch.allclose(y_seq.cumsum(dim=0), expected, atol=1e-6, rtol=1e-6)
 
+    def test_bias_false_matches_per_timestep_linear(self):
+        x_seq = torch.randn(5, 2, 4)
+        op = TDLinear(4, 3, bias=False)
+
+        y_seq = op(x_seq)
+        expected = F.linear(x_seq, op.weight, None)
+
+        assert torch.allclose(y_seq, expected, atol=1e-6, rtol=1e-6)
+
     def test_final_cumulative_output_matches_linear_on_total_input(self):
         x_seq = torch.randn(6, 3, 5)
         op = TDLinear(5, 4)
@@ -463,9 +500,7 @@ class TestTDLinear:
         y_seq = op(x_seq)
         expected = F.linear(x_seq.sum(dim=0), op.weight, op.bias)
 
-        assert torch.allclose(
-            y_seq.cumsum(dim=0)[-1], expected, atol=1e-6, rtol=1e-6
-        )
+        assert torch.allclose(y_seq.cumsum(dim=0)[-1], expected, atol=1e-6, rtol=1e-6)
 
     def test_single_timestep_returns_linear_of_input(self):
         x_seq = torch.randn(1, 2, 3)
@@ -487,6 +522,9 @@ class TestTDLinear:
         y_seq = op(x_seq)
 
         assert torch.allclose(y_seq.cumsum(dim=0)[-1], op.bias.expand(2, 5))
+        assert not torch.allclose(
+            y_seq.cumsum(dim=0)[-1], op.bias.mul(x_seq.shape[0]).expand(2, 5)
+        )
         assert torch.allclose(y_seq[0], op.bias.expand(2, 5))
         assert torch.count_nonzero(y_seq[1:]) == 0
 
@@ -561,6 +599,226 @@ class TestTDLinear:
         op = TDLinear(3, 5, bias=False)
 
         assert op.extra_repr() == "in_features=3, out_features=5, bias=False"
+
+
+class TestSNNMatrixOperator:
+    def test_matches_las_style_loop_reference(self):
+        a_seq = torch.randn(4, 2, 3, 5, dtype=torch.float64)
+        b_seq = torch.randn(4, 2, 5, 7, dtype=torch.float64)
+        op = SNNMatrixOperator()
+
+        y_seq = op(a_seq, b_seq)
+        expected = _snn_matrix_loop_reference(a_seq, b_seq)
+
+        assert y_seq.shape == (4, 2, 3, 7)
+        assert torch.allclose(y_seq, expected, atol=1e-6, rtol=1e-6)
+
+    def test_cumulative_output_matches_matmul_on_cumulative_inputs(self):
+        a_seq = torch.randn(5, 2, 3, 4)
+        b_seq = torch.randn(5, 2, 4, 6)
+        op = SNNMatrixOperator()
+
+        y_seq = op(a_seq, b_seq)
+        expected = torch.matmul(a_seq.cumsum(dim=0), b_seq.cumsum(dim=0))
+
+        assert torch.allclose(y_seq.cumsum(dim=0), expected, atol=1e-6, rtol=1e-6)
+
+    def test_preserves_cross_time_terms(self):
+        a_seq = torch.tensor([[[[1.0]]], [[[2.0]]]])
+        b_seq = torch.tensor([[[[3.0]]], [[[5.0]]]])
+        op = SNNMatrixOperator()
+
+        y_seq = op(a_seq, b_seq)
+        naive = torch.matmul(a_seq, b_seq)
+
+        assert torch.allclose(y_seq.flatten(), torch.tensor([3.0, 21.0]))
+        assert not torch.allclose(y_seq, naive)
+
+    def test_supports_broadcast_batch_dimensions(self):
+        a_seq = torch.randn(3, 2, 4, 5)
+        b_seq = torch.randn(3, 1, 5, 6)
+        op = SNNMatrixOperator()
+
+        y_seq = op(a_seq, b_seq)
+        expected = torch.matmul(a_seq.cumsum(dim=0), b_seq.cumsum(dim=0))
+
+        assert y_seq.shape == (3, 2, 4, 6)
+        assert torch.allclose(y_seq.cumsum(dim=0), expected, atol=1e-6, rtol=1e-6)
+
+    def test_broadcast_ignores_time_dimension_when_ranks_differ(self):
+        a_seq = torch.randn(3, 2, 4, 5)
+        b_seq = torch.randn(3, 5, 6)
+        op = SNNMatrixOperator()
+
+        y_seq = op(a_seq, b_seq)
+        expected = torch.matmul(a_seq.cumsum(dim=0), b_seq.unsqueeze(1).cumsum(dim=0))
+
+        assert y_seq.shape == (3, 2, 4, 6)
+        assert torch.allclose(y_seq.cumsum(dim=0), expected, atol=1e-6, rtol=1e-6)
+
+    def test_gradients_match_reference(self):
+        a_seq = torch.randn(3, 2, 4, 5)
+        b_seq = torch.randn(3, 2, 5, 6)
+        op = SNNMatrixOperator()
+
+        a_ref = a_seq.clone().detach().requires_grad_()
+        b_ref = b_seq.clone().detach().requires_grad_()
+        y_ref = _temporal_difference(
+            torch.matmul(a_ref.cumsum(dim=0), b_ref.cumsum(dim=0))
+        )
+        y_ref.square().sum().backward()
+
+        a_seq = a_seq.clone().detach().requires_grad_()
+        b_seq = b_seq.clone().detach().requires_grad_()
+        y_seq = op(a_seq, b_seq)
+        y_seq.square().sum().backward()
+
+        assert torch.allclose(a_seq.grad, a_ref.grad, atol=1e-6, rtol=1e-6)
+        assert torch.allclose(b_seq.grad, b_ref.grad, atol=1e-6, rtol=1e-6)
+
+    def test_preserves_dtype_and_device(self):
+        a_seq = torch.randn(3, 2, 4, 5, dtype=torch.float64)
+        b_seq = torch.randn(3, 2, 5, 6, dtype=torch.float64)
+        op = SNNMatrixOperator()
+
+        y_seq = op(a_seq, b_seq)
+
+        assert y_seq.dtype == torch.float64
+        assert y_seq.device == a_seq.device
+
+    def test_rejects_mismatched_time_lengths(self):
+        op = SNNMatrixOperator()
+
+        with pytest.raises(ValueError, match="same time length"):
+            op(torch.randn(3, 2, 4, 5), torch.randn(4, 2, 5, 6))
+
+    def test_rejects_empty_time_dimension(self):
+        op = SNNMatrixOperator()
+
+        with pytest.raises(ValueError, match="non-empty time dimension"):
+            op(torch.empty(0, 2, 4, 5), torch.empty(0, 2, 5, 6))
+
+    def test_rejects_inputs_with_too_few_dimensions(self):
+        op = SNNMatrixOperator()
+
+        with pytest.raises(ValueError, match="at least 3 dimensions"):
+            op(torch.randn(3, 5), torch.randn(3, 5, 6))
+
+    def test_invalid_matmul_shape_raises_from_pytorch(self):
+        op = SNNMatrixOperator()
+
+        with pytest.raises(RuntimeError):
+            op(torch.randn(3, 2, 4, 5), torch.randn(3, 2, 4, 6))
+
+
+class TestSNNElementWiseProduct:
+    def test_cumulative_output_matches_product_on_cumulative_inputs(self):
+        a_seq = torch.randn(5, 2, 3)
+        b_seq = torch.randn(5, 2, 3)
+        op = SNNElementWiseProduct()
+
+        y_seq = op(a_seq, b_seq)
+        expected = a_seq.cumsum(dim=0) * b_seq.cumsum(dim=0)
+
+        assert y_seq.shape == (5, 2, 3)
+        assert torch.allclose(y_seq.cumsum(dim=0), expected, atol=1e-6, rtol=1e-6)
+
+    def test_final_sum_matches_product_of_final_sums(self):
+        a_seq = torch.randn(5, 2, 3)
+        b_seq = torch.randn(5, 2, 3)
+        op = SNNElementWiseProduct()
+
+        y_seq = op(a_seq, b_seq)
+        expected = a_seq.sum(dim=0) * b_seq.sum(dim=0)
+
+        assert torch.allclose(y_seq.sum(dim=0), expected, atol=1e-6, rtol=1e-6)
+
+    def test_supports_broadcast(self):
+        a_seq = torch.randn(4, 2, 3)
+        b_seq = torch.randn(4, 1, 3)
+        op = SNNElementWiseProduct()
+
+        y_seq = op(a_seq, b_seq)
+        expected = a_seq.cumsum(dim=0) * b_seq.cumsum(dim=0)
+
+        assert y_seq.shape == (4, 2, 3)
+        assert torch.allclose(y_seq.cumsum(dim=0), expected, atol=1e-6, rtol=1e-6)
+
+    def test_broadcast_ignores_time_dimension_when_ranks_differ(self):
+        a_seq = torch.randn(4, 2, 3)
+        b_seq = torch.randn(4, 3)
+        op = SNNElementWiseProduct()
+
+        y_seq = op(a_seq, b_seq)
+        expected = a_seq.cumsum(dim=0) * b_seq.unsqueeze(1).cumsum(dim=0)
+
+        assert y_seq.shape == (4, 2, 3)
+        assert torch.allclose(y_seq.cumsum(dim=0), expected, atol=1e-6, rtol=1e-6)
+
+    def test_gradients_match_reference(self):
+        a_seq = torch.randn(3, 2, 4)
+        b_seq = torch.randn(3, 2, 4)
+        op = SNNElementWiseProduct()
+
+        a_ref = a_seq.clone().detach().requires_grad_()
+        b_ref = b_seq.clone().detach().requires_grad_()
+        y_ref = _temporal_difference(a_ref.cumsum(dim=0) * b_ref.cumsum(dim=0))
+        y_ref.square().sum().backward()
+
+        a_seq = a_seq.clone().detach().requires_grad_()
+        b_seq = b_seq.clone().detach().requires_grad_()
+        y_seq = op(a_seq, b_seq)
+        y_seq.square().sum().backward()
+
+        assert torch.allclose(a_seq.grad, a_ref.grad, atol=1e-6, rtol=1e-6)
+        assert torch.allclose(b_seq.grad, b_ref.grad, atol=1e-6, rtol=1e-6)
+
+    def test_rejects_mismatched_time_lengths(self):
+        op = SNNElementWiseProduct()
+
+        with pytest.raises(ValueError, match="same time length"):
+            op(torch.randn(3, 2, 4), torch.randn(4, 2, 4))
+
+    def test_rejects_empty_time_dimension(self):
+        op = SNNElementWiseProduct()
+
+        with pytest.raises(ValueError, match="non-empty time dimension"):
+            op(torch.empty(0, 2, 4), torch.empty(0, 2, 4))
+
+    def test_rejects_one_dimensional_input(self):
+        op = SNNElementWiseProduct()
+
+        with pytest.raises(ValueError, match="at least 2 dimensions"):
+            op(torch.randn(3), torch.randn(3))
+
+    def test_invalid_broadcast_shape_raises_from_pytorch(self):
+        op = SNNElementWiseProduct()
+
+        with pytest.raises(RuntimeError):
+            op(torch.randn(3, 2, 4), torch.randn(3, 2, 5))
+
+
+def test_few_spike_tdlinear_few_spike_sequence_smoke():
+    table = neuron.FewSpikeTable(
+        theta=torch.tensor([0.25, 0.5, 0.75]),
+        h=torch.tensor([0.1, 0.1, 0.1]),
+        d=torch.tensor([1.0, 2.0, 4.0]),
+    )
+    first = neuron.FewSpikeNode(
+        table, surrogate_function=surrogate.Sigmoid(), step_mode="m"
+    )
+    linear = TDLinear(4, 5)
+    second = neuron.FewSpikeNode(
+        table, surrogate_function=surrogate.Sigmoid(), step_mode="m"
+    )
+    x_seq = torch.randn(table.K, 2, 4, requires_grad=True)
+
+    y_seq = second(linear(first(x_seq)))
+    y_seq.sum().backward()
+
+    assert y_seq.shape == (table.K, 2, 5)
+    assert x_seq.grad is not None
+    assert torch.isfinite(x_seq.grad).all()
 
 
 class TestTDScaledDotProductAttention:
@@ -880,9 +1138,7 @@ class TestTDMultiheadAttention:
         y_seq, _ = op(x_seq, x_seq, x_seq, need_weights=False)
         expected = _mha_cumulative_reference(op, x_seq, x_seq, x_seq)[-1]
 
-        assert torch.allclose(
-            y_seq.cumsum(dim=0)[-1], expected, atol=1e-5, rtol=1e-5
-        )
+        assert torch.allclose(y_seq.cumsum(dim=0)[-1], expected, atol=1e-5, rtol=1e-5)
 
     def test_single_timestep_matches_ann_mha(self):
         x_seq = torch.randn(1, 2, 4, 8)
@@ -918,7 +1174,9 @@ class TestTDMultiheadAttention:
         op = TDMultiheadAttention(embed_dim=8, num_heads=2)
 
         y_seq, _ = op(x_seq, x_seq, x_seq, attn_mask=attn_mask, need_weights=False)
-        expected = _mha_cumulative_reference(op, x_seq, x_seq, x_seq, attn_mask=attn_mask)
+        expected = _mha_cumulative_reference(
+            op, x_seq, x_seq, x_seq, attn_mask=attn_mask
+        )
 
         assert torch.allclose(y_seq.cumsum(dim=0), expected, atol=1e-5, rtol=1e-5)
 
@@ -935,7 +1193,9 @@ class TestTDMultiheadAttention:
         op = TDMultiheadAttention(embed_dim=8, num_heads=2)
 
         y_seq, _ = op(x_seq, x_seq, x_seq, attn_mask=attn_mask, need_weights=False)
-        expected = _mha_cumulative_reference(op, x_seq, x_seq, x_seq, attn_mask=attn_mask)
+        expected = _mha_cumulative_reference(
+            op, x_seq, x_seq, x_seq, attn_mask=attn_mask
+        )
 
         assert torch.allclose(y_seq.cumsum(dim=0), expected, atol=1e-5, rtol=1e-5)
 

--- a/test/activation_based/test_few_spike_neuron.py
+++ b/test/activation_based/test_few_spike_neuron.py
@@ -232,6 +232,29 @@ def test_outlier_aware_threshold_node_multi_step_and_validation():
         )
 
 
+def test_outlier_aware_threshold_node_aligns_outlier_buffer_dtype():
+    normal = neuron.FewSpikeTable(
+        theta=torch.tensor([0.25, 0.5], dtype=torch.float64),
+        h=torch.tensor([0.1, 0.1], dtype=torch.float64),
+        d=torch.tensor([1.0, 2.0], dtype=torch.float64),
+    )
+    outlier = neuron.FewSpikeTable(
+        theta=torch.tensor([0.25, 0.5], dtype=torch.float32),
+        h=torch.tensor([0.1, 0.1], dtype=torch.float32),
+        d=torch.tensor([10.0, 20.0], dtype=torch.float32),
+    )
+
+    node = neuron.OutlierAwareThresholdNode(
+        table=normal,
+        outlier_table=outlier,
+        split_threshold=0.5,
+    )
+
+    assert node.outlier_theta.dtype == node.theta.dtype == torch.float64
+    assert node.outlier_h.dtype == node.h.dtype == torch.float64
+    assert node.outlier_d.dtype == node.d.dtype == torch.float64
+
+
 def test_hg_node_matches_region_reference():
     table_low = neuron.FewSpikeTable(theta=[0.25, 0.5], h=[0.1, 0.1], d=[1.0, 2.0])
     table_mid = neuron.FewSpikeTable(theta=[0.25, 0.5], h=[0.1, 0.1], d=[10.0, 20.0])
@@ -289,3 +312,25 @@ def test_hg_node_multi_step_and_validation():
         neuron.HGNode(tables=[table0, table1], gate_thresholds=[1.0, 2.0])
     with pytest.raises(ValueError):
         neuron.HGNode(tables=[table0, table1, table0], gate_thresholds=[1.0, 0.0])
+
+
+def test_hg_node_does_not_register_unused_parent_table_buffers():
+    table0 = neuron.FewSpikeTable(theta=[0.25, 0.5], h=[0.1, 0.1], d=[1.0, 2.0])
+    table1 = neuron.FewSpikeTable(theta=[0.25, 0.5], h=[0.1, 0.1], d=[10.0, 20.0])
+
+    node = neuron.HGNode(
+        tables=[table0, table1],
+        gate_thresholds=[0.0],
+    )
+
+    assert isinstance(node, neuron.FewSpikeNode)
+    assert node.K == table0.K
+    assert "theta" not in node.state_dict()
+    assert "h" not in node.state_dict()
+    assert "d" not in node.state_dict()
+    assert set(node.state_dict().keys()) == {
+        "region_theta",
+        "region_h",
+        "region_d",
+        "gate_thresholds",
+    }

--- a/test/activation_based/test_few_spike_neuron.py
+++ b/test/activation_based/test_few_spike_neuron.py
@@ -204,6 +204,25 @@ def test_outlier_aware_threshold_node_multi_step_and_validation():
             outlier_table=_table(),
             split_threshold=0.5,
         )
+    with pytest.raises(TypeError, match="table must be FewSpikeTable"):
+        neuron.OutlierAwareThresholdNode(
+            table=torch.tensor([1.0]),
+            outlier_table=outlier,
+            split_threshold=0.5,
+        )
+    with pytest.raises(ValueError, match="finite non-negative"):
+        neuron.OutlierAwareThresholdNode(
+            table=normal,
+            outlier_table=outlier,
+            split_threshold=float("nan"),
+        )
+    with pytest.raises(ValueError, match="finite and positive"):
+        neuron.OutlierAwareThresholdNode(
+            table=normal,
+            outlier_table=outlier,
+            split_threshold=0.5,
+            clamp_value=float("inf"),
+        )
     with pytest.raises(ValueError):
         neuron.OutlierAwareThresholdNode(
             table=normal,

--- a/test/activation_based/test_few_spike_neuron.py
+++ b/test/activation_based/test_few_spike_neuron.py
@@ -135,6 +135,25 @@ def test_few_spike_node_autograd_and_dtype_follow_module_buffers():
     assert torch.isfinite(x.grad).all()
 
 
+def test_few_spike_nodes_do_not_share_default_surrogate_module():
+    table = _table()
+    node0 = neuron.FewSpikeNode(table=table)
+    node1 = neuron.FewSpikeNode(table=table)
+    oat = neuron.OutlierAwareThresholdNode(
+        table=neuron.FewSpikeTable(theta=[0.25], h=[0.1], d=[1.0]),
+        outlier_table=neuron.FewSpikeTable(theta=[0.25], h=[0.1], d=[2.0]),
+        split_threshold=1.0,
+    )
+    hg = neuron.HGNode(
+        tables=[neuron.FewSpikeTable(theta=[0.25], h=[0.1], d=[1.0])],
+        gate_thresholds=[],
+    )
+
+    assert node0.surrogate_function is not node1.surrogate_function
+    assert node0.surrogate_function is not oat.surrogate_function
+    assert node0.surrogate_function is not hg.surrogate_function
+
+
 def test_outlier_aware_threshold_node_matches_reference():
     normal = neuron.FewSpikeTable(theta=[0.25, 0.5], h=[0.1, 0.1], d=[1.0, 2.0])
     outlier = neuron.FewSpikeTable(theta=[0.25, 0.5], h=[0.1, 0.1], d=[10.0, 20.0])

--- a/test/activation_based/test_few_spike_neuron.py
+++ b/test/activation_based/test_few_spike_neuron.py
@@ -1,0 +1,253 @@
+import pytest
+import torch
+
+from spikingjelly.activation_based import functional, neuron, surrogate
+
+
+def _table(scale=1.0):
+    return neuron.FewSpikeTable(
+        theta=torch.tensor([0.25, 0.5, 0.75]) * scale,
+        h=torch.tensor([0.2, 0.3, 0.4]) * scale,
+        d=torch.tensor([1.0, 2.0, 4.0]) * scale,
+    )
+
+
+def _manual_fs(gate, table, surrogate_function, return_sequence):
+    theta = table.theta.to(device=gate.device, dtype=gate.dtype)
+    h = table.h.to(device=gate.device, dtype=gate.dtype)
+    d = table.d.to(device=gate.device, dtype=gate.dtype)
+    v = gate
+    y = torch.zeros_like(gate)
+    y_seq = []
+    for k in range(table.K):
+        z = surrogate_function(v - theta[k])
+        weighted_spike = d[k] * z
+        if return_sequence:
+            y_seq.append(weighted_spike)
+        else:
+            y = y + weighted_spike
+        v = v - h[k] * z
+    if return_sequence:
+        return torch.stack(y_seq)
+    return y
+
+
+def test_few_spike_table_validation():
+    table = _table()
+
+    assert table.K == 3
+    assert table.theta.dtype == torch.float32
+
+    with pytest.raises(ValueError):
+        neuron.FewSpikeTable(theta=[], h=[], d=[])
+    with pytest.raises(ValueError):
+        neuron.FewSpikeTable(theta=[1.0, 2.0], h=[1.0], d=[1.0, 2.0])
+    with pytest.raises(ValueError):
+        neuron.FewSpikeTable(theta=[[1.0]], h=[[1.0]], d=[[1.0]])
+    with pytest.raises(ValueError):
+        neuron.FewSpikeTable(theta=[float("inf")], h=[1.0], d=[1.0])
+    with pytest.raises(TypeError):
+        neuron.FewSpikeTable(theta=torch.tensor([1.0 + 1.0j]), h=[1.0], d=[1.0])
+
+
+def test_few_spike_node_single_step_matches_reference():
+    table = _table()
+    sg = surrogate.DeterministicPass()
+    node = neuron.FewSpikeNode(
+        table=table,
+        surrogate_function=sg,
+        step_mode="s",
+    )
+    x = torch.tensor([[0.1, 0.6], [1.2, 2.0]])
+
+    y = node(x)
+    expected = _manual_fs(x, table, sg, return_sequence=False)
+
+    assert torch.allclose(y, expected)
+
+
+def test_few_spike_node_multi_step_shape_and_sum_match_single_step():
+    table = _table()
+    sg = surrogate.DeterministicPass()
+    node = neuron.FewSpikeNode(
+        table=table,
+        surrogate_function=sg,
+        step_mode="m",
+    )
+    x_seq = torch.tensor(
+        [
+            [[0.1, 0.3], [0.2, 0.5]],
+            [[0.2, 0.1], [0.4, 0.3]],
+            [[0.3, 0.4], [0.1, 0.2]],
+        ]
+    )
+
+    y_seq = node(x_seq)
+    expected_seq = _manual_fs(x_seq.sum(0), table, sg, return_sequence=True)
+    single = node.single_step_forward(x_seq.sum(0))
+
+    assert y_seq.shape == x_seq.shape
+    assert torch.allclose(y_seq, expected_seq)
+    assert torch.allclose(y_seq.sum(0), single)
+
+
+def test_few_spike_node_rejects_wrong_multi_step_length_and_non_float_input():
+    node = neuron.FewSpikeNode(table=_table(), step_mode="m")
+
+    with pytest.raises(ValueError):
+        node(torch.ones(2, 4))
+    with pytest.raises(TypeError):
+        node(torch.ones(3, 4, dtype=torch.int64))
+
+
+def test_few_spike_node_is_step_module_and_stateless():
+    node = neuron.FewSpikeNode(
+        table=_table(),
+        surrogate_function=surrogate.DeterministicPass(),
+    )
+    x = torch.tensor([[0.5, 1.0]])
+
+    functional.set_step_mode(node, "s")
+    y0 = node(x)
+    y1 = node(x)
+
+    assert torch.allclose(y0, y1)
+    assert not hasattr(node, "reset")
+
+    functional.set_step_mode(node, "m")
+    x_seq = torch.stack([x, x, x])
+    assert node(x_seq).shape == x_seq.shape
+
+
+def test_few_spike_node_autograd_and_dtype_follow_module_buffers():
+    node = neuron.FewSpikeNode(
+        table=_table(),
+        surrogate_function=surrogate.Sigmoid(),
+    ).to(dtype=torch.float64)
+    x = torch.tensor([[0.9, 1.8]], dtype=torch.float64, requires_grad=True)
+
+    y = node(x)
+    y.sum().backward()
+
+    assert y.dtype == torch.float64
+    assert node.theta.dtype == torch.float64
+    assert x.grad is not None
+    assert torch.isfinite(x.grad).all()
+
+
+def test_outlier_aware_threshold_node_matches_reference():
+    normal = neuron.FewSpikeTable(theta=[0.25, 0.5], h=[0.1, 0.1], d=[1.0, 2.0])
+    outlier = neuron.FewSpikeTable(theta=[0.25, 0.5], h=[0.1, 0.1], d=[10.0, 20.0])
+    sg = surrogate.DeterministicPass()
+    node = neuron.OutlierAwareThresholdNode(
+        table=normal,
+        outlier_table=outlier,
+        split_threshold=1.0,
+        clamp_value=2.0,
+        surrogate_function=sg,
+        step_mode="s",
+    )
+    x = torch.tensor([[-2.5, -0.8, 0.0, 0.9, 1.5]])
+
+    y = node(x)
+    gate = x.clamp(min=-2.0, max=2.0)
+    signs = torch.sign(gate).detach()
+    magnitude = gate.abs()
+    expected = (
+        torch.where(
+            magnitude <= 1.0,
+            _manual_fs(magnitude, normal, sg, return_sequence=False),
+            _manual_fs(magnitude, outlier, sg, return_sequence=False),
+        )
+        * signs
+    )
+
+    assert torch.allclose(y, expected)
+
+
+def test_outlier_aware_threshold_node_multi_step_and_validation():
+    normal = neuron.FewSpikeTable(theta=[0.25, 0.5], h=[0.1, 0.1], d=[1.0, 2.0])
+    outlier = neuron.FewSpikeTable(theta=[0.25, 0.5], h=[0.1, 0.1], d=[10.0, 20.0])
+    node = neuron.OutlierAwareThresholdNode(
+        table=normal,
+        outlier_table=outlier,
+        split_threshold=0.5,
+        surrogate_function=surrogate.DeterministicPass(),
+        step_mode="m",
+    )
+
+    x_seq = torch.tensor([[[-0.2, 0.3]], [[-0.4, 0.5]]])
+
+    assert node(x_seq).shape == x_seq.shape
+    with pytest.raises(ValueError):
+        neuron.OutlierAwareThresholdNode(
+            table=normal,
+            outlier_table=_table(),
+            split_threshold=0.5,
+        )
+    with pytest.raises(ValueError):
+        neuron.OutlierAwareThresholdNode(
+            table=normal,
+            outlier_table=outlier,
+            split_threshold=2.0,
+            clamp_value=1.0,
+        )
+
+
+def test_hg_node_matches_region_reference():
+    table_low = neuron.FewSpikeTable(theta=[0.25, 0.5], h=[0.1, 0.1], d=[1.0, 2.0])
+    table_mid = neuron.FewSpikeTable(theta=[0.25, 0.5], h=[0.1, 0.1], d=[10.0, 20.0])
+    table_high = neuron.FewSpikeTable(theta=[0.25, 0.5], h=[0.1, 0.1], d=[100.0, 200.0])
+    sg = surrogate.DeterministicPass()
+    node = neuron.HGNode(
+        tables=[table_low, table_mid, table_high],
+        gate_thresholds=[0.0, 1.0],
+        surrogate_function=sg,
+        step_mode="s",
+    )
+    x = torch.tensor([[-0.5, 0.5, 1.5]])
+
+    y = node(x)
+    expected = torch.where(
+        x <= 0.0,
+        _manual_fs(x, table_low, sg, return_sequence=False),
+        torch.where(
+            x <= 1.0,
+            _manual_fs(x, table_mid, sg, return_sequence=False),
+            _manual_fs(x, table_high, sg, return_sequence=False),
+        ),
+    )
+
+    assert torch.allclose(y, expected)
+
+
+def test_hg_node_multi_step_and_validation():
+    table0 = neuron.FewSpikeTable(theta=[0.25, 0.5], h=[0.1, 0.1], d=[1.0, 2.0])
+    table1 = neuron.FewSpikeTable(theta=[0.25, 0.5], h=[0.1, 0.1], d=[10.0, 20.0])
+    node = neuron.HGNode(
+        tables=[table0, table1],
+        gate_thresholds=[0.0],
+        surrogate_function=surrogate.DeterministicPass(),
+        step_mode="m",
+    )
+    x_seq = torch.tensor([[[-0.2, 0.2]], [[-0.1, 0.3]]])
+
+    assert node(x_seq).shape == x_seq.shape
+    single_table = neuron.HGNode(
+        tables=[table0],
+        gate_thresholds=[],
+        surrogate_function=surrogate.DeterministicPass(),
+    )
+    x = torch.tensor([[0.2, 0.8]])
+    assert torch.allclose(
+        single_table(x),
+        _manual_fs(x, table0, surrogate.DeterministicPass(), False),
+    )
+    with pytest.raises(ValueError):
+        neuron.HGNode(tables=[], gate_thresholds=[])
+    with pytest.raises(ValueError):
+        neuron.HGNode(tables=[table0, _table()], gate_thresholds=[0.0])
+    with pytest.raises(ValueError):
+        neuron.HGNode(tables=[table0, table1], gate_thresholds=[1.0, 2.0])
+    with pytest.raises(ValueError):
+        neuron.HGNode(tables=[table0, table1, table0], gate_thresholds=[1.0, 0.0])

--- a/test/activation_based/test_few_spike_sequence_attention.py
+++ b/test/activation_based/test_few_spike_sequence_attention.py
@@ -1,0 +1,387 @@
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from spikingjelly.activation_based import neuron, surrogate
+from spikingjelly.activation_based.ann2snn.operators import (
+    SNNElementWiseProduct,
+    SNNMatrixOperator,
+    TDLinear,
+)
+
+
+def _table(scale=1.0):
+    return neuron.FewSpikeTable(
+        theta=torch.tensor([0.25, 0.5, 0.75]) * scale,
+        h=torch.tensor([0.2, 0.3, 0.4]) * scale,
+        d=torch.tensor([1.0, 2.0, 4.0]) * scale,
+    )
+
+
+def _two_step_table(scale=1.0):
+    return neuron.FewSpikeTable(
+        theta=torch.tensor([0.25, 0.5]) * scale,
+        h=torch.tensor([0.1, 0.1]) * scale,
+        d=torch.tensor([1.0, 2.0]) * scale,
+    )
+
+
+def _few_spike_node(table=None, surrogate_function=None):
+    if table is None:
+        table = _table()
+    if surrogate_function is None:
+        surrogate_function = surrogate.DeterministicPass()
+    return neuron.FewSpikeNode(
+        table=table,
+        surrogate_function=surrogate_function,
+        step_mode="m",
+    )
+
+
+def _split_heads(x, num_heads):
+    if x.shape[-1] % num_heads != 0:
+        raise ValueError("embed_dim must be divisible by num_heads.")
+    head_dim = x.shape[-1] // num_heads
+    x = x.reshape(*x.shape[:-1], num_heads, head_dim)
+    return x.transpose(-3, -2)
+
+
+def _merge_heads(x):
+    x = x.transpose(-3, -2).contiguous()
+    return x.reshape(*x.shape[:-2], x.shape[-2] * x.shape[-1])
+
+
+class _FewSpikeSelfAttentionBlock(nn.Module):
+    def __init__(self, embed_dim, num_heads, score_node):
+        super().__init__()
+        if embed_dim % num_heads != 0:
+            raise ValueError("embed_dim must be divisible by num_heads.")
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.q_proj = TDLinear(embed_dim, embed_dim, bias=False)
+        self.k_proj = TDLinear(embed_dim, embed_dim, bias=False)
+        self.v_proj = TDLinear(embed_dim, embed_dim, bias=False)
+        self.score_node = score_node
+        self.matmul = SNNMatrixOperator()
+        self.out_proj = TDLinear(embed_dim, embed_dim, bias=False)
+
+    def _project_sequence(self, x_seq):
+        q_seq = _split_heads(self.q_proj(x_seq), self.num_heads)
+        k_seq = _split_heads(self.k_proj(x_seq), self.num_heads)
+        v_seq = _split_heads(self.v_proj(x_seq), self.num_heads)
+        return q_seq, k_seq, v_seq
+
+    def _score_sequence_from_projected(self, q_seq, k_seq):
+        return self.matmul(q_seq, k_seq.transpose(-1, -2))
+
+    def score_sequence(self, x_seq):
+        q_seq, k_seq, _ = self._project_sequence(x_seq)
+        return self._score_sequence_from_projected(q_seq, k_seq)
+
+    def _encoded_score_sequence_from_projected(self, q_seq, k_seq):
+        return self.score_node(self._score_sequence_from_projected(q_seq, k_seq))
+
+    def encoded_score_sequence(self, x_seq):
+        return self.score_node(self.score_sequence(x_seq))
+
+    def context_sequence(self, x_seq):
+        q_seq, k_seq, v_seq = self._project_sequence(x_seq)
+        score_seq = self._encoded_score_sequence_from_projected(q_seq, k_seq)
+        return self.matmul(score_seq, v_seq)
+
+    def forward(self, x_seq):
+        context_seq = _merge_heads(self.context_sequence(x_seq))
+        return self.out_proj(context_seq)
+
+
+class _FewSpikeGatedMLPBlock(nn.Module):
+    def __init__(self, embed_dim, hidden_features, activation, gate):
+        super().__init__()
+        self.up_proj = TDLinear(embed_dim, hidden_features, bias=False)
+        self.gate_proj = TDLinear(embed_dim, hidden_features, bias=False)
+        self.activation = activation
+        self.gate = gate
+        self.product = SNNElementWiseProduct()
+        self.down_proj = TDLinear(hidden_features, embed_dim, bias=False)
+
+    def forward(self, x_seq):
+        up_seq = self.activation(self.up_proj(x_seq))
+        gate_seq = self.gate(self.gate_proj(x_seq))
+        return self.down_proj(self.product(up_seq, gate_seq))
+
+
+class _TinyFewSpikeDecoderBlock(nn.Module):
+    """Simplified decoder toy: no LayerNorm, Softmax, dropout, mask, or KV-cache."""
+
+    def __init__(
+        self,
+        embed_dim,
+        num_heads,
+        hidden_features,
+        score_node,
+        activation,
+        gate,
+    ):
+        super().__init__()
+        self.attn = _FewSpikeSelfAttentionBlock(embed_dim, num_heads, score_node)
+        self.mlp = _FewSpikeGatedMLPBlock(embed_dim, hidden_features, activation, gate)
+
+    def forward(self, x_seq):
+        x_seq = x_seq + self.attn(x_seq)
+        return x_seq + self.mlp(x_seq)
+
+
+class _TinyFewSpikeDecoderStack(nn.Module):
+    def __init__(self, layers):
+        super().__init__()
+        self.layers = nn.ModuleList(layers)
+
+    def forward(self, x_seq):
+        for layer in self.layers:
+            x_seq = layer(x_seq)
+        return x_seq
+
+
+def _single_step_attention_reference_from_analog(block, x):
+    q = _split_heads(F.linear(x, block.q_proj.weight, None), block.num_heads)
+    k = _split_heads(F.linear(x, block.k_proj.weight, None), block.num_heads)
+    v = _split_heads(F.linear(x, block.v_proj.weight, None), block.num_heads)
+    score = torch.matmul(q, k.transpose(-1, -2))
+    score = block.score_node.single_step_forward(score)
+    context = torch.matmul(score, v)
+    context = _merge_heads(context)
+    return F.linear(context, block.out_proj.weight, None)
+
+
+def _single_step_attention_reference(block, x_seq):
+    return _single_step_attention_reference_from_analog(block, x_seq.sum(dim=0))
+
+
+def _single_step_gated_reference_from_analog(block, x):
+    up = F.linear(x, block.up_proj.weight, None)
+    gate = F.linear(x, block.gate_proj.weight, None)
+    up = block.activation.single_step_forward(up)
+    gate = block.gate.single_step_forward(gate)
+    return F.linear(up * gate, block.down_proj.weight, None)
+
+
+def _single_step_decoder_reference_from_analog(block, x):
+    x = x + _single_step_attention_reference_from_analog(block.attn, x)
+    return x + _single_step_gated_reference_from_analog(block.mlp, x)
+
+
+def _single_step_decoder_reference(block, x_seq):
+    return _single_step_decoder_reference_from_analog(block, x_seq.sum(dim=0))
+
+
+def _single_step_stack_reference(stack, x_seq):
+    x = x_seq.sum(dim=0)
+    for layer in stack.layers:
+        x = _single_step_decoder_reference_from_analog(layer, x)
+    return x
+
+
+def _assert_finite_gradients(module, x_seq):
+    assert x_seq.grad is not None
+    assert torch.isfinite(x_seq.grad).all()
+    for parameter in module.parameters():
+        assert parameter.grad is not None
+        assert torch.isfinite(parameter.grad).all()
+
+
+def test_single_head_attention_final_sum_matches_single_step_reference():
+    table = _table()
+    block = _FewSpikeSelfAttentionBlock(
+        embed_dim=4,
+        num_heads=1,
+        score_node=_few_spike_node(table),
+    )
+    x_seq = torch.randn(table.K, 2, 3, 4)
+
+    y_seq = block(x_seq)
+    expected = _single_step_attention_reference(block, x_seq)
+
+    assert y_seq.shape == (table.K, 2, 3, 4)
+    assert torch.allclose(y_seq.sum(dim=0), expected, atol=1e-5, rtol=1e-5)
+
+
+def test_multi_head_attention_keeps_score_and_context_sequences():
+    table = _table()
+    block = _FewSpikeSelfAttentionBlock(
+        embed_dim=6,
+        num_heads=2,
+        score_node=_few_spike_node(table),
+    )
+    x_seq = torch.randn(table.K, 2, 4, 6)
+
+    score_seq = block.score_sequence(x_seq)
+    encoded_score_seq = block.score_node(score_seq)
+    context_seq = block.context_sequence(x_seq)
+    y_seq = block(x_seq)
+    expected = _single_step_attention_reference(block, x_seq)
+
+    assert score_seq.shape == (table.K, 2, 2, 4, 4)
+    assert encoded_score_seq.shape == (table.K, 2, 2, 4, 4)
+    assert context_seq.shape == (table.K, 2, 2, 4, 3)
+    assert y_seq.shape == (table.K, 2, 4, 6)
+    assert torch.allclose(y_seq.sum(dim=0), expected, atol=1e-5, rtol=1e-5)
+
+
+def test_attention_oat_score_branch_matches_single_step_reference():
+    normal = _two_step_table()
+    outlier = _two_step_table(scale=10.0)
+    block = _FewSpikeSelfAttentionBlock(
+        embed_dim=4,
+        num_heads=1,
+        score_node=neuron.OutlierAwareThresholdNode(
+            table=normal,
+            outlier_table=outlier,
+            split_threshold=1.0,
+            clamp_value=2.0,
+            surrogate_function=surrogate.DeterministicPass(),
+            step_mode="m",
+        ),
+    )
+    x_seq = torch.tensor(
+        [
+            [
+                [[1.0, 0.2, -0.5, 0.3], [0.4, -1.2, 0.6, 0.1]],
+                [[-0.6, 0.7, 0.2, -0.4], [0.9, 0.1, -0.3, 0.5]],
+            ],
+            [
+                [[0.8, -0.1, 0.4, 0.5], [0.5, -0.4, 0.3, 0.2]],
+                [[-0.2, 0.5, 0.6, -0.1], [0.7, 0.3, -0.2, 0.4]],
+            ],
+        ]
+    )
+
+    y_seq = block(x_seq)
+    expected = _single_step_attention_reference(block, x_seq)
+
+    assert y_seq.shape == (normal.K, 2, 2, 4)
+    assert torch.allclose(y_seq.sum(dim=0), expected, atol=1e-5, rtol=1e-5)
+
+
+def test_attention_hg_score_branch_matches_single_step_reference():
+    table_low = _two_step_table()
+    table_mid = _two_step_table(scale=2.0)
+    table_high = _two_step_table(scale=4.0)
+    block = _FewSpikeSelfAttentionBlock(
+        embed_dim=4,
+        num_heads=1,
+        score_node=neuron.HGNode(
+            tables=[table_low, table_mid, table_high],
+            gate_thresholds=[0.0, 1.0],
+            surrogate_function=surrogate.DeterministicPass(),
+            step_mode="m",
+        ),
+    )
+    x_seq = torch.randn(table_low.K, 2, 3, 4)
+
+    y_seq = block(x_seq)
+    expected = _single_step_attention_reference(block, x_seq)
+
+    assert y_seq.shape == (table_low.K, 2, 3, 4)
+    assert torch.allclose(y_seq.sum(dim=0), expected, atol=1e-5, rtol=1e-5)
+
+
+def test_attention_rejects_wrong_time_length_from_score_node():
+    table = _table()
+    block = _FewSpikeSelfAttentionBlock(
+        embed_dim=4,
+        num_heads=1,
+        score_node=_few_spike_node(table),
+    )
+
+    with pytest.raises(ValueError, match="K=3"):
+        block(torch.randn(table.K - 1, 2, 3, 4))
+
+
+def test_decoder_block_final_sum_matches_reference_and_is_stateless():
+    table = _table()
+    block = _TinyFewSpikeDecoderBlock(
+        embed_dim=4,
+        num_heads=1,
+        hidden_features=5,
+        score_node=_few_spike_node(table),
+        activation=_few_spike_node(table),
+        gate=_few_spike_node(table),
+    )
+    x_seq = torch.randn(table.K, 2, 3, 4)
+
+    y0 = block(x_seq)
+    y1 = block(x_seq)
+    expected = _single_step_decoder_reference(block, x_seq)
+
+    assert y0.shape == (table.K, 2, 3, 4)
+    assert torch.allclose(y0, y1)
+    assert torch.allclose(y0.sum(dim=0), expected, atol=1e-4, rtol=1e-4)
+
+
+def test_decoder_block_autograd_with_sigmoid_surrogates():
+    table = _table()
+    block = _TinyFewSpikeDecoderBlock(
+        embed_dim=4,
+        num_heads=1,
+        hidden_features=5,
+        score_node=_few_spike_node(table, surrogate.Sigmoid()),
+        activation=_few_spike_node(table, surrogate.Sigmoid()),
+        gate=_few_spike_node(table, surrogate.Sigmoid()),
+    )
+    x_seq = torch.randn(table.K, 2, 3, 4, requires_grad=True)
+
+    y_seq = block(x_seq)
+    expected = _single_step_decoder_reference(block, x_seq)
+    y_seq.square().sum().backward()
+
+    assert y_seq.shape == (table.K, 2, 3, 4)
+    assert torch.allclose(y_seq.sum(dim=0), expected, atol=1e-4, rtol=1e-4)
+    _assert_finite_gradients(block, x_seq)
+
+
+def test_synthetic_decoder_stack_benchmark_smoke():
+    torch.manual_seed(0)
+    table = _table()
+    vocab_size = 11
+    embed_dim = 4
+    embedding = nn.Embedding(vocab_size, embed_dim)
+    token_ids = torch.tensor([[0, 3, 7], [2, 5, 1]])
+    dense_tokens = embedding(token_ids)
+    coeffs = torch.tensor([0.5, -0.25, 0.75]).view(table.K, 1, 1, 1)
+    x_seq = dense_tokens.unsqueeze(0) * coeffs
+
+    stack = _TinyFewSpikeDecoderStack(
+        [
+            _TinyFewSpikeDecoderBlock(
+                embed_dim=embed_dim,
+                num_heads=1,
+                hidden_features=5,
+                score_node=_few_spike_node(table, surrogate.Sigmoid()),
+                activation=_few_spike_node(table, surrogate.Sigmoid()),
+                gate=_few_spike_node(table, surrogate.Sigmoid()),
+            ),
+            _TinyFewSpikeDecoderBlock(
+                embed_dim=embed_dim,
+                num_heads=2,
+                hidden_features=6,
+                score_node=_few_spike_node(table, surrogate.Sigmoid()),
+                activation=_few_spike_node(table, surrogate.Sigmoid()),
+                gate=_few_spike_node(table, surrogate.Sigmoid()),
+            ),
+        ]
+    )
+
+    y_seq = stack(x_seq)
+    expected = _single_step_stack_reference(stack, x_seq)
+    y_seq.square().sum().backward()
+
+    assert y_seq.shape == (table.K, 2, 3, embed_dim)
+    assert torch.isfinite(y_seq).all()
+    # Two decoder layers with Sigmoid surrogates accumulate more float32 error.
+    assert torch.allclose(y_seq.sum(dim=0), expected, atol=1e-3, rtol=1e-3)
+    assert embedding.weight.grad is not None
+    assert torch.isfinite(embedding.weight.grad).all()
+    for parameter in stack.parameters():
+        assert parameter.grad is not None
+        assert torch.isfinite(parameter.grad).all()

--- a/test/activation_based/test_few_spike_sequence_blocks.py
+++ b/test/activation_based/test_few_spike_sequence_blocks.py
@@ -1,0 +1,281 @@
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from spikingjelly.activation_based import neuron, surrogate
+from spikingjelly.activation_based.ann2snn.operators import (
+    SNNElementWiseProduct,
+    TDLinear,
+)
+
+
+def _table(scale=1.0):
+    return neuron.FewSpikeTable(
+        theta=torch.tensor([0.25, 0.5, 0.75]) * scale,
+        h=torch.tensor([0.2, 0.3, 0.4]) * scale,
+        d=torch.tensor([1.0, 2.0, 4.0]) * scale,
+    )
+
+
+def _two_step_table(scale=1.0):
+    return neuron.FewSpikeTable(
+        theta=torch.tensor([0.25, 0.5]) * scale,
+        h=torch.tensor([0.1, 0.1]) * scale,
+        d=torch.tensor([1.0, 2.0]) * scale,
+    )
+
+
+class _FewSpikeMLPBlock(nn.Module):
+    def __init__(self, in_features, hidden_features, out_features, activation):
+        super().__init__()
+        self.fc1 = TDLinear(in_features, hidden_features, bias=False)
+        self.activation = activation
+        self.fc2 = TDLinear(hidden_features, out_features, bias=False)
+
+    def forward(self, x_seq):
+        return self.fc2(self.activation(self.fc1(x_seq)))
+
+
+class _FewSpikeGatedMLPBlock(nn.Module):
+    def __init__(self, in_features, hidden_features, out_features, activation, gate):
+        super().__init__()
+        self.up_proj = TDLinear(in_features, hidden_features, bias=False)
+        self.gate_proj = TDLinear(in_features, hidden_features, bias=False)
+        self.activation = activation
+        self.gate = gate
+        self.product = SNNElementWiseProduct()
+        self.down_proj = TDLinear(hidden_features, out_features, bias=False)
+
+    def forward(self, x_seq):
+        up_seq = self.activation(self.up_proj(x_seq))
+        gate_seq = self.gate(self.gate_proj(x_seq))
+        return self.down_proj(self.product(up_seq, gate_seq))
+
+
+def _single_step_mlp_reference(block, x_seq):
+    x = x_seq.sum(dim=0)
+    hidden = F.linear(x, block.fc1.weight, None)
+    hidden = block.activation.single_step_forward(hidden)
+    return F.linear(hidden, block.fc2.weight, None)
+
+
+def _single_step_gated_reference(block, x_seq):
+    x = x_seq.sum(dim=0)
+    up = F.linear(x, block.up_proj.weight, None)
+    gate = F.linear(x, block.gate_proj.weight, None)
+    up = block.activation.single_step_forward(up)
+    gate = block.gate.single_step_forward(gate)
+    return F.linear(up * gate, block.down_proj.weight, None)
+
+
+def test_few_spike_mlp_block_final_sum_matches_single_step_reference():
+    table = _table()
+    activation = neuron.FewSpikeNode(
+        table=table,
+        surrogate_function=surrogate.DeterministicPass(),
+        step_mode="m",
+    )
+    block = _FewSpikeMLPBlock(4, 6, 3, activation)
+    x_seq = torch.randn(table.K, 2, 4)
+
+    y_seq = block(x_seq)
+    expected = _single_step_mlp_reference(block, x_seq)
+
+    assert y_seq.shape == (table.K, 2, 3)
+    assert torch.allclose(y_seq.sum(dim=0), expected)
+
+
+def test_few_spike_mlp_block_supports_higher_rank_input():
+    table = _table()
+    activation = neuron.FewSpikeNode(
+        table=table,
+        surrogate_function=surrogate.DeterministicPass(),
+        step_mode="m",
+    )
+    block = _FewSpikeMLPBlock(5, 7, 2, activation)
+    x_seq = torch.randn(table.K, 2, 3, 5)
+
+    y_seq = block(x_seq)
+    expected = _single_step_mlp_reference(block, x_seq)
+
+    assert y_seq.shape == (table.K, 2, 3, 2)
+    assert torch.allclose(y_seq.sum(dim=0), expected)
+
+
+def test_few_spike_mlp_block_rejects_wrong_time_length():
+    table = _table()
+    activation = neuron.FewSpikeNode(
+        table=table,
+        surrogate_function=surrogate.DeterministicPass(),
+        step_mode="m",
+    )
+    block = _FewSpikeMLPBlock(4, 6, 3, activation)
+
+    with pytest.raises(ValueError):
+        block(torch.randn(table.K - 1, 2, 4))
+
+
+def test_few_spike_gated_block_final_sum_matches_single_step_reference():
+    table = _table()
+    block = _FewSpikeGatedMLPBlock(
+        in_features=4,
+        hidden_features=6,
+        out_features=3,
+        activation=neuron.FewSpikeNode(
+            table=table,
+            surrogate_function=surrogate.DeterministicPass(),
+            step_mode="m",
+        ),
+        gate=neuron.FewSpikeNode(
+            table=table,
+            surrogate_function=surrogate.DeterministicPass(),
+            step_mode="m",
+        ),
+    )
+    x_seq = torch.randn(table.K, 2, 4)
+
+    up_seq = block.activation(block.up_proj(x_seq))
+    gate_seq = block.gate(block.gate_proj(x_seq))
+    product_seq = block.product(up_seq, gate_seq)
+    y_seq = block(x_seq)
+    expected = _single_step_gated_reference(block, x_seq)
+
+    assert up_seq.shape == (table.K, 2, 6)
+    assert gate_seq.shape == (table.K, 2, 6)
+    assert product_seq.shape == (table.K, 2, 6)
+    assert y_seq.shape == (table.K, 2, 3)
+    assert torch.allclose(y_seq.sum(dim=0), expected)
+
+
+def test_oat_activation_block_matches_single_step_reference():
+    normal = _two_step_table()
+    outlier = _two_step_table(scale=10.0)
+    activation = neuron.OutlierAwareThresholdNode(
+        table=normal,
+        outlier_table=outlier,
+        split_threshold=1.0,
+        clamp_value=2.0,
+        surrogate_function=surrogate.DeterministicPass(),
+        step_mode="m",
+    )
+    block = _FewSpikeMLPBlock(3, 4, 2, activation)
+    with torch.no_grad():
+        block.fc1.weight.copy_(
+            torch.tensor(
+                [
+                    [1.0, 0.0, 0.0],
+                    [-1.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                    [0.0, 0.0, 1.0],
+                ]
+            )
+        )
+    x_seq = torch.tensor(
+        [
+            [[1.5, 0.2, -0.1], [-1.2, 0.3, 0.4]],
+            [[1.0, 0.5, 0.6], [-0.7, 0.4, 0.5]],
+        ]
+    )
+
+    y_seq = block(x_seq)
+    expected = _single_step_mlp_reference(block, x_seq)
+
+    assert y_seq.shape == (normal.K, 2, 2)
+    assert torch.allclose(y_seq.sum(dim=0), expected)
+
+
+def test_hg_gate_block_matches_single_step_reference():
+    table_low = _two_step_table()
+    table_mid = _two_step_table(scale=10.0)
+    table_high = _two_step_table(scale=100.0)
+    table_gate = _two_step_table(scale=2.0)
+    block = _FewSpikeGatedMLPBlock(
+        in_features=3,
+        hidden_features=4,
+        out_features=2,
+        activation=neuron.FewSpikeNode(
+            table=table_gate,
+            surrogate_function=surrogate.DeterministicPass(),
+            step_mode="m",
+        ),
+        gate=neuron.HGNode(
+            tables=[table_low, table_mid, table_high],
+            gate_thresholds=[0.0, 1.0],
+            surrogate_function=surrogate.DeterministicPass(),
+            step_mode="m",
+        ),
+    )
+    with torch.no_grad():
+        block.gate_proj.weight.copy_(
+            torch.tensor(
+                [
+                    [1.0, 0.0, 0.0],
+                    [-1.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                    [0.0, 0.0, 1.0],
+                ]
+            )
+        )
+    x_seq = torch.tensor(
+        [
+            [[-0.4, 0.3, 0.7], [0.2, 0.4, 0.5]],
+            [[-0.3, 0.5, 0.6], [0.6, 0.8, 0.7]],
+        ]
+    )
+
+    y_seq = block(x_seq)
+    expected = _single_step_gated_reference(block, x_seq)
+
+    assert y_seq.shape == (table_low.K, 2, 2)
+    assert torch.allclose(y_seq.sum(dim=0), expected)
+
+
+def test_gated_block_autograd_and_stateless_forward():
+    table = _table()
+    block = _FewSpikeGatedMLPBlock(
+        in_features=4,
+        hidden_features=5,
+        out_features=3,
+        activation=neuron.FewSpikeNode(
+            table=table,
+            surrogate_function=surrogate.Sigmoid(),
+            step_mode="m",
+        ),
+        gate=neuron.FewSpikeNode(
+            table=table,
+            surrogate_function=surrogate.Sigmoid(),
+            step_mode="m",
+        ),
+    )
+    x_seq = torch.randn(table.K, 2, 4, requires_grad=True)
+
+    y0 = block(x_seq)
+    y1 = block(x_seq)
+    y0.square().sum().backward()
+
+    assert torch.allclose(y0, y1)
+    assert x_seq.grad is not None
+    assert torch.isfinite(x_seq.grad).all()
+    for parameter in block.parameters():
+        assert parameter.grad is not None
+        assert torch.isfinite(parameter.grad).all()
+
+
+def test_block_rejects_mixed_table_lengths():
+    table = _two_step_table()
+    other = _table()
+
+    with pytest.raises(ValueError):
+        neuron.OutlierAwareThresholdNode(
+            table=table,
+            outlier_table=other,
+            split_threshold=1.0,
+            step_mode="m",
+        )
+    with pytest.raises(ValueError):
+        neuron.HGNode(
+            tables=[table, other],
+            gate_thresholds=[0.0],
+            step_mode="m",
+        )


### PR DESCRIPTION
## Summary

This PR adds the Phase 3 Few-Spike / LAS primitive slice for `spikingjelly.activation_based`.

Main changes:

- Add Few-Spike neuron primitives:
  - `FewSpikeTable`
  - `FewSpikeNode`
  - `OutlierAwareThresholdNode`
  - `HGNode`
- Add sequence-preserving ANN/SNN operators:
  - `SNNMatrixOperator`
  - `SNNElementWiseProduct`
  - stronger `TDLinear` semantics and bias handling
- Add `TDModule` and step-mode hardening for TD/SNN operators:
  - `step_mode="s"`: ordinary PyTorch / ANN operator fast path
  - `step_mode="m"`: temporal-difference / sequence-preserving path
  - default remains `step_mode="m"` for backward compatibility
- Add test-local composition validation for:
  - Few-Spike MLP / gated-MLP toy blocks
  - Few-Spike self-attention toy blocks
  - tiny decoder-only toy block
  - synthetic decoder stack smoke test
- Update API docs for the new neuron and operator primitives.

## Non-Goals

This PR intentionally does not:

- Change the default `Converter(dataloader, mode="Max")` ReLU-to-IFNode path.
- Add a public `FewSpikeLinear` API.
- Add a public LAS attention / decoder / LLM recipe.
- Implement full LAS Transformer or LLM conversion.
- Claim the TD operators are fully spike-driven hardware kernels.

The toy MLP, attention, and decoder blocks are test-local composition checks only.

## Design Notes

Few-Spike neurons are implemented as memoryless `StepModule`s rather than `MemoryModule`s. Their multi-step path requires a complete input window and enforces `T == K`, where `K` is the table length.

TD/SNN operators now follow the same explicit step-mode contract:

- In single-step mode, they directly call the corresponding PyTorch operator.
- In multi-step mode, they preserve sequence semantics through cumulative-state evaluation and temporal differencing.

This allows `functional.set_step_mode(model, "s" / "m")` to switch Few-Spike nodes and TD/SNN operators consistently.

## Validation

Passed locally:

```bash
uv format --check -- spikingjelly/activation_based/ann2snn/operators.py test/activation_based/test_ann2snn_operators.py test/activation_based/test_few_spike_sequence_blocks.py

PYTHONPATH=$PWD python -m pytest \
  test/activation_based/test_ann2snn_operators.py \
  test/activation_based/test_ann2snn_transformer.py \
  test/activation_based/test_few_spike_neuron.py \
  test/activation_based/test_few_spike_sequence_blocks.py \
  test/activation_based/test_few_spike_sequence_attention.py -q
# 165 passed

git diff --check

cd docs
PYTHONPATH=.. make html
# build succeeded
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Few-Spike / LAS neuron primitives (tables plus routing nodes) and exposed them in the neuron API.
  * Added step-mode switching for ANN-to-SNN temporal operators, including temporal softmax/LayerNorm/GELU/linear, TD attention, and new sequence-preserving matrix/elementwise operators.
* **Bug Fixes**
  * Strengthened validation and improved consistent single-step vs multi-step behavior for temporal attention options.
* **Documentation**
  * Updated neuron API docs with the new primitives and the ActivationAwareIFNode entry.
* **Tests**
  * Expanded test coverage for step-mode switching, operator equivalence/gradients, and Few-Spike sequence/attention/block behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->