### PR TITLE
fix: detach reward passed to MSTDP learners to prevent memory growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ Module: `spikingjelly.activation_based.triton_kernel.neuron_kernel`.
   the learners' monitors are now detached, so `step()` no longer needs to
   be wrapped in `torch.no_grad()`.
 
+- Fixed `MSTDPLearner.step()` and `MSTDPETLearner.step()` retaining the
+  autograd graph of a graph-connected `reward` (e.g. the output of a critic
+  network), which leaked the forward pass's graph into `weight.grad` and the
+  returned `delta_w` and accumulated memory across training iterations — the
+  reward-side counterpart of #576. The reward is now detached inside
+  `step()`.
+
 ### Breaking Changes and Notices
 
 - None.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -62,6 +62,13 @@ Bug Fixes
   the learners' monitors are now detached, so ``step()`` no longer needs to
   be wrapped in ``torch.no_grad()``.
 
+- Fixed ``MSTDPLearner.step()`` and ``MSTDPETLearner.step()`` retaining the
+  autograd graph of a graph-connected ``reward`` (e.g. the output of a critic
+  network), which leaked the forward pass's graph into ``weight.grad`` and the
+  returned ``delta_w`` and accumulated memory across training iterations — the
+  reward-side counterpart of #576. The reward is now detached inside
+  ``step()``.
+
 Breaking Changes and Notices
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/spikingjelly/activation_based/learning.py
+++ b/spikingjelly/activation_based/learning.py
@@ -1162,6 +1162,12 @@ class MSTDPLearner(base.MemoryModule):
         :raises NotImplementedError: Only some ``step_mode`` / synapse-type combinations are currently supported
         :raises ValueError: Raised when ``self.step_mode`` is invalid
         """
+        # detach the reward so a graph-connected reward (e.g. produced by a
+        # critic network) never leaks the forward pass's autograd graph into
+        # weight.grad or the returned delta_w (#576)
+        if isinstance(reward, torch.Tensor):
+            reward = reward.detach()
+
         length = self.in_spike_monitor.records.__len__()
         delta_w = None
 
@@ -1434,6 +1440,12 @@ class MSTDPETLearner(base.MemoryModule):
         :raises NotImplementedError: Only some ``step_mode`` / synapse-type combinations are currently supported
         :raises ValueError: Raised when ``self.step_mode`` is invalid
         """
+        # detach the reward so a graph-connected reward (e.g. produced by a
+        # critic network) never leaks the forward pass's autograd graph into
+        # weight.grad or the returned delta_w (#576)
+        if isinstance(reward, torch.Tensor):
+            reward = reward.detach()
+
         length = self.in_spike_monitor.records.__len__()
         delta_w = None
 

--- a/test/activation_based/test_learning.py
+++ b/test/activation_based/test_learning.py
@@ -229,30 +229,37 @@ def test_mstdp_learners_step_detaches_reward():
         learner.reset()
 
 
-def test_mstdp_learner_returns_detached_delta_w():
-    fc = layer.Linear(8, 5, bias=False)
-    sn = neuron.IFNode()
-    critic = nn.Linear(5, 1)
-    learner = learning.MSTDPLearner(
-        step_mode="s",
-        synapse=fc,
-        sn=sn,
-        tau_pre=2.0,
-        tau_post=2.0,
-        batch_size=3,
-        f_pre=f_weight,
-        f_post=f_weight,
-    )
-    in_spike = (torch.rand(3, 8) > 0.5).float()
-    out_spike = sn(fc(in_spike))
-    reward = critic(out_spike).squeeze(-1)
+def test_mstdp_learners_return_detached_delta_w():
+    for cls, kwargs, batched in (
+        (learning.MSTDPLearner, {"batch_size": 3}, True),
+        (learning.MSTDPETLearner, {"tau_trace": 2.0}, False),
+    ):
+        fc = layer.Linear(8, 5, bias=False)
+        sn = neuron.IFNode()
+        critic = nn.Linear(5, 1)
+        learner = cls(
+            step_mode="s",
+            synapse=fc,
+            sn=sn,
+            tau_pre=2.0,
+            tau_post=2.0,
+            f_pre=f_weight,
+            f_post=f_weight,
+            **kwargs,
+        )
+        if batched:
+            in_spike = (torch.rand(3, 8) > 0.5).float()
+        else:
+            in_spike = (torch.rand(8) > 0.5).float()
+        out_spike = sn(fc(in_spike))
+        reward = critic(out_spike).squeeze(-1) if batched else critic(out_spike).mean()
 
-    delta_w = learner.step(reward, on_grad=False)
-    assert delta_w.grad_fn is None
-    assert not delta_w.requires_grad
+        delta_w = learner.step(reward, on_grad=False)
+        assert delta_w.grad_fn is None
+        assert not delta_w.requires_grad
 
-    functional.reset_net(sn)
-    learner.reset()
+        functional.reset_net(sn)
+        learner.reset()
 
 
 def test_mstdp_learners_free_tensors_with_graph_connected_reward():
@@ -278,6 +285,6 @@ if __name__ == "__main__":
     test_stdp_learner_frees_tensors_across_runs()
     test_mstdp_learners_records_are_detached()
     test_mstdp_learners_step_detaches_reward()
-    test_mstdp_learner_returns_detached_delta_w()
+    test_mstdp_learners_return_detached_delta_w()
     test_mstdp_learners_free_tensors_with_graph_connected_reward()
     print("Done!")

--- a/test/activation_based/test_learning.py
+++ b/test/activation_based/test_learning.py
@@ -173,10 +173,111 @@ def test_mstdp_learners_records_are_detached():
         functional.reset_net(sn)
 
 
+def _run_mstdp_with_critic_reward(steps=4):
+    # reward comes out of a differentiable critic, as in reward-modulated
+    # training loops, and is passed to step() without an explicit detach
+    fc = layer.Linear(8, 5, bias=False)
+    sn = neuron.IFNode()
+    critic = nn.Linear(5, 1)
+    learner = learning.MSTDPLearner(
+        step_mode="s",
+        synapse=fc,
+        sn=sn,
+        tau_pre=2.0,
+        tau_post=2.0,
+        batch_size=3,
+        f_pre=f_weight,
+        f_post=f_weight,
+    )
+    for _ in range(steps):
+        in_spike = (torch.rand(3, 8) > 0.5).float()
+        out_spike = sn(fc(in_spike))
+        reward = critic(out_spike).squeeze(-1)
+        learner.step(reward, on_grad=True)
+    return fc, sn, learner
+
+
+def _run_mstdpet_with_critic_reward(steps=4):
+    fc = layer.Linear(8, 5, bias=False)
+    sn = neuron.IFNode()
+    critic = nn.Linear(5, 1)
+    learner = learning.MSTDPETLearner(
+        step_mode="s",
+        synapse=fc,
+        sn=sn,
+        tau_pre=2.0,
+        tau_post=2.0,
+        tau_trace=2.0,
+        f_pre=f_weight,
+        f_post=f_weight,
+    )
+    for _ in range(steps):
+        in_spike = (torch.rand(8) > 0.5).float()
+        out_spike = sn(fc(in_spike))
+        reward = critic(out_spike).mean()
+        learner.step(reward, on_grad=True)
+    return fc, sn, learner
+
+
+def test_mstdp_learners_step_detaches_reward():
+    for run in (_run_mstdp_with_critic_reward, _run_mstdpet_with_critic_reward):
+        fc, sn, learner = run()
+        assert fc.weight.grad is not None
+        assert fc.weight.grad.grad_fn is None
+        assert not fc.weight.grad.requires_grad
+        functional.reset_net(sn)
+        learner.reset()
+
+
+def test_mstdp_learner_returns_detached_delta_w():
+    fc = layer.Linear(8, 5, bias=False)
+    sn = neuron.IFNode()
+    critic = nn.Linear(5, 1)
+    learner = learning.MSTDPLearner(
+        step_mode="s",
+        synapse=fc,
+        sn=sn,
+        tau_pre=2.0,
+        tau_post=2.0,
+        batch_size=3,
+        f_pre=f_weight,
+        f_post=f_weight,
+    )
+    in_spike = (torch.rand(3, 8) > 0.5).float()
+    out_spike = sn(fc(in_spike))
+    reward = critic(out_spike).squeeze(-1)
+
+    delta_w = learner.step(reward, on_grad=False)
+    assert delta_w.grad_fn is None
+    assert not delta_w.requires_grad
+
+    functional.reset_net(sn)
+    learner.reset()
+
+
+def test_mstdp_learners_free_tensors_with_graph_connected_reward():
+    # regression test for the reward-side counterpart of #576: a
+    # graph-connected reward must not accumulate retained graphs across runs
+    def one_run():
+        for run in (_run_mstdp_with_critic_reward, _run_mstdpet_with_critic_reward):
+            fc, sn, learner = run()
+            functional.reset_net(sn)
+            learner.reset()
+
+    one_run()
+    baseline = _count_alive_tensors()
+    for _ in range(3):
+        one_run()
+    assert _count_alive_tensors() <= baseline + 5
+
+
 if __name__ == "__main__":
     test_stdp_learner_records_are_detached()
     test_stdp_learner_step_does_not_retain_graph()
     test_stdp_learner_matches_functional_update()
     test_stdp_learner_frees_tensors_across_runs()
     test_mstdp_learners_records_are_detached()
+    test_mstdp_learners_step_detaches_reward()
+    test_mstdp_learner_returns_detached_delta_w()
+    test_mstdp_learners_free_tensors_with_graph_connected_reward()
     print("Done!")


### PR DESCRIPTION
## What

Detach the external `reward` at the top of `MSTDPLearner.step()` and `MSTDPETLearner.step()`, so a graph-connected reward can never leak the forward pass's autograd graph into `synapse.weight.grad` or the returned `delta_w`. Adds three regression tests and a CHANGELOG entry.

Follow-up to #703; this closes the remaining leak path noted in that PR's description ("a graph-connected `reward` could still leak via `dw = reward * trace_e`").

## Why

#703 detached the spikes the learners *record*, but the reward the caller *passes in* still flows straight into the weight update: `dw = (reward.view(-1, 1, 1) * self.eligibility).sum(0)` (MSTDP) and `dw = reward * self.trace_e` (MSTDPET). In reward-modulated training the reward is often the output of a differentiable module (e.g. a critic network). If the caller doesn't detach it, `step(on_grad=True)` writes a graph-connected tensor into `weight.grad`, and each subsequent `step()` chains onto it via `weight.grad - delta_w` — exactly the retention pattern of #576, just entering through the reward instead of the spikes.

Measured (CPU, torch 2.13, Linear 8→5, critic `nn.Linear(5, 1)`, 20 steps per run, model re-created per run): **before** — `weight.grad.grad_fn` is populated and +122 tensors survive `gc.collect()` per run, growing linearly; **after** — `grad_fn is None`, 0 surviving tensors.

The same reasoning as #703 applies to why detaching is safe: STDP-family updates already operate through `weight.data`/`weight.grad` and `step()` is not a supported differentiable path, so no gradient route is removed. Backpropagating into the critic itself is unaffected — users do that from their own loss on the critic's output, not through the learner's weight update.

## Verification

- `test_mstdp_learners_step_detaches_reward`, `test_mstdp_learner_returns_detached_delta_w`, and `test_mstdp_learners_free_tensors_with_graph_connected_reward` all fail on master and pass with this fix.
- Full suite: 1347 passed, 210 skipped (CPU) — no regressions.
- `uv format --check` clean on the changed files; `docs/source/changelog.rst` regenerated via `tools/generate_changelog_rst.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MSTDPLearner and MSTDPETLearner behavior to detach tensor rewards during `step`, preventing autograd graph leakage into weight gradients and returned updates.
  * Resolved autograd graph retention that could cause memory growth across training iterations.
* **Tests**
  * Added new regression tests covering critic-connected reward behavior, ensuring gradients/returned `delta_w` are detached when expected.
  * Added repeated-run checks to confirm tensor cleanup does not degrade over time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->