### PR TITLE
test: skip profiler tests when CUDA is unavailable

### DIFF
--- a/test/activation_based/test_profiler.py
+++ b/test/activation_based/test_profiler.py
@@ -26,6 +26,7 @@ def _create_test_model():
     return net
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_context_manager_basic():
     net = _create_test_model().cuda()
     optimizer = optim.Adam(net.parameters(), lr=0.001)
@@ -40,6 +41,7 @@ def test_context_manager_basic():
         prof.export()
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_layer_wise_profiling():
     net = _create_test_model().cuda()
     with LayerWiseMemoryProfiler(
@@ -59,6 +61,7 @@ def test_layer_wise_profiling():
     prof.export(output=True)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_time_profiling():
     net = _create_test_model().cuda()
     with LayerWiseFPCUDATimeProfiler(
@@ -78,6 +81,7 @@ def test_time_profiling():
     prof.export(output=True)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_exception_safety():
     net = _create_test_model().cuda()
 


### PR DESCRIPTION
## What

Add `@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")` to the four tests in `test/activation_based/test_profiler.py`.

## Why

All four tests call `.cuda()` unconditionally, so on a CPU-only PyTorch build they fail with `AssertionError: Torch not compiled with CUDA enabled` instead of skipping:

```
FAILED test/activation_based/test_profiler.py::test_context_manager_basic
FAILED test/activation_based/test_profiler.py::test_layer_wise_profiling
FAILED test/activation_based/test_profiler.py::test_time_profiling
FAILED test/activation_based/test_profiler.py::test_exception_safety
```

The intent to skip is already there — the `if __name__ == "__main__":` block checks `torch.cuda.is_available()` and exits — but that check doesn't apply when the file runs under pytest. Other CUDA-dependent tests in the suite (e.g. `test_triton_neuron.py`) use this same `skipif` marker; this brings `test_profiler.py` in line with them.

With the markers, the full suite runs green on CPU-only PyTorch builds — machines without NVIDIA GPUs, CI runners, and edge devices such as the Raspberry Pi, where low-power SNN inference is an increasingly common use case.

## Testing

On a CPU-only environment (torch 2.13.0+cpu, Python 3.11):

- Before: `pytest test/activation_based/test_profiler.py` → 4 failed
- After: 4 skipped; full suite `pytest test/` → 1273 passed, 143 skipped

Formatted with `uv format` (no changes to this file beyond the markers).
