### PR TITLE
Add FP8 hardware validation and benchmark coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,4 +161,5 @@ ObsidianVault
 .codegraph/
 ENV.md
 benchmark/output
+results/fp8-blackwell-5090/
 ocr.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ Module: `spikingjelly.activation_based.precision`.
   LayerNorm, exact LayerNormLinear / LayerNormMLP fusion patterns, and SDPA
   argument validation.
 
+- Added Transformer Engine SDPA output-layout compatibility for both
+  `[B, S, H, D]` and flattened `[B, S, H * D]` results, and scoped FP8
+  autocast to the configured indexed CUDA device.
+
+- Improved Transformer Engine capability failures to preserve the underlying
+  import or runtime error instead of reporting every import failure as a
+  missing installation.
+
 - Added precision conversion reports with pointwise Conv1d, LayerNorm,
   fused-pattern metadata, and shared-module identity preservation for
   Transformer Engine fused precision patterns.
@@ -38,10 +46,18 @@ Module: `spikingjelly.activation_based.triton_kernel.neuron_kernel`.
   experiments with configurable forward and backward compute dtypes.
 
 - Added FP8 Triton neuron capability probes and a reusable execution plan for
-  repeated mixed-precision neuron launches.
+  repeated mixed-precision neuron launches. Capability reports distinguish
+  FP32, FP16, BF16, and FP8 compute probes for each FP8 storage format.
 
 - Added an FP8 Triton neuron benchmark harness for IF, LIF, and ParametricLIF
-  accuracy, backward-gradient, and prepared-plan overhead measurements.
+  accuracy, backward-gradient, prepared-plan overhead, FP16/BF16 comparisons,
+  timing quartiles, and allocated/reserved CUDA memory measurements.
+
+- Validated FP8 training and inference on RTX 5090 with PyTorch 2.7.1 / Triton
+  3.3.1 and PyTorch 2.11 / Triton 3.6. The validated boundary is FP8 storage
+  and GEMM with higher-precision scalar computation or accumulation; pure FP8
+  scalar neuron computation is unsupported, and the measurements do not show
+  a universal speed or peak-memory advantage over BF16.
 
 ### Bug Fixes
 

--- a/benchmark/benchmark_fp8_training_inference.py
+++ b/benchmark/benchmark_fp8_training_inference.py
@@ -183,7 +183,7 @@ def _commit(explicit_commit: str | None = None) -> str | None:
             stderr=subprocess.DEVNULL,
             text=True,
         ).strip()
-    except Exception:
+    except (OSError, subprocess.SubprocessError):
         return None
 
 
@@ -359,9 +359,9 @@ def _print_results(results: list[dict[str, Any]], efficiency: dict[str, Any]) ->
             f"{result['inference_samples_per_sec']:16.1f} "
             f"{result['preparation_ms']:10.3f} "
             f"{result['training_peak_allocated_mb']:9.1f}/"
-            f"{result['training_peak_reserved_mb']:<9.1f} "
+            f"{result['training_peak_reserved_mb']:<10.1f}"
             f"{result['inference_peak_allocated_mb']:9.1f}/"
-            f"{result['inference_peak_reserved_mb']:<9.1f}"
+            f"{result['inference_peak_reserved_mb']:<10.1f}"
         )
     for comparison in efficiency["comparisons"]:
         print(

--- a/benchmark/benchmark_fp8_training_inference.py
+++ b/benchmark/benchmark_fp8_training_inference.py
@@ -146,15 +146,16 @@ def validate_args(args: argparse.Namespace) -> None:
 
 
 def _cuda_time_ms(device: torch.device, steps: int, fn) -> float:
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    torch.cuda.synchronize(device)
-    start.record()
-    for _ in range(steps):
-        fn()
-    end.record()
-    end.synchronize()
-    return start.elapsed_time(end) / steps
+    with torch.cuda.device(device):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        torch.cuda.synchronize(device)
+        start.record()
+        for _ in range(steps):
+            fn()
+        end.record()
+        end.synchronize()
+        return start.elapsed_time(end) / steps
 
 
 def _samples_per_second(batch_size: int, elapsed_ms: float) -> float:

--- a/benchmark/benchmark_fp8_training_inference.py
+++ b/benchmark/benchmark_fp8_training_inference.py
@@ -1,0 +1,462 @@
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import math
+import os
+import platform
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from statistics import median
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+try:
+    from benchmark.fp8_efficiency import assess_model_efficiency, require_efficiency
+except ModuleNotFoundError:
+    from fp8_efficiency import assess_model_efficiency, require_efficiency
+from spikingjelly.activation_based.precision import (
+    PrecisionConfig,
+    prepare_model_for_precision,
+)
+
+
+FP8_MODES = ("fp8-torchao", "fp8-te")
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    precision: str
+    trial: int
+    preparation_ms: float
+    training_ms: float
+    training_samples_per_sec: float
+    training_peak_allocated_mb: float
+    training_peak_reserved_mb: float
+    inference_ms: float
+    inference_samples_per_sec: float
+    inference_peak_allocated_mb: float
+    inference_peak_reserved_mb: float
+    parameter_update_max_abs: float
+    output_checksum: float
+    capability_report: dict[str, Any]
+    conversion_report: dict[str, Any]
+
+
+class LinearWorkload(nn.Module):
+    def __init__(self, width: int, depth: int, num_classes: int):
+        super().__init__()
+        if depth < 2:
+            raise ValueError("depth must be >= 2.")
+        modules: list[nn.Module] = []
+        for _ in range(depth - 1):
+            modules.extend((nn.Linear(width, width), nn.GELU()))
+        modules.append(nn.Linear(width, num_classes))
+        self.layers = nn.Sequential(*modules)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.layers(x)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate FP8 training and inference usability and compare throughput "
+            "and memory against a higher-precision baseline."
+        )
+    )
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--batch-size", type=int, default=4096)
+    parser.add_argument("--width", type=int, default=2048)
+    parser.add_argument("--depth", type=int, default=8)
+    parser.add_argument("--num-classes", type=int, default=2048)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--training-steps", type=int, default=30)
+    parser.add_argument("--inference-steps", type=int, default=100)
+    parser.add_argument("--trials", type=int, default=5)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--seed", type=int, default=20260718)
+    parser.add_argument("--commit")
+    parser.add_argument(
+        "--precisions",
+        nargs="+",
+        default=["fp32", "fp16", "bf16", *FP8_MODES],
+        choices=("fp32", "fp16", "bf16", *FP8_MODES),
+    )
+    parser.add_argument(
+        "--baseline-precision",
+        default="bf16",
+        choices=("fp32", "fp16", "bf16"),
+    )
+    parser.add_argument("--min-training-speedup", type=float, default=1.05)
+    parser.add_argument("--min-inference-speedup", type=float, default=1.05)
+    parser.add_argument(
+        "--require-efficiency",
+        action="store_true",
+        help="Exit non-zero unless every requested FP8 mode meets both speedups.",
+    )
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    if args.baseline_precision not in args.precisions:
+        raise ValueError("--baseline-precision must be included in --precisions.")
+    if not any(precision in FP8_MODES for precision in args.precisions):
+        raise ValueError("--precisions must include at least one FP8 mode.")
+    positive_values = {
+        "batch_size": args.batch_size,
+        "width": args.width,
+        "num_classes": args.num_classes,
+        "training_steps": args.training_steps,
+        "inference_steps": args.inference_steps,
+        "trials": args.trials,
+    }
+    invalid = [name for name, value in positive_values.items() if value <= 0]
+    if invalid:
+        raise ValueError(
+            f"The following values must be positive: {', '.join(invalid)}."
+        )
+    if args.warmup < 1:
+        raise ValueError("--warmup must be >= 1.")
+    if (
+        not math.isfinite(args.min_training_speedup)
+        or not math.isfinite(args.min_inference_speedup)
+        or args.min_training_speedup <= 0
+        or args.min_inference_speedup <= 0
+    ):
+        raise ValueError(
+            "--min-training-speedup and --min-inference-speedup must be finite and > 0."
+        )
+    if args.trials < 2:
+        raise ValueError("--trials must be >= 2 for a median comparison.")
+    if args.depth < 2:
+        raise ValueError("--depth must be >= 2.")
+    fp8_requested = any(precision in FP8_MODES for precision in args.precisions)
+    dimensions = (args.batch_size, args.width, args.num_classes)
+    if fp8_requested and any(value % 16 for value in dimensions):
+        raise ValueError("FP8 benchmark dimensions must be divisible by 16.")
+
+
+def _cuda_time_ms(device: torch.device, steps: int, fn) -> float:
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    torch.cuda.synchronize(device)
+    start.record()
+    for _ in range(steps):
+        fn()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) / steps
+
+
+def _samples_per_second(batch_size: int, elapsed_ms: float) -> float:
+    if not math.isfinite(elapsed_ms) or elapsed_ms <= 0:
+        raise RuntimeError("CUDA timing must be finite and positive.")
+    return batch_size / (elapsed_ms / 1000.0)
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _commit(explicit_commit: str | None = None) -> str | None:
+    if explicit_commit:
+        return explicit_commit
+    for env_name in ("SJ_COMMIT", "GIT_COMMIT", "CODEX_COMMIT"):
+        value = os.environ.get(env_name)
+        if value:
+            return value
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except Exception:
+        return None
+
+
+def benchmark_precision(
+    args: argparse.Namespace,
+    precision: str,
+    trial: int,
+    model_state: dict[str, torch.Tensor],
+    x: torch.Tensor,
+    target: torch.Tensor,
+    device: torch.device,
+) -> BenchmarkResult:
+    model = LinearWorkload(args.width, args.depth, args.num_classes).to(device)
+    model.load_state_dict(model_state, strict=True)
+    model.train()
+    torch.cuda.synchronize(device)
+    preparation_start = time.perf_counter()
+    artifacts = prepare_model_for_precision(
+        model,
+        device,
+        PrecisionConfig(mode=precision, strictness="strict", device=str(device)),
+    )
+    torch.cuda.synchronize(device)
+    preparation_ms = (time.perf_counter() - preparation_start) * 1000.0
+    model = artifacts.model
+    if artifacts.effective_config.mode != precision:
+        raise RuntimeError(
+            f"Requested {precision}, but effective mode is "
+            f"{artifacts.effective_config.mode}."
+        )
+    conversion_report = artifacts.policy.conversion_report()
+    if precision in FP8_MODES and not conversion_report["converted_modules"]:
+        raise RuntimeError(f"{precision} did not convert any benchmark modules.")
+
+    optimizer = torch.optim.SGD(model.parameters(), lr=args.lr)
+    parameters = [
+        parameter for parameter in model.parameters() if parameter.requires_grad
+    ]
+    if not parameters:
+        raise RuntimeError("Benchmark model has no trainable parameters.")
+    parameters_before = [parameter.detach().clone() for parameter in parameters]
+    last_loss = None
+
+    def training_step() -> None:
+        nonlocal last_loss
+        optimizer.zero_grad(set_to_none=True)
+        with artifacts.autocast_context():
+            logits = model(x)
+            loss = torch.nn.functional.cross_entropy(logits, target)
+        artifacts.backward(loss, optimizer, parameters=model.parameters())
+        last_loss = loss.detach()
+
+    for _ in range(args.warmup):
+        training_step()
+    if not torch.isfinite(last_loss):
+        raise RuntimeError(f"{precision} training produced a non-finite loss.")
+    parameter_update = max(
+        float((parameter.detach() - before).abs().max().float().item())
+        for parameter, before in zip(parameters, parameters_before, strict=True)
+    )
+    del parameters_before, parameters
+    if parameter_update == 0.0:
+        raise RuntimeError(f"{precision} training did not update model parameters.")
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats(device)
+    training_ms = _cuda_time_ms(device, args.training_steps, training_step)
+    training_peak_mb = torch.cuda.max_memory_allocated(device) / 1024.0 / 1024.0
+    training_peak_reserved_mb = torch.cuda.max_memory_reserved(device) / 1024.0 / 1024.0
+    if not torch.isfinite(last_loss):
+        raise RuntimeError(
+            f"{precision} training produced a non-finite loss during timed steps."
+        )
+
+    optimizer.zero_grad(set_to_none=True)
+    del last_loss
+    model.eval()
+    torch.cuda.empty_cache()
+    output = None
+
+    def inference_step() -> None:
+        nonlocal output
+        with torch.inference_mode(), artifacts.autocast_context():
+            output = model(x)
+
+    for _ in range(args.warmup):
+        inference_step()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats(device)
+    inference_ms = _cuda_time_ms(device, args.inference_steps, inference_step)
+    inference_peak_mb = torch.cuda.max_memory_allocated(device) / 1024.0 / 1024.0
+    inference_peak_reserved_mb = (
+        torch.cuda.max_memory_reserved(device) / 1024.0 / 1024.0
+    )
+    if output is None or not torch.isfinite(output).all():
+        raise RuntimeError(f"{precision} inference produced non-finite output.")
+
+    return BenchmarkResult(
+        precision=precision,
+        trial=trial,
+        preparation_ms=preparation_ms,
+        training_ms=training_ms,
+        training_samples_per_sec=_samples_per_second(args.batch_size, training_ms),
+        training_peak_allocated_mb=training_peak_mb,
+        training_peak_reserved_mb=training_peak_reserved_mb,
+        inference_ms=inference_ms,
+        inference_samples_per_sec=_samples_per_second(args.batch_size, inference_ms),
+        inference_peak_allocated_mb=inference_peak_mb,
+        inference_peak_reserved_mb=inference_peak_reserved_mb,
+        parameter_update_max_abs=parameter_update,
+        output_checksum=float(output.float().mean().item()),
+        capability_report=artifacts.policy.capability_report(),
+        conversion_report=conversion_report,
+    )
+
+
+def _aggregate_precision_trials(
+    precision: str, trials: list[dict[str, Any]]
+) -> dict[str, Any]:
+    if not trials:
+        raise ValueError(f"No benchmark trials found for {precision}.")
+    metric_names = (
+        "preparation_ms",
+        "training_ms",
+        "training_samples_per_sec",
+        "training_peak_allocated_mb",
+        "training_peak_reserved_mb",
+        "inference_ms",
+        "inference_samples_per_sec",
+        "inference_peak_allocated_mb",
+        "inference_peak_reserved_mb",
+        "parameter_update_max_abs",
+        "output_checksum",
+    )
+    result = {
+        "precision": precision,
+        "trial_count": len(trials),
+        "trials": trials,
+        "capability_report": trials[-1]["capability_report"],
+        "conversion_report": trials[-1]["conversion_report"],
+    }
+    for metric_name in metric_names:
+        values = [float(trial[metric_name]) for trial in trials]
+        result[metric_name] = median(values)
+        result[f"{metric_name}_p25"] = _percentile(values, 0.25)
+        result[f"{metric_name}_p75"] = _percentile(values, 0.75)
+    return result
+
+
+def _percentile(values: list[float], quantile: float) -> float:
+    if not values:
+        raise ValueError("Cannot compute a percentile from an empty sequence.")
+    if not 0.0 <= quantile <= 1.0:
+        raise ValueError("quantile must be in [0, 1].")
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+
+def _print_results(results: list[dict[str, Any]], efficiency: dict[str, Any]) -> None:
+    print(
+        f"{'precision':<14} {'train ms':>10} {'train samples/s':>16} "
+        f"{'infer ms':>10} {'infer samples/s':>16} {'prep ms':>10} "
+        f"{'train alloc/res MB':>20} {'infer alloc/res MB':>20}"
+    )
+    for result in results:
+        print(
+            f"{result['precision']:<14} {result['training_ms']:10.3f} "
+            f"{result['training_samples_per_sec']:16.1f} "
+            f"{result['inference_ms']:10.3f} "
+            f"{result['inference_samples_per_sec']:16.1f} "
+            f"{result['preparation_ms']:10.3f} "
+            f"{result['training_peak_allocated_mb']:9.1f}/"
+            f"{result['training_peak_reserved_mb']:<9.1f} "
+            f"{result['inference_peak_allocated_mb']:9.1f}/"
+            f"{result['inference_peak_reserved_mb']:<9.1f}"
+        )
+    for comparison in efficiency["comparisons"]:
+        print(
+            f"{comparison['precision']} vs {efficiency['baseline_precision']}: "
+            f"training {comparison['training_speedup']:.3f}x, "
+            f"inference {comparison['inference_speedup']:.3f}x, "
+            f"training memory {comparison['training_memory_ratio']:.3f}x, "
+            f"inference memory {comparison['inference_memory_ratio']:.3f}x, "
+            f"passed={comparison['passed']}"
+        )
+
+
+def main() -> None:
+    args = parse_args()
+    validate_args(args)
+    device = torch.device(args.device)
+    if device.type != "cuda" or not torch.cuda.is_available():
+        raise RuntimeError("This benchmark requires CUDA.")
+
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    base_model = LinearWorkload(args.width, args.depth, args.num_classes)
+    model_state = base_model.state_dict()
+    x = torch.randn(args.batch_size, args.width, device=device)
+    target = torch.randint(0, args.num_classes, (args.batch_size,), device=device)
+    trial_results: list[dict[str, Any]] = []
+    for trial in range(args.trials):
+        offset = trial % len(args.precisions)
+        trial_order = args.precisions[offset:] + args.precisions[:offset]
+        for precision in trial_order:
+            result = benchmark_precision(
+                args,
+                precision,
+                trial,
+                model_state,
+                x,
+                target,
+                device,
+            )
+            trial_results.append(asdict(result))
+    result_dicts = [
+        _aggregate_precision_trials(
+            precision,
+            [row for row in trial_results if row["precision"] == precision],
+        )
+        for precision in args.precisions
+    ]
+    efficiency = assess_model_efficiency(
+        result_dicts,
+        baseline_precision=args.baseline_precision,
+        min_training_speedup=args.min_training_speedup,
+        min_inference_speedup=args.min_inference_speedup,
+    )
+    payload = {
+        "metadata": {
+            "host": platform.node(),
+            "platform": platform.platform(),
+            "command": " ".join(sys.argv),
+            "commit": _commit(args.commit),
+            "device": str(device),
+            "gpu": torch.cuda.get_device_name(device),
+            "compute_capability": torch.cuda.get_device_capability(device),
+            "visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+            "torch_version": torch.__version__,
+            "torchao_version": _package_version("torchao"),
+            "transformer_engine_version": _package_version("transformer-engine"),
+            "triton_version": _package_version("triton"),
+        },
+        "config": {
+            "batch_size": args.batch_size,
+            "width": args.width,
+            "depth": args.depth,
+            "num_classes": args.num_classes,
+            "warmup": args.warmup,
+            "training_steps": args.training_steps,
+            "inference_steps": args.inference_steps,
+            "trials": args.trials,
+            "trial_order": "rotated",
+            "timing_scope": "steady_state_excludes_precision_conversion",
+            "precisions": args.precisions,
+        },
+        "results": result_dicts,
+        "efficiency": efficiency,
+    }
+
+    _print_results(result_dicts, efficiency)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        print(f"Wrote {args.output}")
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    if args.require_efficiency:
+        require_efficiency(efficiency)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/benchmark_fp8_training_inference.py
+++ b/benchmark/benchmark_fp8_training_inference.py
@@ -18,9 +18,13 @@ import torch
 import torch.nn as nn
 
 try:
-    from benchmark.fp8_efficiency import assess_model_efficiency, require_efficiency
+    from benchmark.fp8_efficiency import (
+        assess_model_efficiency,
+        percentile,
+        require_efficiency,
+    )
 except ModuleNotFoundError:
-    from fp8_efficiency import assess_model_efficiency, require_efficiency
+    from fp8_efficiency import assess_model_efficiency, percentile, require_efficiency
 from spikingjelly.activation_based.precision import (
     PrecisionConfig,
     prepare_model_for_precision,
@@ -328,22 +332,9 @@ def _aggregate_precision_trials(
     for metric_name in metric_names:
         values = [float(trial[metric_name]) for trial in trials]
         result[metric_name] = median(values)
-        result[f"{metric_name}_p25"] = _percentile(values, 0.25)
-        result[f"{metric_name}_p75"] = _percentile(values, 0.75)
+        result[f"{metric_name}_p25"] = percentile(values, 0.25)
+        result[f"{metric_name}_p75"] = percentile(values, 0.75)
     return result
-
-
-def _percentile(values: list[float], quantile: float) -> float:
-    if not values:
-        raise ValueError("Cannot compute a percentile from an empty sequence.")
-    if not 0.0 <= quantile <= 1.0:
-        raise ValueError("quantile must be in [0, 1].")
-    ordered = sorted(values)
-    position = (len(ordered) - 1) * quantile
-    lower = int(position)
-    upper = min(lower + 1, len(ordered) - 1)
-    fraction = position - lower
-    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
 
 
 def _print_results(results: list[dict[str, Any]], efficiency: dict[str, Any]) -> None:

--- a/benchmark/benchmark_triton_neuron_kernels.py
+++ b/benchmark/benchmark_triton_neuron_kernels.py
@@ -281,14 +281,16 @@ def _measure(
             fn()
         _cuda_sync(device)
         torch.cuda.reset_peak_memory_stats(device)
-        for _ in range(repeats):
-            start = torch.cuda.Event(enable_timing=True)
-            end = torch.cuda.Event(enable_timing=True)
+        starts = [torch.cuda.Event(enable_timing=True) for _ in range(repeats)]
+        ends = [torch.cuda.Event(enable_timing=True) for _ in range(repeats)]
+        for start, end in zip(starts, ends, strict=True):
             start.record()
             fn()
             end.record()
-            end.synchronize()
-            timings.append(start.elapsed_time(end))
+        _cuda_sync(device)
+        timings = [
+            start.elapsed_time(end) for start, end in zip(starts, ends, strict=True)
+        ]
         peak_allocated_mb = torch.cuda.max_memory_allocated(device) / 1024.0 / 1024.0
         peak_reserved_mb = torch.cuda.max_memory_reserved(device) / 1024.0 / 1024.0
         return {
@@ -862,7 +864,6 @@ def main() -> None:
                     finally:
                         if "x" in locals():
                             del x
-                        torch.cuda.empty_cache()
                     rows.append(row)
                     _write_outputs(output_dir, metadata, rows)
                     print(

--- a/benchmark/benchmark_triton_neuron_kernels.py
+++ b/benchmark/benchmark_triton_neuron_kernels.py
@@ -17,10 +17,11 @@ import torch
 try:
     from benchmark.fp8_efficiency import (
         assess_triton_efficiency,
+        percentile,
         require_efficiency,
     )
 except ModuleNotFoundError:
-    from fp8_efficiency import assess_triton_efficiency, require_efficiency
+    from fp8_efficiency import assess_triton_efficiency, percentile, require_efficiency
 from spikingjelly.activation_based import surrogate
 from spikingjelly.activation_based.triton_kernel.fp8_capability import (
     triton_fp8_neuron_capability_report,
@@ -296,24 +297,13 @@ def _measure(
         return {
             "avg_ms": sum(timings) / len(timings),
             "median_ms": median(timings),
-            "p25_ms": _percentile(timings, 0.25),
-            "p75_ms": _percentile(timings, 0.75),
+            "p25_ms": percentile(timings, 0.25),
+            "p75_ms": percentile(timings, 0.75),
             "min_ms": min(timings),
             "max_ms": max(timings),
             "peak_allocated_mb": peak_allocated_mb,
             "peak_reserved_mb": peak_reserved_mb,
         }
-
-
-def _percentile(values: list[float], quantile: float) -> float:
-    if not values:
-        raise ValueError("Cannot compute a percentile from an empty sequence.")
-    ordered = sorted(values)
-    position = (len(ordered) - 1) * quantile
-    lower = int(position)
-    upper = min(lower + 1, len(ordered) - 1)
-    fraction = position - lower
-    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
 
 
 def _benchmark_inference(

--- a/benchmark/benchmark_triton_neuron_kernels.py
+++ b/benchmark/benchmark_triton_neuron_kernels.py
@@ -273,33 +273,34 @@ def _measure(
     warmup: int,
     fn: Callable[[], Any],
 ) -> dict[str, float]:
-    timings: list[float] = []
-    torch.cuda.empty_cache()
-    _cuda_sync(device)
-    for _ in range(warmup):
-        fn()
-    _cuda_sync(device)
-    torch.cuda.reset_peak_memory_stats(device)
-    for _ in range(repeats):
-        start = torch.cuda.Event(enable_timing=True)
-        end = torch.cuda.Event(enable_timing=True)
-        start.record()
-        fn()
-        end.record()
-        end.synchronize()
-        timings.append(start.elapsed_time(end))
-    peak_allocated_mb = torch.cuda.max_memory_allocated(device) / 1024.0 / 1024.0
-    peak_reserved_mb = torch.cuda.max_memory_reserved(device) / 1024.0 / 1024.0
-    return {
-        "avg_ms": sum(timings) / len(timings),
-        "median_ms": median(timings),
-        "p25_ms": _percentile(timings, 0.25),
-        "p75_ms": _percentile(timings, 0.75),
-        "min_ms": min(timings),
-        "max_ms": max(timings),
-        "peak_allocated_mb": peak_allocated_mb,
-        "peak_reserved_mb": peak_reserved_mb,
-    }
+    with torch.cuda.device(device):
+        timings: list[float] = []
+        torch.cuda.empty_cache()
+        _cuda_sync(device)
+        for _ in range(warmup):
+            fn()
+        _cuda_sync(device)
+        torch.cuda.reset_peak_memory_stats(device)
+        for _ in range(repeats):
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            fn()
+            end.record()
+            end.synchronize()
+            timings.append(start.elapsed_time(end))
+        peak_allocated_mb = torch.cuda.max_memory_allocated(device) / 1024.0 / 1024.0
+        peak_reserved_mb = torch.cuda.max_memory_reserved(device) / 1024.0 / 1024.0
+        return {
+            "avg_ms": sum(timings) / len(timings),
+            "median_ms": median(timings),
+            "p25_ms": _percentile(timings, 0.25),
+            "p75_ms": _percentile(timings, 0.75),
+            "min_ms": min(timings),
+            "max_ms": max(timings),
+            "peak_allocated_mb": peak_allocated_mb,
+            "peak_reserved_mb": peak_reserved_mb,
+        }
 
 
 def _percentile(values: list[float], quantile: float) -> float:

--- a/benchmark/benchmark_triton_neuron_kernels.py
+++ b/benchmark/benchmark_triton_neuron_kernels.py
@@ -14,6 +14,13 @@ from typing import Any, Callable
 
 import torch
 
+try:
+    from benchmark.fp8_efficiency import (
+        assess_triton_efficiency,
+        require_efficiency,
+    )
+except ModuleNotFoundError:
+    from fp8_efficiency import assess_triton_efficiency, require_efficiency
 from spikingjelly.activation_based import surrogate
 from spikingjelly.activation_based.triton_kernel.fp8_capability import (
     triton_fp8_neuron_capability_report,
@@ -91,8 +98,8 @@ def _cuda_sync(device: torch.device) -> None:
     torch.cuda.synchronize(device)
 
 
-def _make_input(T: int, N: int, device: torch.device) -> torch.Tensor:
-    return torch.randn(T, N, device=device, dtype=torch.float32)
+def _make_input(T: int, N: int) -> torch.Tensor:
+    return torch.randn(T, N, device="cpu", dtype=torch.float32)
 
 
 def _call_stable(
@@ -274,18 +281,36 @@ def _measure(
     _cuda_sync(device)
     torch.cuda.reset_peak_memory_stats(device)
     for _ in range(repeats):
-        start = time.perf_counter()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
         fn()
-        _cuda_sync(device)
-        timings.append((time.perf_counter() - start) * 1000.0)
+        end.record()
+        end.synchronize()
+        timings.append(start.elapsed_time(end))
     peak_allocated_mb = torch.cuda.max_memory_allocated(device) / 1024.0 / 1024.0
+    peak_reserved_mb = torch.cuda.max_memory_reserved(device) / 1024.0 / 1024.0
     return {
         "avg_ms": sum(timings) / len(timings),
         "median_ms": median(timings),
+        "p25_ms": _percentile(timings, 0.25),
+        "p75_ms": _percentile(timings, 0.75),
         "min_ms": min(timings),
         "max_ms": max(timings),
         "peak_allocated_mb": peak_allocated_mb,
+        "peak_reserved_mb": peak_reserved_mb,
     }
+
+
+def _percentile(values: list[float], quantile: float) -> float:
+    if not values:
+        raise ValueError("Cannot compute a percentile from an empty sequence.")
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
 
 
 def _benchmark_inference(
@@ -303,7 +328,7 @@ def _benchmark_inference(
 ) -> dict[str, float]:
     v_init = torch.zeros_like(x[0])
     r_tau_tensor = (
-        torch.tensor(_R_TAU, device=device, dtype=torch.float32)
+        torch.tensor(_R_TAU, device=x.device, dtype=x.dtype)
         if neuron_type == "plif"
         else None
     )
@@ -361,7 +386,7 @@ def _benchmark_training(
     r_tau_tensor = None
     if neuron_type == "plif":
         r_tau_tensor = torch.tensor(
-            _R_TAU, device=device, dtype=torch.float32, requires_grad=True
+            _R_TAU, device=x.device, dtype=x.dtype, requires_grad=True
         )
 
     def fn() -> None:
@@ -412,6 +437,13 @@ def _dtype_variants() -> list[tuple[str, torch.dtype]]:
     return variants
 
 
+def _higher_precision_variants() -> list[tuple[str, torch.dtype, str]]:
+    return [
+        ("float16", torch.float16, "fp16"),
+        ("bfloat16", torch.bfloat16, "bf16"),
+    ]
+
+
 def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
     fieldnames = [
         "T",
@@ -426,10 +458,13 @@ def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         "success",
         "avg_ms",
         "median_ms",
+        "p25_ms",
+        "p75_ms",
         "min_ms",
         "max_ms",
         "throughput_melems_s",
         "peak_allocated_mb",
+        "peak_reserved_mb",
         "plan_prepare_ms",
         "failure_reason",
     ]
@@ -450,7 +485,12 @@ def _format_float(value: Any, digits: int = 3) -> str:
     return str(value)
 
 
-def _write_markdown(path: Path, rows: list[dict[str, Any]], metadata: dict[str, Any]) -> None:
+def _write_markdown(
+    path: Path,
+    rows: list[dict[str, Any]],
+    metadata: dict[str, Any],
+    efficiency: dict[str, Any],
+) -> None:
     lines = [
         "# Triton Neuron Kernel Benchmark",
         "",
@@ -459,7 +499,7 @@ def _write_markdown(path: Path, rows: list[dict[str, Any]], metadata: dict[str, 
         f"- Commit: `{metadata.get('commit')}` ({metadata.get('commit_source')})",
         f"- Command: `{metadata['command']}`",
         "",
-        "| T | N | neuron | variant | process | avg ms | median ms | throughput Melem/s | peak MB |",
+        "| T | N | neuron | variant | process | median ms | P25-P75 ms | throughput Melem/s | allocated/reserved MB |",
         "|---:|---:|---|---|---|---:|---:|---:|---:|",
     ]
     for row in rows:
@@ -474,10 +514,11 @@ def _write_markdown(path: Path, rows: list[dict[str, Any]], metadata: dict[str, 
                     str(row["neuron_type"]),
                     str(row["variant"]),
                     str(row["process"]),
-                    _format_float(row["avg_ms"]),
                     _format_float(row["median_ms"]),
+                    f"{_format_float(row['p25_ms'])}-{_format_float(row['p75_ms'])}",
                     _format_float(row["throughput_melems_s"]),
-                    _format_float(row["peak_allocated_mb"]),
+                    f"{_format_float(row['peak_allocated_mb'])}/"
+                    f"{_format_float(row['peak_reserved_mb'])}",
                 ]
             )
             + " |"
@@ -486,12 +527,51 @@ def _write_markdown(path: Path, rows: list[dict[str, Any]], metadata: dict[str, 
     if failures:
         lines.extend(["", "## Failures", ""])
         for row in failures:
-            lines.append(
-                "- "
+            failure_reason = (
+                str(row.get("failure_reason")).replace("\r", " ").replace("\n", " ")
+            )
+            failure = (
                 f"T={row['T']} N={row['N']} neuron={row['neuron_type']} "
                 f"variant={row['variant']} process={row['process']}: "
-                f"{row.get('failure_reason')}"
+                f"{failure_reason}"
             )
+            code_fence = "`"
+            while code_fence in failure:
+                code_fence += "`"
+            lines.append(f"- {code_fence}{failure}{code_fence}")
+    lines.extend(
+        [
+            "",
+            "## FP8-Storage Mixed-Precision Efficiency",
+            "",
+            f"Required speedup: `{efficiency['min_speedup']:.3f}x`",
+            "",
+            "| T | N | neuron | process | best FP8 plan | compute | speedup | "
+            "memory ratio | passed |",
+            "|---:|---:|---|---|---|---|---:|---:|---|",
+        ]
+    )
+    for comparison in efficiency["comparisons"]:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(comparison["T"]),
+                    str(comparison["N"]),
+                    str(comparison["neuron_type"]),
+                    str(comparison["process"]),
+                    str(comparison["best_fp8_variant"]),
+                    str(comparison["best_compute_dtype"]),
+                    f"{comparison['speedup']:.3f}x",
+                    f"{comparison['memory_ratio']:.3f}x",
+                    str(comparison["passed"]),
+                ]
+            )
+            + " |"
+        )
+    if efficiency["failures"]:
+        lines.extend(["", "### Efficiency Failures", ""])
+        lines.extend(f"- {failure}" for failure in efficiency["failures"])
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
@@ -499,14 +579,16 @@ def _write_outputs(
     output_dir: Path,
     metadata: dict[str, Any],
     rows: list[dict[str, Any]],
-) -> None:
-    payload = {"metadata": metadata, "rows": rows}
+) -> dict[str, Any]:
+    efficiency = assess_triton_efficiency(rows, min_speedup=metadata["min_speedup"])
+    payload = {"metadata": metadata, "rows": rows, "efficiency": efficiency}
     json_path = output_dir / "triton_neuron_kernel_benchmark.json"
     csv_path = output_dir / "triton_neuron_kernel_benchmark.csv"
     md_path = output_dir / "triton_neuron_kernel_benchmark.md"
-    json_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    json_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     _write_csv(csv_path, rows)
-    _write_markdown(md_path, rows, metadata)
+    _write_markdown(md_path, rows, metadata, efficiency)
+    return efficiency
 
 
 def main() -> None:
@@ -520,10 +602,19 @@ def main() -> None:
         help="Comma-separated T x N sizes.",
     )
     parser.add_argument("--neurons", default="if,lif,plif")
-    parser.add_argument("--compute-dtypes", default="fp16,bf16,fp32")
+    parser.add_argument("--compute-dtypes", default="fp8,fp16,bf16,fp32")
     parser.add_argument("--backward-compute-dtype", default="fp32")
     parser.add_argument("--warmup", type=int, default=5)
     parser.add_argument("--repeats", type=int, default=20)
+    parser.add_argument("--min-speedup", type=float, default=1.05)
+    parser.add_argument(
+        "--require-efficiency",
+        action="store_true",
+        help=(
+            "Exit non-zero unless the fastest successful FP8-storage prepared "
+            "plan for every case beats stable FP32 by --min-speedup."
+        ),
+    )
     parser.add_argument(
         "--include-safe-wrapper",
         action="store_true",
@@ -538,6 +629,8 @@ def main() -> None:
         raise ValueError("--warmup must be >= 0.")
     if args.repeats <= 0:
         raise ValueError("--repeats must be > 0.")
+    if args.min_speedup <= 0:
+        raise ValueError("--min-speedup must be > 0.")
 
     sizes = _parse_sizes(args.sizes)
     neurons = [item.strip() for item in args.neurons.split(",") if item.strip()]
@@ -578,7 +671,9 @@ def main() -> None:
         "backward_compute_dtype": backward_compute_dtype,
         "warmup": args.warmup,
         "repeats": args.repeats,
+        "min_speedup": args.min_speedup,
         "mp_plan_reuse": True,
+        "variant_order": "rotated_by_size_neuron_and_process",
         "inference_save_intermediates": False,
         "training_save_intermediates": True,
         "loss_outputs": "s_seq,v_seq",
@@ -591,10 +686,10 @@ def main() -> None:
     dtype_variants = _dtype_variants()
     _write_outputs(output_dir, metadata, rows)
 
-    for T, N in sizes:
-        x = _make_input(T, N, device)
+    for size_index, (T, N) in enumerate(sizes):
+        x_host = _make_input(T, N)
         elements = T * N
-        for neuron_type in neurons:
+        for neuron_index, neuron_type in enumerate(neurons):
             variants: list[dict[str, Any]] = [
                 {
                     "variant": "stable_fp32",
@@ -604,9 +699,28 @@ def main() -> None:
                     "plan": None,
                     "uses_plan": False,
                     "storage_dtype_obj": None,
+                    "input_dtype_obj": torch.float32,
                     "plan_prepare_ms": None,
                 }
             ]
+            for (
+                storage_name,
+                storage_dtype,
+                compute_dtype,
+            ) in _higher_precision_variants():
+                variants.append(
+                    {
+                        "variant": f"stable_{storage_name}",
+                        "variant_kind": "stable",
+                        "storage_dtype": storage_name,
+                        "compute_dtype": compute_dtype,
+                        "plan": None,
+                        "uses_plan": False,
+                        "storage_dtype_obj": None,
+                        "input_dtype_obj": storage_dtype,
+                        "plan_prepare_ms": None,
+                    }
+                )
             for storage_name, storage_dtype in dtype_variants:
                 for compute_dtype in compute_dtypes:
                     variants.append(
@@ -618,6 +732,7 @@ def main() -> None:
                             "plan": None,
                             "uses_plan": True,
                             "storage_dtype_obj": storage_dtype,
+                            "input_dtype_obj": torch.float32,
                             "plan_prepare_ms": None,
                         }
                     )
@@ -631,12 +746,17 @@ def main() -> None:
                                 "plan": None,
                                 "uses_plan": False,
                                 "storage_dtype_obj": storage_dtype,
+                                "input_dtype_obj": torch.float32,
                                 "plan_prepare_ms": None,
                             }
                         )
 
-            for process in ("inference_forward", "training_forward_backward"):
-                for variant in variants:
+            for process_index, process in enumerate(
+                ("inference_forward", "training_forward_backward")
+            ):
+                offset = (size_index + neuron_index + process_index) % len(variants)
+                ordered_variants = variants[offset:] + variants[:offset]
+                for variant in ordered_variants:
                     print(
                         "START "
                         f"T={T} N={N} neuron={neuron_type} "
@@ -654,9 +774,7 @@ def main() -> None:
                         "backward_compute_dtype": backward_compute_dtype,
                         "process": process,
                         "plan_prepare_ms": variant.get("plan_prepare_ms"),
-                        "save_intermediates": (
-                            process == "training_forward_backward"
-                        ),
+                        "save_intermediates": (process == "training_forward_backward"),
                         "loss_outputs": "s_seq,v_seq",
                     }
                     plan = variant["plan"]
@@ -698,6 +816,10 @@ def main() -> None:
                             )
                             continue
                     try:
+                        x = x_host.to(
+                            device=device,
+                            dtype=variant["input_dtype_obj"],
+                        )
                         if process == "inference_forward":
                             metrics = _benchmark_inference(
                                 x=x,
@@ -726,7 +848,9 @@ def main() -> None:
                             )
                         row.update(metrics)
                         row["success"] = True
-                        row["throughput_melems_s"] = elements / row["avg_ms"] / 1000.0
+                        row["throughput_melems_s"] = (
+                            elements / row["median_ms"] / 1000.0
+                        )
                     except Exception as e:
                         row.update(
                             {
@@ -734,6 +858,10 @@ def main() -> None:
                                 "failure_reason": f"{type(e).__name__}: {e or repr(e)}",
                             }
                         )
+                    finally:
+                        if "x" in locals():
+                            del x
+                        torch.cuda.empty_cache()
                     rows.append(row)
                     _write_outputs(output_dir, metadata, rows)
                     print(
@@ -744,13 +872,16 @@ def main() -> None:
                         flush=True,
                     )
 
-    _write_outputs(output_dir, metadata, rows)
+    efficiency = _write_outputs(output_dir, metadata, rows)
     json_path = output_dir / "triton_neuron_kernel_benchmark.json"
     csv_path = output_dir / "triton_neuron_kernel_benchmark.csv"
     md_path = output_dir / "triton_neuron_kernel_benchmark.md"
     print(f"Wrote {json_path}")
     print(f"Wrote {csv_path}")
     print(f"Wrote {md_path}")
+    print(f"FP8 efficiency passed={efficiency['passed']}")
+    if args.require_efficiency:
+        require_efficiency(efficiency)
 
 
 if __name__ == "__main__":

--- a/benchmark/fp8_efficiency.py
+++ b/benchmark/fp8_efficiency.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+def _positive_float(row: Mapping[str, Any], key: str) -> float:
+    if key not in row:
+        raise ValueError(f"{key} is required.")
+    try:
+        value = float(row[key])
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{key} must be a finite positive number, but got {row[key]!r}."
+        ) from exc
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(
+            f"{key} must be a finite positive number, but got {row[key]!r}."
+        )
+    return value
+
+
+def assess_model_efficiency(
+    results: Iterable[Mapping[str, Any]],
+    *,
+    baseline_precision: str,
+    min_training_speedup: float,
+    min_inference_speedup: float,
+) -> dict[str, Any]:
+    results = list(results)
+    if (
+        not math.isfinite(min_training_speedup)
+        or not math.isfinite(min_inference_speedup)
+        or min_training_speedup <= 0
+        or min_inference_speedup <= 0
+    ):
+        raise ValueError("Minimum speedups must be finite and positive.")
+    if baseline_precision.startswith("fp8-"):
+        raise ValueError(
+            "baseline_precision must not be an FP8 variant, but got "
+            f"{baseline_precision!r}."
+        )
+    baselines = [row for row in results if row["precision"] == baseline_precision]
+    if len(baselines) != 1:
+        raise ValueError(
+            f"Expected exactly one {baseline_precision!r} baseline, "
+            f"but found {len(baselines)}."
+        )
+    candidates = [row for row in results if str(row["precision"]).startswith("fp8-")]
+    if not candidates:
+        raise ValueError("At least one FP8 precision result is required.")
+
+    baseline = baselines[0]
+    baseline_training = _positive_float(baseline, "training_samples_per_sec")
+    baseline_inference = _positive_float(baseline, "inference_samples_per_sec")
+    baseline_training_memory = _positive_float(baseline, "training_peak_allocated_mb")
+    baseline_inference_memory = _positive_float(baseline, "inference_peak_allocated_mb")
+    comparisons = []
+    failures = []
+
+    for candidate in candidates:
+        precision = str(candidate["precision"])
+        training_speedup = (
+            _positive_float(candidate, "training_samples_per_sec") / baseline_training
+        )
+        inference_speedup = (
+            _positive_float(candidate, "inference_samples_per_sec") / baseline_inference
+        )
+        training_memory_ratio = (
+            _positive_float(candidate, "training_peak_allocated_mb")
+            / baseline_training_memory
+        )
+        inference_memory_ratio = (
+            _positive_float(candidate, "inference_peak_allocated_mb")
+            / baseline_inference_memory
+        )
+        training_passed = training_speedup >= min_training_speedup
+        inference_passed = inference_speedup >= min_inference_speedup
+        if not training_passed:
+            failures.append(
+                f"{precision} training speedup {training_speedup:.4f}x "
+                f"< {min_training_speedup:.4f}x"
+            )
+        if not inference_passed:
+            failures.append(
+                f"{precision} inference speedup {inference_speedup:.4f}x "
+                f"< {min_inference_speedup:.4f}x"
+            )
+        comparisons.append(
+            {
+                "precision": precision,
+                "training_speedup": training_speedup,
+                "inference_speedup": inference_speedup,
+                "training_memory_ratio": training_memory_ratio,
+                "inference_memory_ratio": inference_memory_ratio,
+                "training_passed": training_passed,
+                "inference_passed": inference_passed,
+                "passed": training_passed and inference_passed,
+            }
+        )
+
+    return {
+        "baseline_precision": baseline_precision,
+        "min_training_speedup": min_training_speedup,
+        "min_inference_speedup": min_inference_speedup,
+        "comparisons": comparisons,
+        "failures": failures,
+        "passed": not failures,
+    }
+
+
+def assess_triton_efficiency(
+    rows: Iterable[Mapping[str, Any]], *, min_speedup: float
+) -> dict[str, Any]:
+    if not math.isfinite(min_speedup) or min_speedup <= 0:
+        raise ValueError("min_speedup must be finite and positive.")
+    rows = list(rows)
+    group_fields = ("T", "N", "neuron_type", "process")
+    all_baselines = [row for row in rows if row.get("variant") == "stable_fp32"]
+    baselines = [row for row in all_baselines if row.get("success") is True]
+    comparisons = []
+    failures = []
+
+    if not all_baselines:
+        failures.append("no usable stable_fp32 baseline results")
+
+    for baseline in all_baselines:
+        if baseline.get("success") is True:
+            continue
+        group = tuple(baseline.get(field) for field in group_fields)
+        label = f"T={group[0]} N={group[1]} neuron={group[2]} process={group[3]}"
+        reason = baseline.get("failure_reason") or "unknown failure"
+        failures.append(f"{label} stable_fp32 baseline failed: {reason}")
+
+    seen_groups = set()
+    for baseline in baselines:
+        group = tuple(baseline.get(field) for field in group_fields)
+        label = f"T={group[0]} N={group[1]} neuron={group[2]} process={group[3]}"
+        missing_fields = [
+            field
+            for field, value in zip(group_fields, group, strict=True)
+            if value is None
+        ]
+        if missing_fields:
+            failures.append(
+                f"{label} stable_fp32 baseline is missing required group fields: "
+                + ", ".join(missing_fields)
+            )
+            continue
+        if group in seen_groups:
+            failures.append(f"{label} has duplicate successful stable_fp32 baselines")
+            continue
+        seen_groups.add(group)
+        candidates = [
+            row
+            for row in rows
+            if row.get("success") is True
+            and str(row.get("variant", "")).startswith("mp_plan_float8_")
+            and tuple(row.get(field) for field in group_fields) == group
+        ]
+        if not candidates:
+            failures.append(f"{label} has no successful FP8 prepared-plan result")
+            continue
+
+        best = min(candidates, key=lambda row: _positive_float(row, "median_ms"))
+        baseline_ms = _positive_float(baseline, "median_ms")
+        best_ms = _positive_float(best, "median_ms")
+        speedup = baseline_ms / best_ms
+        baseline_memory = _positive_float(baseline, "peak_allocated_mb")
+        best_memory = _positive_float(best, "peak_allocated_mb")
+        passed = speedup >= min_speedup
+        if not passed:
+            failures.append(
+                f"{label} best FP8 speedup {speedup:.4f}x < {min_speedup:.4f}x"
+            )
+        comparisons.append(
+            {
+                "T": group[0],
+                "N": group[1],
+                "neuron_type": group[2],
+                "process": group[3],
+                "baseline_variant": "stable_fp32",
+                "best_fp8_variant": best["variant"],
+                "best_compute_dtype": best.get("compute_dtype"),
+                "speedup": speedup,
+                "memory_ratio": best_memory / baseline_memory,
+                "passed": passed,
+            }
+        )
+
+    return {
+        "baseline_variant": "stable_fp32",
+        "min_speedup": min_speedup,
+        "comparisons": comparisons,
+        "failures": failures,
+        "passed": not failures,
+    }
+
+
+def require_efficiency(report: Mapping[str, Any]) -> None:
+    if report.get("passed") is True:
+        return
+    failures = report.get("failures") or ["efficiency requirements were not met"]
+    raise RuntimeError("FP8 efficiency validation failed: " + "; ".join(failures))

--- a/benchmark/fp8_efficiency.py
+++ b/benchmark/fp8_efficiency.py
@@ -27,6 +27,19 @@ def _row_precision(row: Mapping[str, Any]) -> str:
     return str(row["precision"])
 
 
+def percentile(values: list[float], quantile: float) -> float:
+    if not values:
+        raise ValueError("Cannot compute a percentile from an empty sequence.")
+    if not 0.0 <= quantile <= 1.0:
+        raise ValueError("quantile must be in [0, 1].")
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+
 def assess_model_efficiency(
     results: Iterable[Mapping[str, Any]],
     *,

--- a/benchmark/fp8_efficiency.py
+++ b/benchmark/fp8_efficiency.py
@@ -21,6 +21,12 @@ def _positive_float(row: Mapping[str, Any], key: str) -> float:
     return value
 
 
+def _row_precision(row: Mapping[str, Any]) -> str:
+    if "precision" not in row:
+        raise ValueError("precision is required.")
+    return str(row["precision"])
+
+
 def assess_model_efficiency(
     results: Iterable[Mapping[str, Any]],
     *,
@@ -41,13 +47,13 @@ def assess_model_efficiency(
             "baseline_precision must not be an FP8 variant, but got "
             f"{baseline_precision!r}."
         )
-    baselines = [row for row in results if row["precision"] == baseline_precision]
+    baselines = [row for row in results if _row_precision(row) == baseline_precision]
     if len(baselines) != 1:
         raise ValueError(
             f"Expected exactly one {baseline_precision!r} baseline, "
             f"but found {len(baselines)}."
         )
-    candidates = [row for row in results if str(row["precision"]).startswith("fp8-")]
+    candidates = [row for row in results if _row_precision(row).startswith("fp8-")]
     if not candidates:
         raise ValueError("At least one FP8 precision result is required.")
 
@@ -60,7 +66,7 @@ def assess_model_efficiency(
     failures = []
 
     for candidate in candidates:
-        precision = str(candidate["precision"])
+        precision = _row_precision(candidate)
         training_speedup = (
             _positive_float(candidate, "training_samples_per_sec") / baseline_training
         )
@@ -188,6 +194,19 @@ def assess_triton_efficiency(
                 "passed": passed,
             }
         )
+
+    baseline_groups = {
+        tuple(row.get(field) for field in group_fields) for row in all_baselines
+    }
+    fp8_groups = {
+        tuple(row.get(field) for field in group_fields)
+        for row in rows
+        if row.get("success") is True
+        and str(row.get("variant", "")).startswith("mp_plan_float8_")
+    }
+    for group in sorted(fp8_groups - baseline_groups, key=repr):
+        label = f"T={group[0]} N={group[1]} neuron={group[2]} process={group[3]}"
+        failures.append(f"{label} has no successful stable_fp32 baseline")
 
     return {
         "baseline_variant": "stable_fp32",

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -33,6 +33,14 @@ Module: ``spikingjelly.activation_based.precision``.
   LayerNorm, exact LayerNormLinear / LayerNormMLP fusion patterns, and SDPA
   argument validation.
 
+- Added Transformer Engine SDPA output-layout compatibility for both
+  ``[B, S, H, D]`` and flattened ``[B, S, H * D]`` results, and scoped FP8
+  autocast to the configured indexed CUDA device.
+
+- Improved Transformer Engine capability failures to preserve the underlying
+  import or runtime error instead of reporting every import failure as a
+  missing installation.
+
 - Added precision conversion reports with pointwise Conv1d, LayerNorm,
   fused-pattern metadata, and shared-module identity preservation for
   Transformer Engine fused precision patterns.
@@ -47,10 +55,18 @@ Module: ``spikingjelly.activation_based.triton_kernel.neuron_kernel``.
   experiments with configurable forward and backward compute dtypes.
 
 - Added FP8 Triton neuron capability probes and a reusable execution plan for
-  repeated mixed-precision neuron launches.
+  repeated mixed-precision neuron launches. Capability reports distinguish
+  FP32, FP16, BF16, and FP8 compute probes for each FP8 storage format.
 
 - Added an FP8 Triton neuron benchmark harness for IF, LIF, and ParametricLIF
-  accuracy, backward-gradient, and prepared-plan overhead measurements.
+  accuracy, backward-gradient, prepared-plan overhead, FP16/BF16 comparisons,
+  timing quartiles, and allocated/reserved CUDA memory measurements.
+
+- Validated FP8 training and inference on RTX 5090 with PyTorch 2.7.1 / Triton
+  3.3.1 and PyTorch 2.11 / Triton 3.6. The validated boundary is FP8 storage
+  and GEMM with higher-precision scalar computation or accumulation; pure FP8
+  scalar neuron computation is unsupported, and the measurements do not show
+  a universal speed or peak-memory advantage over BF16.
 
 Bug Fixes
 ~~~~~~~~~

--- a/spikingjelly/activation_based/precision/capability.py
+++ b/spikingjelly/activation_based/precision/capability.py
@@ -23,11 +23,11 @@ def _transformer_engine_fp8_status() -> tuple[
 ]:
     try:
         import transformer_engine.pytorch as te
-    except ImportError:
+    except ImportError as exc:
         return (
             False,
             False,
-            "transformer-engine is not installed",
+            f"transformer-engine import failed: {exc}",
             None,
             {},
         )
@@ -333,6 +333,9 @@ def _validate_fp8(report: dict[str, Any]) -> None:
 
 def _validate_fp8_te(report: dict[str, Any]) -> None:
     if not report.get("transformer_engine_installed", False):
+        reason = report.get("te_fp8_unavailable_reason")
+        if reason:
+            raise RuntimeError(f"precision='fp8-te' is unavailable: {reason}")
         raise RuntimeError(
             "precision='fp8-te' requires transformer-engine, but transformer-engine "
             "is not installed."

--- a/spikingjelly/activation_based/precision/capability.py
+++ b/spikingjelly/activation_based/precision/capability.py
@@ -333,13 +333,10 @@ def _validate_fp8(report: dict[str, Any]) -> None:
 
 def _validate_fp8_te(report: dict[str, Any]) -> None:
     if not report.get("transformer_engine_installed", False):
-        reason = report.get("te_fp8_unavailable_reason")
-        if reason:
-            raise RuntimeError(f"precision='fp8-te' is unavailable: {reason}")
-        raise RuntimeError(
-            "precision='fp8-te' requires transformer-engine, but transformer-engine "
-            "is not installed."
+        reason = report.get("te_fp8_unavailable_reason") or (
+            "transformer-engine is not installed."
         )
+        raise RuntimeError(f"precision='fp8-te' is unavailable: {reason}")
     if report["device_type"] != "cuda":
         raise RuntimeError(
             "precision='fp8-te' is only supported on CUDA in the current stage."

--- a/spikingjelly/activation_based/precision/float8_attention.py
+++ b/spikingjelly/activation_based/precision/float8_attention.py
@@ -15,25 +15,59 @@ def _import_te_pytorch():
 
 
 class TransformerEngineDotProductAttentionAdapter(nn.Module):
-    """Adapter for standard PyTorch SDPA tensors backed by TE DotProductAttention.
-
-    The public input/output layout is PyTorch's common ``[B, H, S, D]`` layout.
-    Internally the adapter calls TE with explicit ``bshd`` layout tensors.
-
-    Version 1 intentionally supports only no-mask SDPA: ``attn_mask`` must be
-    ``None``, ``is_causal`` must be ``False``, and ``scale`` must be ``None``.
-    During training, ``dropout_p`` must match the adapter's fixed
-    ``attention_dropout``; during evaluation it must be ``0.0``. Query sequence
-    length may differ from key/value sequence length for cross-attention, but
-    key and value sequence lengths must match.
-    """
-
     def __init__(
         self,
         num_attention_heads: int,
         head_dim: int,
         attention_dropout: float = 0.0,
-    ):
+    ) -> None:
+        r"""
+        **API Language** - 中文 | English
+
+        中文
+        ----
+
+        将 PyTorch SDPA 常用的 ``[B, H, S, D]`` 输入输出布局适配到
+        Transformer Engine ``DotProductAttention`` 的 ``bshd`` 布局。兼容 TE
+        返回 ``[B, S, H, D]`` 或展平的 ``[B, S, H * D]`` 张量。
+        交叉注意力允许查询序列长度与键值序列长度不同，但键和值的序列长度
+        必须相同。
+
+        当前仅支持无掩码注意力：``attn_mask`` 必须为 ``None``，
+        ``is_causal`` 必须为 ``False``，``scale`` 必须为 ``None``。训练时
+        ``dropout_p`` 必须等于固定的 ``attention_dropout``；推理时必须为
+        ``0.0``。
+
+        :param num_attention_heads: 注意力头数，必须与输入的 ``H`` 一致。
+        :type num_attention_heads: int
+        :param head_dim: 每个注意力头的维度，必须与输入的 ``D`` 一致。
+        :type head_dim: int
+        :param attention_dropout: 训练时使用的固定注意力 dropout 概率。
+        :type attention_dropout: float
+
+        English
+        -------
+
+        Adapts PyTorch SDPA's common ``[B, H, S, D]`` input/output layout to
+        Transformer Engine ``DotProductAttention`` with the ``bshd`` layout. TE
+        outputs in either ``[B, S, H, D]`` or flattened ``[B, S, H * D]`` form
+        are supported. Cross-attention may use a different query sequence length,
+        but the key and value sequence lengths must match.
+
+        This version supports unmasked attention only: ``attn_mask`` must be
+        ``None``, ``is_causal`` must be ``False``, and ``scale`` must be
+        ``None``. During training, ``dropout_p`` must equal the fixed
+        ``attention_dropout``; during evaluation it must be ``0.0``.
+
+        :param num_attention_heads: Number of attention heads; must match input
+            dimension ``H``.
+        :type num_attention_heads: int
+        :param head_dim: Per-head dimension; must match input dimension ``D``.
+        :type head_dim: int
+        :param attention_dropout: Fixed attention dropout probability for
+            training.
+        :type attention_dropout: float
+        """
         super().__init__()
         te = _import_te_pytorch()
         DotProductAttention = te.DotProductAttention
@@ -176,6 +210,24 @@ class TransformerEngineDotProductAttentionAdapter(nn.Module):
         output = self._call_te_attention(q, k, v)
         if isinstance(output, tuple):
             output = output[0]
+        expected_shape = (
+            query.shape[0],
+            query.shape[2],
+            self.num_attention_heads,
+            self.head_dim,
+        )
+        if output.ndim == 3 and output.shape == (
+            expected_shape[0],
+            expected_shape[1],
+            expected_shape[2] * expected_shape[3],
+        ):
+            output = output.reshape(expected_shape)
+        elif output.shape != expected_shape:
+            raise RuntimeError(
+                "Transformer Engine DotProductAttention returned an unsupported "
+                f"shape {tuple(output.shape)}; expected {expected_shape} or "
+                f"{expected_shape[:2] + (expected_shape[2] * expected_shape[3],)}."
+            )
         return output.transpose(1, 2).contiguous()
 
     def _call_te_attention(

--- a/spikingjelly/activation_based/precision/float8_te.py
+++ b/spikingjelly/activation_based/precision/float8_te.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 import importlib
 import warnings
 
@@ -18,6 +18,12 @@ from .float8_conv import (
 from .policy import PrecisionPolicy
 
 _SUPPORTED_TE_RECIPES = {"auto", "delayed", "current", "block", "mxfp8"}
+
+
+@contextmanager
+def _cuda_device_autocast_context(device: torch.device, autocast_context):
+    with torch.cuda.device(device), autocast_context:
+        yield
 
 
 def _import_te_pytorch():
@@ -452,6 +458,7 @@ class Float8TransformerEnginePolicy(PrecisionPolicy):
         self._resolved_recipe_name: str | None = None
         self._resolved_recipe = None
         self._recipe_resolved = False
+        self._target_device: torch.device | None = None
 
     def describe(self) -> dict:
         return {
@@ -466,10 +473,14 @@ class Float8TransformerEnginePolicy(PrecisionPolicy):
         }
 
     def check_capability(self, model, device) -> None:
+        target_device = torch.device(device)
         report = build_capability_report(model, device, self.name)
         self._capability_report = report
         self._annotate_recipe_report(report)
         validate_capability(report)
+        if target_device.type == "cuda" and target_device.index is None:
+            target_device = torch.device("cuda", torch.cuda.current_device())
+        self._target_device = target_device
         if report.get("transformer_engine_installed", False):
             try:
                 te = _import_te_pytorch()
@@ -552,6 +563,12 @@ class Float8TransformerEnginePolicy(PrecisionPolicy):
             )
 
     def autocast_context(self):
+        context = self._te_autocast_context()
+        if self._target_device is not None and self._target_device.type == "cuda":
+            return _cuda_device_autocast_context(self._target_device, context)
+        return context
+
+    def _te_autocast_context(self):
         try:
             te = _import_te_pytorch()
         except ImportError:

--- a/spikingjelly/activation_based/triton_kernel/fp8_capability.py
+++ b/spikingjelly/activation_based/triton_kernel/fp8_capability.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import functools
 import logging
 import traceback
@@ -78,12 +79,8 @@ if triton is not None:
 
         for t in tl.static_range(1, -1, -1):
             base = t * N + offsets
-            grad_s = tl.load(grad_s_ptr + base, mask=mask, other=0.0).to(
-                compute_dtype
-            )
-            grad_v = tl.load(grad_v_ptr + base, mask=mask, other=0.0).to(
-                compute_dtype
-            )
+            grad_s = tl.load(grad_s_ptr + base, mask=mask, other=0.0).to(compute_dtype)
+            grad_v = tl.load(grad_v_ptr + base, mask=mask, other=0.0).to(compute_dtype)
             h = tl.load(h_ptr + base, mask=mask, other=0.0).to(compute_dtype)
             v_last = tl.load(v_ptr + base, mask=mask, other=0.0).to(compute_dtype)
             s = tl.where(h >= 1.0, 1.0, 0.0).to(compute_dtype)
@@ -359,7 +356,40 @@ def triton_fp8_neuron_backward_capability(
     return _backward_probe(dtype, device, compute_dtype=compute_dtype)
 
 
-def triton_fp8_neuron_capability_report(device) -> dict[str, Any]:
+def triton_fp8_neuron_capability_report(
+    device: torch.device | str,
+) -> dict[str, Any]:
+    r"""
+    **API Language** - 中文 | English
+
+    中文
+    ----
+
+    探测指定设备上 Triton 神经元内核的 FP8 能力。返回值保留兼容字段
+    ``dtypes``（对应 FP32 compute），并通过 ``compute_dtypes`` 分别报告
+    FP32、FP16、BF16 和 FP8 compute 与每种 FP8 storage dtype 的前向、
+    反向可用性及失败原因。探测会实际编译并运行最小 Triton kernel。
+
+    :param device: 待探测的 CUDA 设备；非 CUDA 设备返回不可用报告。
+    :type device: torch.device | str
+    :return: 包含设备、版本、storage dtype 和 compute dtype 探测结果的字典。
+    :rtype: dict[str, Any]
+
+    English
+    -------
+
+    Probes FP8 support for Triton neuron kernels on a device. The compatibility
+    field ``dtypes`` reports FP32-compute results, while ``compute_dtypes``
+    reports forward/backward availability and failure reasons for every FP8
+    storage dtype with FP32, FP16, BF16, and FP8 compute. The probe compiles and
+    executes minimal Triton kernels.
+
+    :param device: CUDA device to probe; non-CUDA devices return an unavailable
+        report.
+    :type device: torch.device | str
+    :return: Device, version, storage-dtype, and compute-dtype probe results.
+    :rtype: dict[str, Any]
+    """
     device = _normalize_cuda_device(device)
     report = {
         "device": str(device),
@@ -372,24 +402,27 @@ def triton_fp8_neuron_capability_report(device) -> dict[str, Any]:
         else None,
         "cuda_device_capability": None,
         "dtypes": {},
+        "compute_dtypes": {},
     }
     if device.type == "cuda" and torch.cuda.is_available():
         report["cuda_device_capability"] = torch.cuda.get_device_capability(device)
 
-    for dtype_name, dtype in _fp8_dtype_candidates().items():
-        if dtype is None:
-            dtype_report = _failure(
-                False, f"{dtype_name} is unavailable in this PyTorch build"
-            )
-        else:
-            dtype_report = _probe(dtype, device)
-        backward_report = (
-            dtype_report
-            if dtype is None
-            else _backward_probe(dtype, device)
-        )
-        report["dtypes"][dtype_name] = {
-            "forward": dtype_report,
-            "backward": backward_report,
-        }
+    dtype_candidates = _fp8_dtype_candidates()
+    for compute_dtype in ("fp32", "fp16", "bf16", "fp8"):
+        compute_report = {}
+        for dtype_name, dtype in dtype_candidates.items():
+            if dtype is None:
+                forward_report = _failure(
+                    False, f"{dtype_name} is unavailable in this PyTorch build"
+                )
+                backward_report = forward_report
+            else:
+                forward_report = _probe(dtype, device, compute_dtype)
+                backward_report = _backward_probe(dtype, device, compute_dtype)
+            compute_report[dtype_name] = {
+                "forward": forward_report,
+                "backward": backward_report,
+            }
+        report["compute_dtypes"][compute_dtype] = compute_report
+    report["dtypes"] = copy.deepcopy(report["compute_dtypes"]["fp32"])
     return report

--- a/test/activation_based/test_fp8_benchmark.py
+++ b/test/activation_based/test_fp8_benchmark.py
@@ -26,6 +26,8 @@ from benchmark.fp8_efficiency import (
 def _patch_cuda_timing(monkeypatch):
     active_devices: list[torch.device] = []
     entered_devices: list[torch.device] = []
+    event_synchronize_calls: list[None] = []
+    created_events: list[None] = []
 
     @contextmanager
     def cuda_device(device: torch.device):
@@ -45,12 +47,14 @@ def _patch_cuda_timing(monkeypatch):
         def __init__(self, *, enable_timing: bool):
             assert enable_timing
             assert active_devices
+            created_events.append(None)
 
         def record(self):
             assert active_devices
 
         def synchronize(self):
             assert active_devices
+            event_synchronize_calls.append(None)
 
         def elapsed_time(self, other):
             assert isinstance(other, Event)
@@ -64,30 +68,41 @@ def _patch_cuda_timing(monkeypatch):
     monkeypatch.setattr(torch.cuda, "reset_peak_memory_stats", require_active_device)
     monkeypatch.setattr(torch.cuda, "max_memory_allocated", require_active_device)
     monkeypatch.setattr(torch.cuda, "max_memory_reserved", require_active_device)
-    return entered_devices
+    return entered_devices, event_synchronize_calls, created_events
 
 
 def test_model_benchmark_timing_uses_requested_cuda_device(monkeypatch):
-    entered_devices = _patch_cuda_timing(monkeypatch)
+    entered_devices, event_synchronize_calls, _ = _patch_cuda_timing(monkeypatch)
     device = torch.device("cuda", 1)
 
     elapsed_ms = _cuda_time_ms(device, 2, lambda: None)
 
     assert elapsed_ms == pytest.approx(1.0)
     assert entered_devices == [device]
+    assert len(event_synchronize_calls) == 1
 
 
 def test_triton_benchmark_timing_uses_requested_cuda_device(monkeypatch):
-    entered_devices = _patch_cuda_timing(monkeypatch)
+    entered_devices, event_synchronize_calls, created_events = _patch_cuda_timing(
+        monkeypatch
+    )
     monkeypatch.setattr(triton_neuron_benchmark, "_cuda_sync", lambda device: None)
     device = torch.device("cuda", 1)
+    calls = 0
+
+    def benchmark_fn():
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            assert len(created_events) == 4
 
     result = triton_neuron_benchmark._measure(
-        device=device, repeats=2, warmup=1, fn=lambda: None
+        device=device, repeats=2, warmup=1, fn=benchmark_fn
     )
 
     assert result["median_ms"] == pytest.approx(2.0)
     assert entered_devices == [device]
+    assert not event_synchronize_calls
 
 
 def test_aggregate_precision_trials_uses_medians_and_preserves_raw_trials():

--- a/test/activation_based/test_fp8_benchmark.py
+++ b/test/activation_based/test_fp8_benchmark.py
@@ -1,13 +1,17 @@
 from argparse import Namespace
+from contextlib import contextmanager
 
 import pytest
+import torch
 
 from benchmark.benchmark_fp8_training_inference import (
     _aggregate_precision_trials,
     _commit,
+    _cuda_time_ms,
     _samples_per_second,
     validate_args,
 )
+import benchmark.benchmark_triton_neuron_kernels as triton_neuron_benchmark
 from benchmark.benchmark_triton_neuron_kernels import (
     _higher_precision_variants,
     _write_markdown,
@@ -17,6 +21,73 @@ from benchmark.fp8_efficiency import (
     assess_triton_efficiency,
     require_efficiency,
 )
+
+
+def _patch_cuda_timing(monkeypatch):
+    active_devices: list[torch.device] = []
+    entered_devices: list[torch.device] = []
+
+    @contextmanager
+    def cuda_device(device: torch.device):
+        active_devices.append(device)
+        entered_devices.append(device)
+        try:
+            yield
+        finally:
+            active_devices.pop()
+
+    def require_active_device(*args, **kwargs):
+        del args, kwargs
+        assert active_devices
+        return 1.0
+
+    class Event:
+        def __init__(self, *, enable_timing: bool):
+            assert enable_timing
+            assert active_devices
+
+        def record(self):
+            assert active_devices
+
+        def synchronize(self):
+            assert active_devices
+
+        def elapsed_time(self, other):
+            assert isinstance(other, Event)
+            assert active_devices
+            return 2.0
+
+    monkeypatch.setattr(torch.cuda, "device", cuda_device)
+    monkeypatch.setattr(torch.cuda, "Event", Event)
+    monkeypatch.setattr(torch.cuda, "synchronize", require_active_device)
+    monkeypatch.setattr(torch.cuda, "empty_cache", require_active_device)
+    monkeypatch.setattr(torch.cuda, "reset_peak_memory_stats", require_active_device)
+    monkeypatch.setattr(torch.cuda, "max_memory_allocated", require_active_device)
+    monkeypatch.setattr(torch.cuda, "max_memory_reserved", require_active_device)
+    return entered_devices
+
+
+def test_model_benchmark_timing_uses_requested_cuda_device(monkeypatch):
+    entered_devices = _patch_cuda_timing(monkeypatch)
+    device = torch.device("cuda", 1)
+
+    elapsed_ms = _cuda_time_ms(device, 2, lambda: None)
+
+    assert elapsed_ms == pytest.approx(1.0)
+    assert entered_devices == [device]
+
+
+def test_triton_benchmark_timing_uses_requested_cuda_device(monkeypatch):
+    entered_devices = _patch_cuda_timing(monkeypatch)
+    monkeypatch.setattr(triton_neuron_benchmark, "_cuda_sync", lambda device: None)
+    device = torch.device("cuda", 1)
+
+    result = triton_neuron_benchmark._measure(
+        device=device, repeats=2, warmup=1, fn=lambda: None
+    )
+
+    assert result["median_ms"] == pytest.approx(2.0)
+    assert entered_devices == [device]
 
 
 def test_aggregate_precision_trials_uses_medians_and_preserves_raw_trials():

--- a/test/activation_based/test_fp8_benchmark.py
+++ b/test/activation_based/test_fp8_benchmark.py
@@ -19,6 +19,7 @@ from benchmark.benchmark_triton_neuron_kernels import (
 from benchmark.fp8_efficiency import (
     assess_model_efficiency,
     assess_triton_efficiency,
+    percentile,
     require_efficiency,
 )
 
@@ -103,6 +104,14 @@ def test_triton_benchmark_timing_uses_requested_cuda_device(monkeypatch):
     assert result["median_ms"] == pytest.approx(2.0)
     assert entered_devices == [device]
     assert not event_synchronize_calls
+
+
+def test_percentile_rejects_invalid_inputs():
+    assert percentile([3.0, 1.0, 2.0], 0.25) == pytest.approx(1.5)
+    with pytest.raises(ValueError, match="empty sequence"):
+        percentile([], 0.5)
+    with pytest.raises(ValueError, match="quantile"):
+        percentile([1.0], 1.1)
 
 
 def test_aggregate_precision_trials_uses_medians_and_preserves_raw_trials():

--- a/test/activation_based/test_fp8_benchmark.py
+++ b/test/activation_based/test_fp8_benchmark.py
@@ -244,6 +244,58 @@ def test_assess_model_efficiency_reports_missing_metric():
         )
 
 
+def test_assess_model_efficiency_reports_missing_precision():
+    with pytest.raises(ValueError, match="precision is required"):
+        assess_model_efficiency(
+            [
+                {
+                    "training_samples_per_sec": 100.0,
+                    "inference_samples_per_sec": 200.0,
+                    "training_peak_allocated_mb": 1000.0,
+                    "inference_peak_allocated_mb": 600.0,
+                }
+            ],
+            baseline_precision="bf16",
+            min_training_speedup=1.0,
+            min_inference_speedup=1.0,
+        )
+
+
+def test_assess_triton_efficiency_reports_fp8_group_without_baseline():
+    rows = [
+        {
+            "T": 4,
+            "N": 8,
+            "neuron_type": "if",
+            "process": "inference_forward",
+            "variant": "stable_fp32",
+            "success": True,
+            "median_ms": 2.0,
+            "peak_allocated_mb": 8.0,
+        },
+        {
+            "T": 8,
+            "N": 8,
+            "neuron_type": "if",
+            "process": "inference_forward",
+            "variant": "mp_plan_float8_e4m3fn_fp8",
+            "success": True,
+            "median_ms": 1.0,
+            "peak_allocated_mb": 4.0,
+        },
+    ]
+
+    report = assess_triton_efficiency(rows, min_speedup=1.0)
+
+    assert report["passed"] is False
+    assert report["failures"] == [
+        "T=4 N=8 neuron=if process=inference_forward has no successful FP8 "
+        "prepared-plan result",
+        "T=8 N=8 neuron=if process=inference_forward has no successful "
+        "stable_fp32 baseline",
+    ]
+
+
 def test_assess_model_efficiency_rejects_fp8_baseline():
     with pytest.raises(ValueError, match="must not be an FP8 variant"):
         assess_model_efficiency(

--- a/test/activation_based/test_fp8_benchmark.py
+++ b/test/activation_based/test_fp8_benchmark.py
@@ -1,0 +1,493 @@
+from argparse import Namespace
+
+import pytest
+
+from benchmark.benchmark_fp8_training_inference import (
+    _aggregate_precision_trials,
+    _commit,
+    _samples_per_second,
+    validate_args,
+)
+from benchmark.benchmark_triton_neuron_kernels import (
+    _higher_precision_variants,
+    _write_markdown,
+)
+from benchmark.fp8_efficiency import (
+    assess_model_efficiency,
+    assess_triton_efficiency,
+    require_efficiency,
+)
+
+
+def test_aggregate_precision_trials_uses_medians_and_preserves_raw_trials():
+    trials = [
+        {
+            "precision": "fp8-torchao",
+            "trial": trial,
+            "training_ms": training_ms,
+            "training_samples_per_sec": samples_per_sec,
+            "training_peak_allocated_mb": 800.0 + trial,
+            "training_peak_reserved_mb": 900.0 + trial,
+            "inference_ms": training_ms / 2,
+            "inference_samples_per_sec": samples_per_sec * 2,
+            "inference_peak_allocated_mb": 400.0 + trial,
+            "inference_peak_reserved_mb": 500.0 + trial,
+            "preparation_ms": 10.0 + trial,
+            "parameter_update_max_abs": 0.01,
+            "output_checksum": 0.1,
+            "capability_report": {"can_execute": True},
+            "conversion_report": {"converted_modules": ["layers.0"]},
+        }
+        for trial, training_ms, samples_per_sec in (
+            (0, 3.0, 100.0),
+            (1, 1.0, 300.0),
+            (2, 2.0, 200.0),
+        )
+    ]
+
+    result = _aggregate_precision_trials("fp8-torchao", trials)
+
+    assert result["training_ms"] == pytest.approx(2.0)
+    assert result["training_samples_per_sec"] == pytest.approx(200.0)
+    assert result["training_ms_p25"] == pytest.approx(1.5)
+    assert result["training_ms_p75"] == pytest.approx(2.5)
+    assert result["inference_ms"] == pytest.approx(1.0)
+    assert result["training_peak_reserved_mb"] == pytest.approx(901.0)
+    assert result["inference_peak_reserved_mb"] == pytest.approx(501.0)
+    assert result["preparation_ms"] == pytest.approx(11.0)
+    assert result["trial_count"] == 3
+    assert result["trials"] == trials
+
+
+@pytest.mark.parametrize("elapsed_ms", [0.0, -1.0, float("nan"), float("inf")])
+def test_samples_per_second_rejects_invalid_cuda_timing(elapsed_ms):
+    with pytest.raises(RuntimeError, match="timing must be finite and positive"):
+        _samples_per_second(16, elapsed_ms)
+
+
+def test_samples_per_second_converts_milliseconds():
+    assert _samples_per_second(16, 2.0) == pytest.approx(8000.0)
+
+
+def test_triton_benchmark_includes_fp16_and_bf16_comparisons():
+    variants = _higher_precision_variants()
+
+    assert [(name, compute) for name, _, compute in variants] == [
+        ("float16", "fp16"),
+        ("bfloat16", "bf16"),
+    ]
+
+
+def test_model_benchmark_commit_prefers_explicit_value(monkeypatch):
+    monkeypatch.delenv("SJ_COMMIT", raising=False)
+    monkeypatch.delenv("GIT_COMMIT", raising=False)
+    monkeypatch.setenv("CODEX_COMMIT", "environment-commit")
+
+    assert _commit("explicit-commit") == "explicit-commit"
+    assert _commit() == "environment-commit"
+
+
+@pytest.mark.parametrize(
+    ("speedup_name", "invalid_value"),
+    [
+        ("min_training_speedup", 0.0),
+        ("min_training_speedup", float("nan")),
+        ("min_training_speedup", float("inf")),
+        ("min_inference_speedup", 0.0),
+        ("min_inference_speedup", float("nan")),
+        ("min_inference_speedup", float("inf")),
+    ],
+)
+def test_model_benchmark_rejects_invalid_min_speedup(speedup_name, invalid_value):
+    args = Namespace(
+        baseline_precision="bf16",
+        precisions=["bf16", "fp8-torchao"],
+        batch_size=16,
+        width=16,
+        num_classes=16,
+        training_steps=1,
+        inference_steps=1,
+        trials=2,
+        warmup=1,
+        depth=2,
+        min_training_speedup=1.0,
+        min_inference_speedup=1.0,
+    )
+    setattr(args, speedup_name, invalid_value)
+
+    with pytest.raises(ValueError, match="must be finite and > 0"):
+        validate_args(args)
+
+
+def test_triton_markdown_flattens_multiline_failure_reason(tmp_path):
+    output = tmp_path / "benchmark.md"
+    rows = [
+        {
+            "T": 1,
+            "N": 1,
+            "neuron_type": "if",
+            "variant": "mp_plan_float8_e4m3fn_fp8",
+            "process": "inference_forward",
+            "success": False,
+            "failure_reason": "compile failed:\nline one\r\nline two",
+        }
+    ]
+    metadata = {
+        "host": "test-host",
+        "gpu": "test-gpu",
+        "commit": "test-commit",
+        "commit_source": "test",
+        "command": "benchmark command",
+    }
+    efficiency = {"min_speedup": 1.05, "comparisons": [], "failures": []}
+
+    _write_markdown(output, rows, metadata, efficiency)
+
+    rendered = output.read_text(encoding="utf-8")
+    assert (
+        "- `T=1 N=1 neuron=if variant=mp_plan_float8_e4m3fn_fp8 "
+        "process=inference_forward: compile failed: line one  line two`" in rendered
+    )
+    assert "\nline one" not in rendered
+
+
+def test_assess_model_efficiency_compares_training_inference_and_memory():
+    results = [
+        {
+            "precision": "bf16",
+            "training_samples_per_sec": 100.0,
+            "inference_samples_per_sec": 200.0,
+            "training_peak_allocated_mb": 1000.0,
+            "inference_peak_allocated_mb": 600.0,
+        },
+        {
+            "precision": "fp8-torchao",
+            "training_samples_per_sec": 125.0,
+            "inference_samples_per_sec": 250.0,
+            "training_peak_allocated_mb": 800.0,
+            "inference_peak_allocated_mb": 450.0,
+        },
+    ]
+
+    report = assess_model_efficiency(
+        results,
+        baseline_precision="bf16",
+        min_training_speedup=1.05,
+        min_inference_speedup=1.05,
+    )
+
+    assert report["passed"] is True
+    comparison = report["comparisons"][0]
+    assert comparison["training_speedup"] == pytest.approx(1.25)
+    assert comparison["inference_speedup"] == pytest.approx(1.25)
+    assert comparison["training_memory_ratio"] == pytest.approx(0.8)
+    assert comparison["inference_memory_ratio"] == pytest.approx(0.75)
+
+
+def test_assess_model_efficiency_reports_each_failed_process():
+    results = [
+        {
+            "precision": "fp32",
+            "training_samples_per_sec": 100.0,
+            "inference_samples_per_sec": 200.0,
+            "training_peak_allocated_mb": 1000.0,
+            "inference_peak_allocated_mb": 600.0,
+        },
+        {
+            "precision": "fp8-te",
+            "training_samples_per_sec": 104.0,
+            "inference_samples_per_sec": 180.0,
+            "training_peak_allocated_mb": 900.0,
+            "inference_peak_allocated_mb": 500.0,
+        },
+    ]
+
+    report = assess_model_efficiency(
+        results,
+        baseline_precision="fp32",
+        min_training_speedup=1.05,
+        min_inference_speedup=1.05,
+    )
+
+    assert report["passed"] is False
+    assert report["failures"] == [
+        "fp8-te training speedup 1.0400x < 1.0500x",
+        "fp8-te inference speedup 0.9000x < 1.0500x",
+    ]
+    with pytest.raises(RuntimeError, match="fp8-te training speedup"):
+        require_efficiency(report)
+
+
+def test_assess_model_efficiency_reports_missing_metric():
+    results = [
+        {
+            "precision": "bf16",
+            "inference_samples_per_sec": 200.0,
+            "training_peak_allocated_mb": 1000.0,
+            "inference_peak_allocated_mb": 600.0,
+        },
+        {
+            "precision": "fp8-te",
+            "training_samples_per_sec": 120.0,
+            "inference_samples_per_sec": 220.0,
+            "training_peak_allocated_mb": 900.0,
+            "inference_peak_allocated_mb": 500.0,
+        },
+    ]
+
+    with pytest.raises(ValueError, match="training_samples_per_sec is required"):
+        assess_model_efficiency(
+            results,
+            baseline_precision="bf16",
+            min_training_speedup=1.0,
+            min_inference_speedup=1.0,
+        )
+
+
+def test_assess_model_efficiency_rejects_fp8_baseline():
+    with pytest.raises(ValueError, match="must not be an FP8 variant"):
+        assess_model_efficiency(
+            [
+                {
+                    "precision": "fp8-te",
+                    "training_samples_per_sec": 100.0,
+                    "inference_samples_per_sec": 200.0,
+                    "training_peak_allocated_mb": 1000.0,
+                    "inference_peak_allocated_mb": 600.0,
+                }
+            ],
+            baseline_precision="fp8-te",
+            min_training_speedup=1.0,
+            min_inference_speedup=1.0,
+        )
+
+
+@pytest.mark.parametrize("invalid_speedup", [float("nan"), float("inf")])
+def test_assess_efficiency_rejects_nonfinite_speedup(invalid_speedup):
+    with pytest.raises(ValueError, match="must be finite and positive"):
+        assess_model_efficiency(
+            [],
+            baseline_precision="bf16",
+            min_training_speedup=invalid_speedup,
+            min_inference_speedup=1.0,
+        )
+    with pytest.raises(ValueError, match="must be finite and positive"):
+        assess_triton_efficiency([], min_speedup=invalid_speedup)
+
+
+def test_model_benchmark_rejects_zero_warmup():
+    args = Namespace(
+        baseline_precision="bf16",
+        precisions=["bf16", "fp8-torchao"],
+        batch_size=16,
+        width=16,
+        num_classes=16,
+        training_steps=1,
+        inference_steps=1,
+        trials=2,
+        warmup=0,
+        depth=2,
+        min_training_speedup=1.0,
+        min_inference_speedup=1.0,
+    )
+
+    with pytest.raises(ValueError, match="--warmup must be >= 1"):
+        validate_args(args)
+
+
+@pytest.mark.parametrize("invalid_value", [None, "invalid", float("nan"), float("inf")])
+def test_assess_model_efficiency_rejects_invalid_metric(invalid_value):
+    results = [
+        {
+            "precision": "bf16",
+            "training_samples_per_sec": invalid_value,
+            "inference_samples_per_sec": 200.0,
+            "training_peak_allocated_mb": 1000.0,
+            "inference_peak_allocated_mb": 600.0,
+        },
+        {
+            "precision": "fp8-te",
+            "training_samples_per_sec": 120.0,
+            "inference_samples_per_sec": 220.0,
+            "training_peak_allocated_mb": 900.0,
+            "inference_peak_allocated_mb": 500.0,
+        },
+    ]
+
+    with pytest.raises(ValueError, match="must be a finite positive number"):
+        assess_model_efficiency(
+            results,
+            baseline_precision="bf16",
+            min_training_speedup=1.0,
+            min_inference_speedup=1.0,
+        )
+
+
+def test_assess_triton_efficiency_selects_best_prepared_fp8_variant():
+    rows = [
+        {
+            "T": 32,
+            "N": 4096,
+            "neuron_type": "lif",
+            "process": "inference_forward",
+            "variant": "stable_fp32",
+            "success": True,
+            "median_ms": 2.0,
+            "peak_allocated_mb": 100.0,
+        },
+        {
+            "T": 32,
+            "N": 4096,
+            "neuron_type": "lif",
+            "process": "inference_forward",
+            "variant": "mp_safe_float8_e4m3fn_fp32",
+            "success": True,
+            "median_ms": 3.0,
+            "peak_allocated_mb": 80.0,
+        },
+        {
+            "T": 32,
+            "N": 4096,
+            "neuron_type": "lif",
+            "process": "inference_forward",
+            "variant": "mp_plan_float8_e4m3fn_fp32",
+            "compute_dtype": "fp32",
+            "success": True,
+            "median_ms": 1.5,
+            "peak_allocated_mb": 75.0,
+        },
+        {
+            "T": 32,
+            "N": 4096,
+            "neuron_type": "lif",
+            "process": "inference_forward",
+            "variant": "mp_plan_float8_e5m2_fp16",
+            "compute_dtype": "fp16",
+            "success": True,
+            "median_ms": 1.0,
+            "peak_allocated_mb": 70.0,
+        },
+    ]
+
+    report = assess_triton_efficiency(rows, min_speedup=1.05)
+
+    assert report["passed"] is True
+    comparison = report["comparisons"][0]
+    assert comparison["best_fp8_variant"] == "mp_plan_float8_e5m2_fp16"
+    assert comparison["best_compute_dtype"] == "fp16"
+    assert comparison["speedup"] == pytest.approx(2.0)
+    assert comparison["memory_ratio"] == pytest.approx(0.7)
+
+
+def test_assess_triton_efficiency_fails_when_a_process_has_no_usable_fp8_plan():
+    rows = [
+        {
+            "T": 32,
+            "N": 4096,
+            "neuron_type": "if",
+            "process": "training_forward_backward",
+            "variant": "stable_fp32",
+            "success": True,
+            "median_ms": 2.0,
+            "peak_allocated_mb": 100.0,
+        },
+        {
+            "T": 32,
+            "N": 4096,
+            "neuron_type": "if",
+            "process": "training_forward_backward",
+            "variant": "mp_plan_float8_e4m3fn_fp32",
+            "success": False,
+            "failure_reason": "unsupported",
+        },
+    ]
+
+    report = assess_triton_efficiency(rows, min_speedup=1.05)
+
+    assert report["passed"] is False
+    assert report["failures"] == [
+        "T=32 N=4096 neuron=if process=training_forward_backward has no "
+        "successful FP8 prepared-plan result"
+    ]
+
+
+def test_assess_triton_efficiency_reports_failed_baseline():
+    rows = [
+        {
+            "T": 16,
+            "N": 2048,
+            "neuron_type": "plif",
+            "process": "inference_forward",
+            "variant": "stable_fp32",
+            "success": False,
+            "failure_reason": "out of memory",
+        }
+    ]
+
+    report = assess_triton_efficiency(rows, min_speedup=1.05)
+
+    assert report["passed"] is False
+    assert report["failures"] == [
+        "T=16 N=2048 neuron=plif process=inference_forward stable_fp32 "
+        "baseline failed: out of memory",
+    ]
+
+
+def test_assess_triton_efficiency_reports_absent_baseline():
+    report = assess_triton_efficiency([], min_speedup=1.05)
+
+    assert report["passed"] is False
+    assert report["failures"] == ["no usable stable_fp32 baseline results"]
+
+
+def test_assess_triton_efficiency_reports_missing_baseline_group_field():
+    rows = [
+        {
+            "T": 16,
+            "N": 2048,
+            "neuron_type": "plif",
+            "variant": "stable_fp32",
+            "success": True,
+            "median_ms": 2.0,
+            "peak_allocated_mb": 100.0,
+        }
+    ]
+
+    report = assess_triton_efficiency(rows, min_speedup=1.05)
+
+    assert report["passed"] is False
+    assert report["failures"] == [
+        "T=16 N=2048 neuron=plif process=None stable_fp32 baseline is missing "
+        "required group fields: process"
+    ]
+
+
+def test_assess_triton_efficiency_rejects_duplicate_successful_baseline():
+    baseline = {
+        "T": 16,
+        "N": 2048,
+        "neuron_type": "plif",
+        "process": "inference_forward",
+        "variant": "stable_fp32",
+        "success": True,
+        "median_ms": 2.0,
+        "peak_allocated_mb": 100.0,
+    }
+    candidate = {
+        **baseline,
+        "variant": "mp_plan_float8_e4m3fn_fp32",
+        "compute_dtype": "fp32",
+        "median_ms": 1.0,
+        "peak_allocated_mb": 80.0,
+    }
+
+    report = assess_triton_efficiency(
+        [baseline, dict(baseline), candidate], min_speedup=1.05
+    )
+
+    assert report["passed"] is False
+    assert report["failures"] == [
+        "T=16 N=2048 neuron=plif process=inference_forward has duplicate "
+        "successful stable_fp32 baselines"
+    ]
+    assert len(report["comparisons"]) == 1

--- a/test/activation_based/test_precision_conversion.py
+++ b/test/activation_based/test_precision_conversion.py
@@ -1040,6 +1040,30 @@ def test_transformer_engine_sdpa_adapter_matches_torch_sdpa(monkeypatch):
     torch.testing.assert_close(out, expected)
 
 
+def test_transformer_engine_sdpa_adapter_accepts_flattened_te_output(monkeypatch):
+    _install_fake_te(monkeypatch)
+    adapter = TransformerEngineDotProductAttentionAdapter(
+        num_attention_heads=2,
+        head_dim=4,
+    )
+    original_forward = adapter.wrapped.forward
+
+    def flattened_forward(query, key, value, *args, **kwargs):
+        output = original_forward(query, key, value, *args, **kwargs)
+        return output.flatten(start_dim=2)
+
+    adapter.wrapped.forward = flattened_forward
+    query = torch.randn(3, 2, 5, 4)
+    key = torch.randn(3, 2, 5, 4)
+    value = torch.randn(3, 2, 5, 4)
+    expected = torch.nn.functional.scaled_dot_product_attention(query, key, value)
+
+    out = adapter(query, key, value)
+
+    assert out.shape == query.shape
+    torch.testing.assert_close(out, expected)
+
+
 def test_transformer_engine_sdpa_adapter_rejects_dropout_mismatch(monkeypatch):
     _install_fake_te(monkeypatch)
     adapter = TransformerEngineDotProductAttentionAdapter(

--- a/test/activation_based/test_precision_core.py
+++ b/test/activation_based/test_precision_core.py
@@ -272,6 +272,19 @@ def test_validate_capability_rejects_fp8_te_without_autocast_api():
         validate_capability(report)
 
 
+def test_validate_capability_preserves_transformer_engine_import_error():
+    report = {
+        "requested_mode": "fp8-te",
+        "transformer_engine_installed": False,
+        "te_fp8_unavailable_reason": (
+            "transformer-engine import failed: missing CUDA symbol"
+        ),
+    }
+
+    with pytest.raises(RuntimeError, match="missing CUDA symbol"):
+        validate_capability(report)
+
+
 def test_prepare_model_for_precision_warn_falls_back_to_fp32_when_fp8_te_unavailable():
     model = torch.nn.Linear(4, 4)
     with pytest.warns(RuntimeWarning, match="falling back to fp32"):
@@ -285,6 +298,24 @@ def test_prepare_model_for_precision_warn_falls_back_to_fp32_when_fp8_te_unavail
     assert artifacts.policy.describe()["name"] == "fp32"
     assert artifacts.fallback_reason
     assert artifacts.policy.capability_report()["requested_mode"] == "fp8-te"
+
+
+def test_fp8_te_warn_fallback_does_not_resolve_current_cuda_device(monkeypatch):
+    def fail_current_device():
+        raise AssertionError("current_device must not be called without CUDA")
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(torch.cuda, "current_device", fail_current_device)
+
+    with pytest.warns(RuntimeWarning, match="falling back to fp32"):
+        artifacts = prepare_model_for_precision(
+            torch.nn.Linear(4, 4),
+            "cuda",
+            PrecisionConfig(mode="fp8-te", strictness="warn"),
+        )
+
+    assert artifacts.effective_config.mode == "fp32"
+    assert artifacts.fallback_reason
 
 
 def test_prepare_model_for_precision_strict_keeps_fp8_te_capability_error():
@@ -430,6 +461,49 @@ def test_precision_artifacts_fp8_autocast_context_passes_legacy_recipe(monkeypat
         with artifacts.autocast_context():
             pass
     assert isinstance(state["recipe"], FakeDelayedScaling)
+
+
+def test_fp8_te_autocast_uses_configured_cuda_device(monkeypatch):
+    from spikingjelly.activation_based.precision.float8_te import (
+        Float8TransformerEnginePolicy,
+    )
+
+    events = []
+    fake_te = types.ModuleType("transformer_engine.pytorch")
+
+    class RecordingContext:
+        def __init__(self, name):
+            self.name = name
+
+        def __enter__(self):
+            events.append(f"enter:{self.name}")
+
+        def __exit__(self, exc_type, exc, tb):
+            events.append(f"exit:{self.name}")
+
+    fake_te.autocast = lambda **kwargs: RecordingContext("te")
+    fake_root = types.ModuleType("transformer_engine")
+    fake_root.pytorch = fake_te
+    monkeypatch.setitem(sys.modules, "transformer_engine", fake_root)
+    monkeypatch.setitem(sys.modules, "transformer_engine.pytorch", fake_te)
+    monkeypatch.setattr(
+        torch.cuda,
+        "device",
+        lambda device: RecordingContext(str(device)),
+    )
+    policy = Float8TransformerEnginePolicy()
+    policy._target_device = torch.device("cuda:1")
+
+    with policy.autocast_context():
+        events.append("body")
+
+    assert events == [
+        "enter:cuda:1",
+        "enter:te",
+        "body",
+        "exit:te",
+        "exit:cuda:1",
+    ]
 
 
 def test_fp8_te_device_check_includes_buffers():

--- a/test/activation_based/test_precision_core.py
+++ b/test/activation_based/test_precision_core.py
@@ -285,6 +285,16 @@ def test_validate_capability_preserves_transformer_engine_import_error():
         validate_capability(report)
 
 
+def test_validate_capability_reports_missing_transformer_engine():
+    report = {
+        "requested_mode": "fp8-te",
+        "transformer_engine_installed": False,
+    }
+
+    with pytest.raises(RuntimeError, match="transformer-engine is not installed"):
+        validate_capability(report)
+
+
 def test_prepare_model_for_precision_warn_falls_back_to_fp32_when_fp8_te_unavailable():
     model = torch.nn.Linear(4, 4)
     with pytest.warns(RuntimeWarning, match="falling back to fp32"):

--- a/test/activation_based/test_precision_fp8_hardware.py
+++ b/test/activation_based/test_precision_fp8_hardware.py
@@ -1,0 +1,567 @@
+import copy
+import os
+
+import pytest
+import torch
+
+from spikingjelly.activation_based import functional, layer, neuron
+from spikingjelly.activation_based.model import Spikformer
+from spikingjelly.activation_based.precision import (
+    Float8TransformerEnginePolicy,
+    PrecisionConfig,
+    TransformerEngineDotProductAttentionAdapter,
+    build_capability_report,
+    prepare_model_for_precision,
+    validate_capability,
+)
+
+
+FP8_MODES = ("fp8-torchao", "fp8-te")
+
+
+def _relative_l2(candidate: torch.Tensor, reference: torch.Tensor) -> float:
+    numerator = torch.linalg.vector_norm(candidate.float() - reference.float())
+    denominator = torch.linalg.vector_norm(reference.float()).clamp_min(1e-12)
+    return float((numerator / denominator).item())
+
+
+def _cosine_similarity(candidate: torch.Tensor, reference: torch.Tensor) -> float:
+    candidate = candidate.float().reshape(-1)
+    reference = reference.float().reshape(-1)
+    return float(torch.nn.functional.cosine_similarity(candidate, reference, dim=0))
+
+
+def _assert_gradient_quality(
+    candidate: torch.Tensor,
+    reference: torch.Tensor,
+    *,
+    min_cosine: float,
+    max_relative_l2: float,
+) -> None:
+    reference_norm = float(torch.linalg.vector_norm(reference.float()).item())
+    candidate_norm = float(torch.linalg.vector_norm(candidate.float()).item())
+    if reference_norm < 1e-8:
+        assert candidate_norm < 1e-5
+        return
+    assert _cosine_similarity(candidate, reference) >= min_cosine
+    assert _relative_l2(candidate, reference) <= max_relative_l2
+
+
+def _reset_model(model: torch.nn.Module) -> None:
+    functional.reset_net(model)
+
+
+def _required_backends() -> set[str]:
+    value = os.environ.get("SPIKINGJELLY_REQUIRE_FP8_BACKENDS", "")
+    required = {item.strip() for item in value.split(",") if item.strip()}
+    return set(FP8_MODES) if "all" in required else required
+
+
+def _required_recipes() -> set[str]:
+    value = os.environ.get("SPIKINGJELLY_REQUIRE_FP8_RECIPES", "")
+    return {item.strip() for item in value.split(",") if item.strip()}
+
+
+def _unavailable_backend(mode: str, reason: str) -> None:
+    if mode in _required_backends():
+        pytest.fail(f"Required FP8 backend {mode!r} is unavailable: {reason}")
+    pytest.skip(reason)
+
+
+def _cuda_device_or_skip(mode: str) -> torch.device:
+    if not torch.cuda.is_available():
+        _unavailable_backend(mode, "CUDA is required for FP8 hardware validation.")
+    return torch.device("cuda", 0)
+
+
+def _require_backend_capability(
+    model: torch.nn.Module,
+    device: torch.device,
+    mode: str,
+    recipe: str = "auto",
+) -> dict:
+    report = build_capability_report(model, device, mode)
+    try:
+        validate_capability(report)
+    except RuntimeError as exc:
+        _unavailable_backend(mode, str(exc))
+    if recipe in {"block", "mxfp8"}:
+        availability = report.get("te_recipe_availability") or {}
+        if availability.get(recipe) is not True:
+            reason = f"Transformer Engine recipe {recipe!r} is unavailable."
+            if recipe in _required_recipes():
+                pytest.fail(f"Required FP8 recipe {recipe!r} is unavailable.")
+            pytest.skip(reason)
+    return report
+
+
+def _assert_train_and_infer(
+    model: torch.nn.Module,
+    x: torch.Tensor,
+    mode: str,
+    recipe: str = "auto",
+    output_max_relative_l2: float = 0.10,
+    gradient_min_cosine: float = 0.98,
+    gradient_max_relative_l2: float = 0.20,
+) -> None:
+    device = x.device
+    reference_model = copy.deepcopy(model).eval()
+    reload_model = copy.deepcopy(model)
+    _reset_model(reference_model)
+    with torch.inference_mode():
+        reference_output = reference_model(x)
+    reference_model.train()
+    _reset_model(reference_model)
+    reference_training_output = reference_model(x)
+    reference_loss = (reference_training_output.float() - 0.25).square().mean()
+    reference_loss.backward()
+    reference_gradients = [
+        None if parameter.grad is None else parameter.grad.detach().clone()
+        for parameter in reference_model.parameters()
+    ]
+    _require_backend_capability(model, device, mode, recipe)
+    artifacts = prepare_model_for_precision(
+        model,
+        device,
+        PrecisionConfig(
+            mode=mode,
+            strictness="strict",
+            fp8_recipe=recipe,
+            device=str(device),
+        ),
+    )
+    model = artifacts.model
+    assert artifacts.effective_config.mode == mode
+    assert artifacts.policy.conversion_report()["converted_modules"]
+
+    model.eval()
+    _reset_model(model)
+    with torch.inference_mode(), artifacts.autocast_context():
+        initial_fp8_output = model(x)
+    torch.testing.assert_close(
+        initial_fp8_output.float(),
+        reference_output.float(),
+        atol=0.25,
+        rtol=0.25,
+    )
+    assert _relative_l2(initial_fp8_output, reference_output) <= output_max_relative_l2
+
+    optimizer = torch.optim.SGD(model.parameters(), lr=1e-2)
+    before = [parameter.detach().clone() for parameter in model.parameters()]
+    optimizer.zero_grad(set_to_none=True)
+    model.train()
+    _reset_model(model)
+    with artifacts.autocast_context():
+        output = model(x)
+        loss = (output.float() - 0.25).square().mean()
+    assert torch.isfinite(loss)
+    torch.testing.assert_close(loss, reference_loss, atol=0.1, rtol=0.25)
+    assert _relative_l2(loss, reference_loss) <= 0.10
+    artifacts.backward(loss, optimizer, parameters=model.parameters())
+    assert all(
+        parameter.grad is None or torch.isfinite(parameter.grad).all()
+        for parameter in model.parameters()
+    )
+    candidate_parameters = list(model.parameters())
+    for parameter, reference_gradient in zip(
+        candidate_parameters, reference_gradients, strict=True
+    ):
+        if reference_gradient is None:
+            assert parameter.grad is None
+        else:
+            assert parameter.grad is not None
+            candidate_gradient = parameter.grad.float()
+            reference_gradient = reference_gradient.float()
+            if (
+                reference_gradient.ndim == candidate_gradient.ndim + 1
+                and reference_gradient.shape[-1] == 1
+            ):
+                reference_gradient = reference_gradient.squeeze(-1)
+            assert candidate_gradient.shape == reference_gradient.shape
+            torch.testing.assert_close(
+                candidate_gradient,
+                reference_gradient,
+                atol=0.25,
+                rtol=0.35,
+            )
+            _assert_gradient_quality(
+                candidate_gradient,
+                reference_gradient,
+                min_cosine=gradient_min_cosine,
+                max_relative_l2=gradient_max_relative_l2,
+            )
+    assert any(
+        not torch.equal(previous, parameter.detach())
+        for previous, parameter in zip(before, model.parameters(), strict=True)
+    )
+
+    model.eval()
+    _reset_model(model)
+    with torch.inference_mode(), artifacts.autocast_context():
+        trained_source_output = model(x)
+    state_dict = model.state_dict()
+    reload_artifacts = prepare_model_for_precision(
+        reload_model,
+        device,
+        PrecisionConfig(
+            mode=mode,
+            strictness="strict",
+            fp8_recipe=recipe,
+            device=str(device),
+        ),
+    )
+    assert reload_artifacts.effective_config.mode == mode
+    assert reload_artifacts.policy.conversion_report()["converted_modules"]
+    reload_model = reload_artifacts.model
+    reload_model.load_state_dict(state_dict, strict=True)
+    reload_model.eval()
+    _reset_model(reload_model)
+    with torch.inference_mode(), reload_artifacts.autocast_context():
+        inference_output = reload_model(x)
+    _reset_model(reload_model)
+    with torch.inference_mode(), reload_artifacts.autocast_context():
+        repeated_inference_output = reload_model(x)
+    assert inference_output.shape == output.shape
+    assert torch.isfinite(inference_output).all()
+    torch.testing.assert_close(
+        inference_output.float(),
+        trained_source_output.float(),
+        atol=0.25,
+        rtol=0.25,
+    )
+    assert (
+        _relative_l2(inference_output, trained_source_output) <= output_max_relative_l2
+    )
+    torch.testing.assert_close(
+        repeated_inference_output.float(),
+        inference_output.float(),
+        atol=0.0,
+        rtol=0.0,
+    )
+
+
+@pytest.mark.parametrize("mode", FP8_MODES)
+def test_fp8_backend_trains_updates_parameters_and_runs_inference(mode):
+    device = _cuda_device_or_skip(mode)
+    model = torch.nn.Sequential(
+        torch.nn.Linear(64, 128),
+        torch.nn.GELU(),
+        torch.nn.Linear(128, 64),
+    ).to(device)
+    x = torch.randn(32, 64, device=device)
+
+    _assert_train_and_infer(model, x, mode)
+
+
+@pytest.mark.parametrize("mode", FP8_MODES)
+def test_fp8_backend_pointwise_conv1d_trains_and_runs_multistep_inference(mode):
+    device = _cuda_device_or_skip(mode)
+    model = layer.Conv1d(16, 32, kernel_size=1, step_mode="m").to(device)
+    x = torch.randn(2, 16, 16, 8, device=device)
+
+    _assert_train_and_infer(model, x, mode)
+
+
+@pytest.mark.parametrize("mode", FP8_MODES)
+def test_fp8_backend_stateful_snn_trains_resets_and_runs_inference(mode):
+    device = _cuda_device_or_skip(mode)
+    torch.manual_seed(20260719)
+    model = torch.nn.Sequential(
+        layer.Linear(64, 64, step_mode="m"),
+        neuron.LIFNode(step_mode="m"),
+        layer.Linear(64, 32, step_mode="m"),
+    ).to(device)
+    x = torch.randn(4, 16, 64, device=device) * 0.1
+
+    _assert_train_and_infer(
+        model,
+        x,
+        mode,
+        output_max_relative_l2=0.15,
+        gradient_min_cosine=0.95,
+        gradient_max_relative_l2=0.30,
+    )
+
+
+@pytest.mark.parametrize("mode", FP8_MODES)
+def test_fp8_backend_snn_boundary_spike_mismatch_is_bounded(mode):
+    device = _cuda_device_or_skip(mode)
+    torch.manual_seed(20260719)
+    model = torch.nn.Sequential(
+        layer.Linear(64, 64, step_mode="m"),
+        neuron.LIFNode(step_mode="m", v_reset=None, store_v_seq=True),
+    ).to(device)
+    reference_model = copy.deepcopy(model).eval()
+    x = torch.randn(8, 32, 64, device=device)
+    _require_backend_capability(model, device, mode)
+    artifacts = prepare_model_for_precision(
+        model,
+        device,
+        PrecisionConfig(mode=mode, strictness="strict", device=str(device)),
+    )
+    assert artifacts.effective_config.mode == mode
+    assert artifacts.policy.conversion_report()["converted_modules"]
+    model = artifacts.model.eval()
+
+    _reset_model(reference_model)
+    _reset_model(model)
+    with torch.inference_mode():
+        reference_spike = reference_model(x)
+    with torch.inference_mode(), artifacts.autocast_context():
+        candidate_spike = model(x)
+
+    reference_h = (
+        reference_model[1].v_seq + reference_spike * reference_model[1].v_threshold
+    )
+    near_threshold = (reference_h - reference_model[1].v_threshold).abs() < 0.05
+    away_from_threshold = ~near_threshold
+    mismatch = candidate_spike != reference_spike
+    assert near_threshold.any()
+    assert away_from_threshold.any()
+    assert not mismatch[away_from_threshold].any()
+    mismatch_ratio = float(mismatch.float().mean().item())
+    assert mismatch_ratio <= 0.01
+
+
+@pytest.mark.parametrize("mode", FP8_MODES)
+def test_tiny_spikformer_fp8_trains_and_runs_inference(mode):
+    device = _cuda_device_or_skip(mode)
+    torch.manual_seed(20260719)
+    model = Spikformer(
+        T=2,
+        in_channels=3,
+        img_size_h=64,
+        img_size_w=64,
+        num_classes=16,
+        embed_dims=64,
+        num_heads=4,
+        depths=2,
+        backend="torch",
+    ).to(device)
+    reference_model = copy.deepcopy(model).train()
+    _require_backend_capability(model, device, mode)
+    artifacts = prepare_model_for_precision(
+        model,
+        device,
+        PrecisionConfig(mode=mode, strictness="strict", device=str(device)),
+    )
+    assert artifacts.effective_config.mode == mode
+    model = artifacts.model
+    optimizer = torch.optim.SGD(model.parameters(), lr=1e-2)
+    x = torch.randn(16, 3, 64, 64, device=device, requires_grad=True)
+    reference_x = x.detach().clone().requires_grad_()
+    target = torch.randint(0, 16, (16,), device=device)
+
+    _reset_model(reference_model)
+    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        reference_output = reference_model(reference_x)
+        reference_loss = torch.nn.functional.cross_entropy(
+            reference_output.mean(0).float(), target
+        )
+    reference_loss.backward()
+
+    model.train()
+    _reset_model(model)
+    optimizer.zero_grad(set_to_none=True)
+    with artifacts.autocast_context():
+        output = model(x)
+        loss = torch.nn.functional.cross_entropy(output.mean(0).float(), target)
+    artifacts.backward(loss, optimizer, parameters=model.parameters())
+    assert output.shape == (2, 16, 16)
+    assert torch.isfinite(loss)
+    assert _relative_l2(output, reference_output) <= 0.35
+    assert _relative_l2(loss, reference_loss) <= 0.10
+    assert x.grad is not None and reference_x.grad is not None
+    assert torch.isfinite(x.grad).all()
+    assert torch.isfinite(reference_x.grad).all()
+    assert model.head.weight.grad is not None
+    assert reference_model.head.weight.grad is not None
+    _assert_gradient_quality(
+        model.head.weight.grad,
+        reference_model.head.weight.grad,
+        min_cosine=0.90,
+        max_relative_l2=0.45,
+    )
+    assert artifacts.policy.conversion_report()["converted_modules"]
+    assert any(
+        parameter.grad is not None and torch.isfinite(parameter.grad).all()
+        for parameter in model.parameters()
+    )
+
+    model.eval()
+    _reset_model(model)
+    with torch.inference_mode(), artifacts.autocast_context():
+        inference_output = model(x)
+    assert inference_output.shape == output.shape
+    assert torch.isfinite(inference_output).all()
+
+
+def _train_regression_curve(
+    model: torch.nn.Module,
+    x: torch.Tensor,
+    target: torch.Tensor,
+    mode: str,
+) -> list[float]:
+    device = x.device
+    _require_backend_capability(model, device, mode)
+    artifacts = prepare_model_for_precision(
+        model,
+        device,
+        PrecisionConfig(mode=mode, strictness="strict", device=str(device)),
+    )
+    assert artifacts.effective_config.mode == mode
+    if mode in FP8_MODES:
+        assert artifacts.policy.conversion_report()["converted_modules"]
+    model = artifacts.model.train()
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-2)
+    losses = []
+    for _ in range(20):
+        optimizer.zero_grad(set_to_none=True)
+        with artifacts.autocast_context():
+            output = model(x)
+            loss = torch.nn.functional.mse_loss(output.float(), target)
+        assert torch.isfinite(loss)
+        artifacts.backward(loss, optimizer, parameters=model.parameters())
+        losses.append(float(loss.detach().item()))
+    return losses
+
+
+@pytest.mark.parametrize("mode", FP8_MODES)
+def test_fp8_backend_training_converges_comparably_to_bf16(mode):
+    device = _cuda_device_or_skip(mode)
+    torch.manual_seed(20260719)
+    model = torch.nn.Sequential(
+        torch.nn.Linear(64, 64),
+        torch.nn.GELU(),
+        torch.nn.Linear(64, 64),
+    ).to(device)
+    x = torch.randn(64, 64, device=device)
+    teacher = torch.randn(64, 64, device=device) / 8.0
+    target = x @ teacher
+
+    bf16_losses = _train_regression_curve(copy.deepcopy(model), x, target, "bf16")
+    fp8_losses = _train_regression_curve(copy.deepcopy(model), x, target, mode)
+
+    assert bf16_losses[-1] <= bf16_losses[0] * 0.90
+    assert fp8_losses[-1] <= fp8_losses[0] * 0.90
+    assert fp8_losses[-1] <= bf16_losses[-1] * 1.20
+
+
+@pytest.mark.parametrize("mode", FP8_MODES)
+def test_fp8_backend_runs_inference_on_second_cuda_device(mode):
+    device = _cuda_device_or_skip(mode)
+    if torch.cuda.device_count() < 2:
+        pytest.skip("A second CUDA device is required for this smoke test.")
+    device = torch.device("cuda", 1)
+    model = torch.nn.Linear(64, 64).to(device).eval()
+    x = torch.randn(16, 64, device=device)
+    _require_backend_capability(model, device, mode)
+    artifacts = prepare_model_for_precision(
+        model,
+        device,
+        PrecisionConfig(mode=mode, strictness="strict", device=str(device)),
+    )
+    assert artifacts.effective_config.mode == mode
+    assert artifacts.policy.conversion_report()["converted_modules"]
+    with torch.inference_mode(), artifacts.autocast_context():
+        output = artifacts.model(x)
+    assert output.shape == x.shape
+    assert torch.isfinite(output).all()
+
+
+@pytest.mark.parametrize("recipe", ["auto", "delayed", "current", "block", "mxfp8"])
+def test_fp8_te_recipes_train_and_run_inference(recipe):
+    device = _cuda_device_or_skip("fp8-te")
+    model = torch.nn.Sequential(
+        torch.nn.LayerNorm(64),
+        torch.nn.Linear(64, 128),
+        torch.nn.GELU(),
+        torch.nn.Linear(128, 64),
+    ).to(device)
+    x = torch.randn(32, 64, device=device)
+
+    _assert_train_and_infer(model, x, "fp8-te", recipe)
+
+
+@pytest.mark.parametrize(
+    ("model", "x"),
+    [
+        (
+            torch.nn.LayerNorm(64),
+            torch.randn(32, 64),
+        ),
+        (
+            torch.nn.Sequential(
+                torch.nn.LayerNorm(64),
+                torch.nn.Linear(64, 64),
+            ),
+            torch.randn(32, 64),
+        ),
+        (
+            layer.Linear(64, 64, step_mode="s"),
+            torch.randn(32, 64),
+        ),
+    ],
+    ids=("layer-norm", "layer-norm-linear", "layer-linear-single-step"),
+)
+def test_fp8_te_conversion_surfaces_match_fp32_on_hardware(model, x):
+    device = _cuda_device_or_skip("fp8-te")
+    _assert_train_and_infer(model.to(device), x.to(device), "fp8-te")
+
+
+def test_fp8_te_attention_adapter_propagates_gradients_and_runs_inference():
+    device = _cuda_device_or_skip("fp8-te")
+    adapter = TransformerEngineDotProductAttentionAdapter(
+        num_attention_heads=4,
+        head_dim=16,
+    ).to(device)
+    _require_backend_capability(adapter, device, "fp8-te")
+    policy = Float8TransformerEnginePolicy(fp8_recipe="auto")
+    try:
+        policy.check_capability(adapter, device)
+    except RuntimeError as exc:
+        _unavailable_backend("fp8-te", str(exc))
+    query = torch.randn(2, 4, 32, 16, device=device, requires_grad=True)
+    key = torch.randn(2, 4, 32, 16, device=device, requires_grad=True)
+    value = torch.randn(2, 4, 32, 16, device=device, requires_grad=True)
+    reference_query = query.detach().clone().requires_grad_()
+    reference_key = key.detach().clone().requires_grad_()
+    reference_value = value.detach().clone().requires_grad_()
+    reference_output = torch.nn.functional.scaled_dot_product_attention(
+        reference_query,
+        reference_key,
+        reference_value,
+    )
+    reference_loss = reference_output.float().square().mean()
+    reference_loss.backward()
+
+    adapter.train()
+    with policy.autocast_context():
+        output = adapter(query, key, value)
+        loss = output.float().square().mean()
+    loss.backward()
+    assert output.shape == query.shape
+    assert torch.isfinite(output).all()
+    assert _relative_l2(output, reference_output) <= 0.15
+    assert _relative_l2(loss, reference_loss) <= 0.10
+    assert all(
+        tensor.grad is not None and torch.isfinite(tensor.grad).all()
+        for tensor in (query, key, value)
+    )
+    for candidate, reference in zip(
+        (query, key, value),
+        (reference_query, reference_key, reference_value),
+        strict=True,
+    ):
+        _assert_gradient_quality(
+            candidate.grad,
+            reference.grad,
+            min_cosine=0.95,
+            max_relative_l2=0.30,
+        )
+
+    adapter.eval()
+    with torch.inference_mode(), policy.autocast_context():
+        inference_output = adapter(query.detach(), key.detach(), value.detach())
+    assert inference_output.shape == query.shape
+    assert torch.isfinite(inference_output).all()

--- a/test/activation_based/test_precision_fp8_hardware.py
+++ b/test/activation_based/test_precision_fp8_hardware.py
@@ -87,7 +87,7 @@ def _require_backend_capability(
         _unavailable_backend(mode, str(exc))
     if recipe in {"block", "mxfp8"}:
         availability = report.get("te_recipe_availability") or {}
-        if availability.get(recipe) is not True:
+        if not availability.get(recipe):
             reason = f"Transformer Engine recipe {recipe!r} is unavailable."
             if recipe in _required_recipes():
                 pytest.fail(f"Required FP8 recipe {recipe!r} is unavailable.")
@@ -449,7 +449,7 @@ def test_fp8_backend_training_converges_comparably_to_bf16(mode):
 
 @pytest.mark.parametrize("mode", FP8_MODES)
 def test_fp8_backend_runs_inference_on_second_cuda_device(mode):
-    device = _cuda_device_or_skip(mode)
+    _cuda_device_or_skip(mode)
     if torch.cuda.device_count() < 2:
         pytest.skip("A second CUDA device is required for this smoke test.")
     device = torch.device("cuda", 1)

--- a/test/activation_based/test_precision_spikformer_example.py
+++ b/test/activation_based/test_precision_spikformer_example.py
@@ -94,8 +94,8 @@ def test_precision_artifacts_backward_supports_accumulation_without_scaler():
 @pytest.mark.skipif(
     not HAS_TORCHAO
     or not torch.cuda.is_available()
-    or torch.cuda.get_device_capability(0) < (9, 0),
-    reason="This fp8-torchao smoke test requires Hopper / Blackwell or newer (CUDA compute capability >= 9.0).",
+    or torch.cuda.get_device_capability(0) < (8, 9),
+    reason="This fp8-torchao smoke test requires CUDA compute capability >= 8.9.",
 )
 def test_fp8_torchao_aligned_linear_smoke():
     model = (
@@ -133,7 +133,7 @@ def test_fp8_torchao_aligned_linear_smoke():
 def test_spikformer_precision_tools_fp8_torchao_smoke():
     model = _make_tiny_spikformer()
     config = PrecisionConfig(mode="fp8-torchao", strictness="strict", device="cuda:0")
-    if torch.cuda.get_device_capability(0) >= (9, 0):
+    if torch.cuda.get_device_capability(0) >= (8, 9):
         artifacts, y, loss = _run_one_training_step(
             model.to("cuda:0"),
             torch.device("cuda:0"),

--- a/test/activation_based/test_triton_neuron.py
+++ b/test/activation_based/test_triton_neuron.py
@@ -47,6 +47,26 @@ def _assert_close(a: torch.Tensor, b: torch.Tensor, dtype: torch.dtype):
     torch.testing.assert_close(a, b, atol=atol, rtol=rtol)
 
 
+def _relative_l2(candidate: torch.Tensor, reference: torch.Tensor) -> float:
+    numerator = torch.linalg.vector_norm(candidate.float() - reference.float())
+    denominator = torch.linalg.vector_norm(reference.float()).clamp_min(1e-12)
+    return float((numerator / denominator).item())
+
+
+def _assert_gradient_metrics(candidate: torch.Tensor, reference: torch.Tensor) -> None:
+    candidate = candidate.float().reshape(-1)
+    reference = reference.float().reshape(-1)
+    reference_norm = float(torch.linalg.vector_norm(reference).item())
+    if reference_norm < 1e-8:
+        assert float(torch.linalg.vector_norm(candidate).item()) < 1e-5
+        return
+    # FP8 acceptance bounds cover both e4m3fn and e5m2 and were calibrated by
+    # the dual-environment RTX 5090 validation documented in CHANGELOG.md.
+    cosine = float(torch.nn.functional.cosine_similarity(candidate, reference, dim=0))
+    assert cosine >= 0.95
+    assert _relative_l2(candidate, reference) <= 0.30
+
+
 def _call_mixed_precision_forward(
     kind,
     x,
@@ -157,18 +177,31 @@ def _call_mixed_precision_forward_with_plan(
     raise ValueError(f"Unsupported mixed-precision neuron kind: {kind}.")
 
 
-def _fp8_storage_dtype_or_skip() -> torch.dtype:
-    dtype_candidates = []
-    if hasattr(torch, "float8_e5m2"):
-        dtype_candidates.append(torch.float8_e5m2)
-    if hasattr(torch, "float8_e4m3fn"):
-        dtype_candidates.append(torch.float8_e4m3fn)
-    for storage_dtype in dtype_candidates:
-        if supports_triton_fp8_neuron_forward(
-            storage_dtype, torch.device("cuda"), compute_dtype="fp32"
-        ):
-            return storage_dtype
-    pytest.skip("No supported Triton FP8 storage dtype is available on this CUDA device.")
+def _fp8_storage_dtype_or_skip(
+    dtype_name: str,
+    *,
+    compute_dtype: str = "fp32",
+    require_backward: bool = False,
+) -> torch.dtype:
+    storage_dtype = getattr(torch, dtype_name, None)
+    if storage_dtype is None:
+        pytest.skip(f"This PyTorch build does not expose torch.{dtype_name}.")
+    device = torch.device("cuda")
+    if not supports_triton_fp8_neuron_forward(
+        storage_dtype, device, compute_dtype=compute_dtype
+    ):
+        pytest.skip(
+            f"Triton forward does not support {dtype_name} with "
+            f"compute_dtype={compute_dtype!r} on this CUDA device."
+        )
+    if require_backward and not supports_triton_fp8_neuron_backward(
+        storage_dtype, device, compute_dtype=compute_dtype
+    ):
+        pytest.skip(
+            f"Triton backward does not support {dtype_name} with "
+            f"compute_dtype={compute_dtype!r} on this CUDA device."
+        )
+    return storage_dtype
 
 
 def _quantize_for_storage(x: torch.Tensor, storage_dtype: torch.dtype) -> torch.Tensor:
@@ -216,11 +249,29 @@ def _mixed_precision_reference(
 def test_triton_fp8_capability_report_cpu_is_unavailable():
     report = triton_fp8_neuron_capability_report(torch.device("cpu"))
     assert report["device_type"] == "cpu"
+    assert {"fp32", "fp16", "bf16", "fp8"} <= set(report["compute_dtypes"])
     for dtype_report in report["dtypes"].values():
         assert dtype_report["forward"]["available"] is False
         assert dtype_report["forward"]["reason"]
         assert dtype_report["backward"]["available"] is False
         assert dtype_report["backward"]["reason"]
+    for compute_report in report["compute_dtypes"].values():
+        for dtype_report in compute_report.values():
+            assert dtype_report["forward"]["available"] is False
+            assert dtype_report["forward"]["reason"]
+            assert dtype_report["backward"]["available"] is False
+            assert dtype_report["backward"]["reason"]
+
+
+def test_triton_fp8_capability_compatibility_field_is_independent():
+    report = triton_fp8_neuron_capability_report(torch.device("cpu"))
+    dtype_name = next(iter(report["dtypes"]))
+    compute_entry = report["compute_dtypes"]["fp32"][dtype_name]["forward"]
+    original_reason = compute_entry["reason"]
+
+    report["dtypes"][dtype_name]["forward"]["reason"] = "mutated"
+
+    assert compute_entry["reason"] == original_reason
 
 
 def test_triton_fp8_capability_rejects_invalid_dtype():
@@ -238,8 +289,7 @@ def test_normalize_triton_compute_dtype_accepts_native_fp8_dtype():
         )
     if hasattr(torch, "float8_e5m2"):
         assert (
-            triton_utils.normalize_triton_compute_dtype_name(torch.float8_e5m2)
-            == "fp8"
+            triton_utils.normalize_triton_compute_dtype_name(torch.float8_e5m2) == "fp8"
         )
 
 
@@ -752,35 +802,47 @@ def test_mixed_precision_float32_matches_torch_eval(
         x = torch.randn(T, 4, 8, device="cuda", dtype=torch.float32)
         v_init = torch.zeros_like(x[0])
         if kind == "if":
-            node = neuron.IFNode(
-                v_threshold=1.0,
-                v_reset=v_reset,
-                step_mode="m",
-                backend="torch",
-                store_v_seq=True,
-            ).to("cuda").eval()
+            node = (
+                neuron.IFNode(
+                    v_threshold=1.0,
+                    v_reset=v_reset,
+                    step_mode="m",
+                    backend="torch",
+                    store_v_seq=True,
+                )
+                .to("cuda")
+                .eval()
+            )
             r_tau = None
         elif kind == "lif":
-            node = neuron.LIFNode(
-                tau=2.0,
-                decay_input=decay_input,
-                v_threshold=1.0,
-                v_reset=v_reset,
-                step_mode="m",
-                backend="torch",
-                store_v_seq=True,
-            ).to("cuda").eval()
+            node = (
+                neuron.LIFNode(
+                    tau=2.0,
+                    decay_input=decay_input,
+                    v_threshold=1.0,
+                    v_reset=v_reset,
+                    step_mode="m",
+                    backend="torch",
+                    store_v_seq=True,
+                )
+                .to("cuda")
+                .eval()
+            )
             r_tau = None
         elif kind == "plif":
-            node = neuron.ParametricLIFNode(
-                init_tau=2.0,
-                decay_input=decay_input,
-                v_threshold=1.0,
-                v_reset=v_reset,
-                step_mode="m",
-                backend="torch",
-                store_v_seq=True,
-            ).to("cuda").eval()
+            node = (
+                neuron.ParametricLIFNode(
+                    init_tau=2.0,
+                    decay_input=decay_input,
+                    v_threshold=1.0,
+                    v_reset=v_reset,
+                    step_mode="m",
+                    backend="torch",
+                    store_v_seq=True,
+                )
+                .to("cuda")
+                .eval()
+            )
             r_tau = node.w.sigmoid().to(x)
         else:
             raise ValueError(kind)
@@ -944,9 +1006,7 @@ def test_mixed_precision_rejects_v_init_shape_mismatch(kind, use_plan):
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 @pytest.mark.parametrize("kind", ["if", "lif", "plif"])
-def test_mixed_precision_backward_with_plan_skips_repeated_preflight(
-    kind, monkeypatch
-):
+def test_mixed_precision_backward_with_plan_skips_repeated_preflight(kind, monkeypatch):
     x = torch.randn(8, 4, device="cuda", dtype=torch.float32)
     v_init = torch.zeros_like(x[0])
     r_tau = torch.tensor(0.5, device=x.device, dtype=torch.float32)
@@ -1070,15 +1130,16 @@ def test_mixed_precision_autograd_with_plan_matches_safe_wrapper(kind, v_reset):
     torch.testing.assert_close(x_safe.grad, x_plan.grad, atol=0.0, rtol=0.0)
     torch.testing.assert_close(v_safe.grad, v_plan.grad, atol=0.0, rtol=0.0)
     if kind == "plif":
-        torch.testing.assert_close(
-            r_tau_safe.grad, r_tau_plan.grad, atol=0.0, rtol=0.0
-        )
+        torch.testing.assert_close(r_tau_safe.grad, r_tau_plan.grad, atol=0.0, rtol=0.0)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 @pytest.mark.parametrize("kind", ["if", "lif", "plif"])
-def test_mixed_precision_fp8_storage_backward_fp32_compute_produces_finite_grad(kind):
-    storage_dtype = _fp8_storage_dtype_or_skip()
+@pytest.mark.parametrize("dtype_name", ["float8_e4m3fn", "float8_e5m2"])
+def test_mixed_precision_fp8_storage_backward_fp32_compute_produces_finite_grad(
+    kind, dtype_name
+):
+    storage_dtype = _fp8_storage_dtype_or_skip(dtype_name, require_backward=True)
     x = torch.randn(8, 4, device="cuda", dtype=torch.float32).requires_grad_()
     v_init = torch.zeros(4, device="cuda", dtype=torch.float32).requires_grad_()
     r_tau = torch.tensor(0.5, device=x.device, dtype=torch.float32)
@@ -1109,8 +1170,11 @@ def test_mixed_precision_fp8_storage_backward_fp32_compute_produces_finite_grad(
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 @pytest.mark.parametrize("kind", ["if", "lif", "plif"])
 @pytest.mark.parametrize("v_reset", [0.0, None])
-def test_mixed_precision_fp8_storage_matches_quantized_reference(kind, v_reset):
-    storage_dtype = _fp8_storage_dtype_or_skip()
+@pytest.mark.parametrize("dtype_name", ["float8_e4m3fn", "float8_e5m2"])
+def test_mixed_precision_fp8_storage_matches_quantized_reference(
+    kind, v_reset, dtype_name
+):
+    storage_dtype = _fp8_storage_dtype_or_skip(dtype_name, require_backward=False)
     x = torch.tensor(
         [
             [0.25, 0.50, 0.75, 1.00],
@@ -1180,6 +1244,230 @@ def test_mixed_precision_fp8_storage_matches_quantized_reference(kind, v_reset):
     torch.testing.assert_close(
         plan_h_seq.to(torch.float32), expected_h, atol=0.0625, rtol=0.0
     )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("kind", ["if", "lif", "plif"])
+@pytest.mark.parametrize("dtype_name", ["float8_e4m3fn", "float8_e5m2"])
+def test_mixed_precision_fp8_inference_runs_without_saved_intermediates(
+    kind, dtype_name
+):
+    storage_dtype = _fp8_storage_dtype_or_skip(dtype_name, require_backward=True)
+    x = torch.tensor(
+        [
+            [0.25, 0.50, 0.75, 1.00],
+            [0.50, -0.25, 0.25, -0.50],
+            [0.25, 0.75, -0.50, 0.50],
+            [-0.25, 0.50, 0.25, 0.75],
+        ],
+        device="cuda",
+        dtype=torch.float32,
+    )
+    v_init = torch.zeros_like(x[0])
+    r_tau = torch.tensor(0.5, device=x.device, dtype=torch.float32)
+
+    with torch.inference_mode():
+        spike, v_seq, h_seq = _call_mixed_precision_forward(
+            kind,
+            x,
+            v_init,
+            decay_input=True,
+            v_reset=0.0,
+            storage_dtype=storage_dtype,
+            compute_dtype="fp32",
+            backward_compute_dtype="fp32",
+            spike_dtype=torch.float32,
+            save_intermediates=False,
+            r_tau=r_tau,
+        )
+    expected_spike, expected_v, _ = _mixed_precision_reference(
+        kind,
+        x,
+        v_init,
+        storage_dtype=storage_dtype,
+        decay_input=True,
+        v_reset=0.0,
+        r_tau=float(r_tau.item()),
+    )
+
+    assert h_seq is None
+    torch.testing.assert_close(spike, expected_spike, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(
+        v_seq.to(torch.float32), expected_v, atol=0.0625, rtol=0.0
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("kind", ["if", "lif", "plif"])
+@pytest.mark.parametrize("dtype_name", ["float8_e4m3fn", "float8_e5m2"])
+def test_mixed_precision_pure_fp8_compute_runs_forward_and_backward(kind, dtype_name):
+    storage_dtype = _fp8_storage_dtype_or_skip(
+        dtype_name,
+        compute_dtype="fp8",
+        require_backward=True,
+    )
+    x = (
+        torch.linspace(-0.1, 0.1, 16, device="cuda", dtype=torch.float32)
+        .reshape(4, 4)
+        .requires_grad_()
+    )
+    v_init = torch.zeros(4, device="cuda", dtype=torch.float32).requires_grad_()
+    r_tau = torch.tensor(
+        0.5,
+        device=x.device,
+        dtype=torch.float32,
+        requires_grad=kind == "plif",
+    )
+
+    spike, v_seq, h_seq = _call_mixed_precision_forward(
+        kind,
+        x,
+        v_init,
+        decay_input=True,
+        v_reset=0.0,
+        storage_dtype=storage_dtype,
+        compute_dtype="fp8",
+        backward_compute_dtype="fp8",
+        spike_dtype=torch.float32,
+        save_intermediates=True,
+        r_tau=r_tau,
+    )
+    loss = spike.float().sum() + v_seq.float().sum() * 0.125
+    loss.backward()
+
+    reference_x = x.detach().clone().requires_grad_()
+    reference_v_init = v_init.detach().clone().requires_grad_()
+    reference_r_tau = r_tau.detach().clone().requires_grad_(kind == "plif")
+    reference_spike, reference_v_seq, _ = _call_mixed_precision_forward(
+        kind,
+        reference_x,
+        reference_v_init,
+        decay_input=True,
+        v_reset=0.0,
+        storage_dtype=torch.float32,
+        compute_dtype="fp32",
+        backward_compute_dtype="fp32",
+        spike_dtype=torch.float32,
+        save_intermediates=True,
+        r_tau=reference_r_tau,
+    )
+    reference_loss = (
+        reference_spike.float().sum() + reference_v_seq.float().sum() * 0.125
+    )
+    reference_loss.backward()
+
+    assert h_seq is not None
+    assert torch.isfinite(spike).all()
+    assert torch.isfinite(v_seq.float()).all()
+    assert torch.isfinite(h_seq.float()).all()
+    assert x.grad is not None and torch.isfinite(x.grad).all()
+    assert v_init.grad is not None and torch.isfinite(v_init.grad).all()
+    torch.testing.assert_close(spike, reference_spike, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(
+        v_seq.float(), reference_v_seq.float(), atol=0.125, rtol=0.25
+    )
+    _assert_gradient_metrics(x.grad, reference_x.grad)
+    _assert_gradient_metrics(v_init.grad, reference_v_init.grad)
+    if kind == "plif":
+        assert r_tau.grad is not None and torch.isfinite(r_tau.grad).all()
+        _assert_gradient_metrics(r_tau.grad, reference_r_tau.grad)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("kind", ["if", "lif", "plif"])
+@pytest.mark.parametrize(
+    ("dtype_name", "compute_dtype", "v_reset", "decay_input", "detach_reset", "T"),
+    [
+        ("float8_e4m3fn", "fp16", 0.0, True, False, 8),
+        ("float8_e4m3fn", "bf16", None, False, True, 32),
+        ("float8_e4m3fn", "fp32", 0.0, False, True, 65),
+        ("float8_e5m2", "fp32", 0.0, False, True, 65),
+        ("float8_e5m2", "fp16", None, True, False, 16),
+        ("float8_e5m2", "bf16", None, False, True, 32),
+    ],
+)
+def test_mixed_precision_fp8_matrix_meets_numerical_gates(
+    kind,
+    dtype_name,
+    compute_dtype,
+    v_reset,
+    decay_input,
+    detach_reset,
+    T,
+):
+    storage_dtype = _fp8_storage_dtype_or_skip(
+        dtype_name,
+        compute_dtype=compute_dtype,
+        require_backward=False,
+    )
+    # The execution plan uses the selected dtype for forward and FP32 for backward.
+    _fp8_storage_dtype_or_skip(
+        dtype_name,
+        compute_dtype="fp32",
+        require_backward=True,
+    )
+    N = 32
+    x = torch.full((T, N), -0.5, device="cuda", dtype=torch.float32)
+    x[::4] = 3.0
+    x.requires_grad_()
+    v_init = torch.zeros(N, device="cuda", dtype=torch.float32, requires_grad=True)
+    r_tau = torch.tensor(
+        0.5,
+        device="cuda",
+        dtype=torch.float32,
+        requires_grad=kind == "plif",
+    )
+    reference_x = x.detach().clone().requires_grad_()
+    reference_v = v_init.detach().clone().requires_grad_()
+    reference_r_tau = r_tau.detach().clone().requires_grad_(kind == "plif")
+
+    spike, v_seq, h_seq = _call_mixed_precision_forward(
+        kind,
+        x,
+        v_init,
+        decay_input=decay_input,
+        v_reset=v_reset,
+        storage_dtype=storage_dtype,
+        compute_dtype=compute_dtype,
+        backward_compute_dtype="fp32",
+        spike_dtype=torch.float32,
+        save_intermediates=True,
+        detach_reset=detach_reset,
+        r_tau=r_tau,
+    )
+    reference_spike, reference_v_seq, reference_h_seq = _call_mixed_precision_forward(
+        kind,
+        reference_x,
+        reference_v,
+        decay_input=decay_input,
+        v_reset=v_reset,
+        storage_dtype=torch.float32,
+        compute_dtype="fp32",
+        backward_compute_dtype="fp32",
+        spike_dtype=torch.float32,
+        save_intermediates=True,
+        detach_reset=detach_reset,
+        r_tau=reference_r_tau,
+    )
+    loss = spike.float().sum() + v_seq.float().sum() * 0.125
+    reference_loss = (
+        reference_spike.float().sum() + reference_v_seq.float().sum() * 0.125
+    )
+    loss.backward()
+    reference_loss.backward()
+
+    # These state-error budgets come from the same RTX 5090 FP8 acceptance runs.
+    max_state_relative_l2 = 0.10 if dtype_name == "float8_e4m3fn" else 0.18
+    assert h_seq is not None and reference_h_seq is not None
+    assert reference_spike.any()
+    assert (reference_spike == 0).any()
+    torch.testing.assert_close(spike, reference_spike, atol=0.0, rtol=0.0)
+    assert _relative_l2(v_seq, reference_v_seq) <= max_state_relative_l2
+    assert _relative_l2(h_seq, reference_h_seq) <= max_state_relative_l2
+    _assert_gradient_metrics(x.grad, reference_x.grad)
+    _assert_gradient_metrics(v_init.grad, reference_v.grad)
+    if kind == "plif":
+        _assert_gradient_metrics(r_tau.grad, reference_r_tau.grad)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")

--- a/test/activation_based/test_triton_neuron.py
+++ b/test/activation_based/test_triton_neuron.py
@@ -1252,7 +1252,7 @@ def test_mixed_precision_fp8_storage_matches_quantized_reference(
 def test_mixed_precision_fp8_inference_runs_without_saved_intermediates(
     kind, dtype_name
 ):
-    storage_dtype = _fp8_storage_dtype_or_skip(dtype_name, require_backward=True)
+    storage_dtype = _fp8_storage_dtype_or_skip(dtype_name, require_backward=False)
     x = torch.tensor(
         [
             [0.25, 0.50, 0.75, 1.00],
@@ -1401,11 +1401,13 @@ def test_mixed_precision_fp8_matrix_meets_numerical_gates(
         require_backward=False,
     )
     # The execution plan uses the selected dtype for forward and FP32 for backward.
-    _fp8_storage_dtype_or_skip(
-        dtype_name,
-        compute_dtype="fp32",
-        require_backward=True,
-    )
+    if not supports_triton_fp8_neuron_backward(
+        storage_dtype, torch.device("cuda"), compute_dtype="fp32"
+    ):
+        pytest.skip(
+            f"Triton backward does not support {dtype_name} with "
+            "compute_dtype='fp32' on this CUDA device."
+        )
     N = 32
     x = torch.full((T, N), -0.5, device="cuda", dtype=torch.float32)
     x[::4] = 3.0


### PR DESCRIPTION
## Summary

- harden FP8 capability reporting and Transformer Engine/Triton compatibility paths
- add FP8 conversion, hardware, mixed-precision neuron, Spikformer, and benchmark coverage
- add reproducible training/inference and Triton kernel benchmark tooling
- document RTX 5090 validation conclusions for PyTorch 2.7.1 / Triton 3.3.1 and PyTorch 2.11 / Triton 3.6 in the changelog

## Hardware validation

On a dual RTX 5090 host:

- precision suite: 108 passed, 4 skipped on one visible GPU; 2 explicit dual-GPU cases passed; 110 passed, 2 skipped with both GPUs visible
- Triton FP8/mixed-precision suite: 108 passed, 6 capability-gated pure-FP8 skips in both environments
- strict numerical matrix: 18 passed in both environments
- formal Triton matrix: 264 rows, 216 successful supported measurements, 48 expected pure-FP8 failures in both environments
- safe-wrapper matrix: 114 rows, 90 successful measurements, 24 expected pure-FP8 failures in both environments

The validated neuron boundary is FP8 E4M3/E5M2 storage with FP16/BF16/FP32 forward compute and FP32 backward compute. Pure FP8 scalar neuron compute remains unsupported and is reported through capability probes.

## Efficiency

Efficiency results are reported without making a universal speedup claim. FP8 neuron storage reduced training allocation in the tested Triton workloads and accelerated selected larger training cases, while most inference cases and the end-to-end model benchmark did not beat BF16 consistently. Triton 3.3.1 also showed substantially higher cold JIT latency than Triton 3.6.

Raw logs, JSON, CSV, JUnit, and generated benchmark reports are intentionally not versioned.

## Validation

- RTX 5090 hardware acceptance completed in both dependency environments
- local FP8-related regression: 135 passed, 200 hardware skips
- uv dependency checks passed in both remote environments
- Ruff, formatting, changelog generation, and git diff checks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a CUDA-only FP8 benchmark to measure training/inference throughput and peak allocated/reserved CUDA memory, with median + percentile timing and optional JSON output plus baseline efficiency gating.
  - Added FP8/Triton efficiency validation to enforce minimum speedup and produce richer CSV/Markdown reporting (including timing quartiles and memory).
  - Expanded Transformer Engine SDPA adapter compatibility for both `[B, S, H, D]` and flattened `[B, S, H*D]` outputs.
- **Bug Fixes**
  - Improved Transformer Engine capability/error messages to preserve the underlying import/runtime error; FP8 autocast is now scoped to the configured CUDA device.
- **Documentation / Tests**
  - Updated FP8/Triton documentation and significantly expanded FP8, SDPA, and benchmark efficiency test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->