### PR TITLE
Reduce Triton IF/LIF memory use when voltage sequences are not stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,13 +78,13 @@ Module: `spikingjelly.activation_based.triton_kernel.neuron_kernel`.
 
 ### Improvements
 
-#### Triton Neuron Kernels
+#### Triton IF/LIF Memory Optimisation
 
 Module: `spikingjelly.activation_based.triton_kernel.neuron_kernel`.
 
 - Reduced memory usage for standard Triton IF and LIF neurons with
   `store_v_seq=False` by retaining only the final membrane potential instead of
-  materializing the full voltage sequence.
+  materialising the full voltage sequence.
 
 #### Distributed Training
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,14 @@ Module: `spikingjelly.activation_based.triton_kernel.neuron_kernel`.
 
 ### Improvements
 
+#### Triton Neuron Kernels
+
+Module: `spikingjelly.activation_based.triton_kernel.neuron_kernel`.
+
+- Reduced memory usage for standard Triton IF and LIF neurons with
+  `store_v_seq=False` by retaining only the final membrane potential instead of
+  materializing the full voltage sequence.
+
 #### Distributed Training
 
 Module: `spikingjelly.activation_based.distributed`.

--- a/benchmark/benchmark_triton_last_state.py
+++ b/benchmark/benchmark_triton_last_state.py
@@ -1,0 +1,160 @@
+import argparse
+import json
+import os
+import statistics
+import sys
+from pathlib import Path
+
+import torch
+import triton
+
+
+source_root = Path(
+    os.getenv("SJ_BENCH_SOURCE_ROOT", Path(__file__).resolve().parents[1])
+)
+sys.path.insert(0, str(source_root))
+
+from spikingjelly.activation_based.neuron.integrate_and_fire import IFNode
+from spikingjelly.activation_based.neuron.lif import LIFNode
+
+
+CASES = tuple(
+    (kind, mode, T, N, dtype)
+    for kind in ("if", "lif")
+    for mode in ("inference", "training")
+    for T, N, dtype in (
+        (16, 4096, torch.float32),
+        (32, 16381, torch.float16),
+        (65, 16381, torch.float32),
+    )
+)
+
+
+def percentile(values, q):
+    values = sorted(values)
+    index = (len(values) - 1) * q
+    lower = int(index)
+    upper = min(lower + 1, len(values) - 1)
+    weight = index - lower
+    return values[lower] * (1.0 - weight) + values[upper] * weight
+
+
+def make_node(kind):
+    cls = IFNode if kind == "if" else LIFNode
+    return cls(step_mode="m", backend="triton", store_v_seq=False).cuda()
+
+
+def run_case(
+    kind,
+    mode,
+    T,
+    N,
+    dtype,
+    warmup,
+    repetitions,
+    iterations_per_repetition,
+):
+    torch.manual_seed(20260717)
+    x = torch.randn(
+        T,
+        N,
+        device="cuda",
+        dtype=dtype,
+        requires_grad=mode == "training",
+    )
+    node = make_node(kind)
+
+    if mode == "training":
+
+        def step():
+            node.reset()
+            x.grad = None
+            spikes = node(x)
+            spikes.sum().backward()
+
+    else:
+
+        def step():
+            node.reset()
+            with torch.inference_mode():
+                node(x)
+
+    for _ in range(warmup):
+        step()
+    torch.cuda.synchronize()
+
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    samples_ms = []
+    for _ in range(repetitions):
+        start_event.record()
+        for _ in range(iterations_per_repetition):
+            step()
+        end_event.record()
+        end_event.synchronize()
+        samples_ms.append(
+            start_event.elapsed_time(end_event) / iterations_per_repetition
+        )
+
+    node.reset()
+    x.grad = None
+    torch.cuda.empty_cache()
+    torch.cuda.synchronize()
+    allocated_before = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+    step()
+    torch.cuda.synchronize()
+    peak_delta = torch.cuda.max_memory_allocated() - allocated_before
+
+    return {
+        "neuron": kind,
+        "mode": mode,
+        "T": T,
+        "N": N,
+        "dtype": str(dtype).removeprefix("torch."),
+        "warmup": warmup,
+        "repetitions": repetitions,
+        "iterations_per_repetition": iterations_per_repetition,
+        "median_ms": statistics.median(samples_ms),
+        "p25_ms": percentile(samples_ms, 0.25),
+        "p75_ms": percentile(samples_ms, 0.75),
+        "peak_delta_bytes": peak_delta,
+        "samples_ms": samples_ms,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--repetitions", type=int, default=25)
+    parser.add_argument("--iterations-per-repetition", type=int, default=10)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    results = []
+    for case in CASES:
+        result = run_case(
+            *case,
+            args.warmup,
+            args.repetitions,
+            args.iterations_per_repetition,
+        )
+        results.append(result)
+        print(
+            json.dumps(
+                {key: value for key, value in result.items() if key != "samples_ms"}
+            ),
+            flush=True,
+        )
+
+    payload = {
+        "torch": torch.__version__,
+        "triton": triton.__version__,
+        "gpu": torch.cuda.get_device_name(0),
+        "results": results,
+    }
+    args.output.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/benchmark_triton_last_state.py
+++ b/benchmark/benchmark_triton_last_state.py
@@ -31,6 +31,7 @@ CASES = tuple(
 
 
 def percentile(values, q):
+    """Return an interpolated quantile from a non-empty sequence."""
     values = sorted(values)
     index = (len(values) - 1) * q
     lower = int(index)
@@ -40,6 +41,7 @@ def percentile(values, q):
 
 
 def make_node(kind):
+    """Create the requested Triton neuron in last-state mode."""
     cls = IFNode if kind == "if" else LIFNode
     return cls(step_mode="m", backend="triton", store_v_seq=False).cuda()
 
@@ -54,6 +56,7 @@ def run_case(
     repetitions,
     iterations_per_repetition,
 ):
+    """Measure latency and peak allocation for one benchmark case."""
     torch.manual_seed(20260717)
     x = torch.randn(
         T,
@@ -67,6 +70,7 @@ def run_case(
     if mode == "training":
 
         def step():
+            """Run one forward and backward benchmark iteration."""
             node.reset()
             x.grad = None
             spikes = node(x)
@@ -75,6 +79,7 @@ def run_case(
     else:
 
         def step():
+            """Run one inference benchmark iteration."""
             node.reset()
             with torch.inference_mode():
                 node(x)
@@ -124,6 +129,7 @@ def run_case(
 
 
 def main():
+    """Run the benchmark matrix and write the results as JSON."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--warmup", type=int, default=5)
     parser.add_argument("--repetitions", type=int, default=25)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -89,6 +89,15 @@ Bug Fixes
 Improvements
 ~~~~~~~~~~~~
 
+Triton Neuron Kernels
+^^^^^^^^^^^^^^^^^^^^^
+
+Module: ``spikingjelly.activation_based.triton_kernel.neuron_kernel``.
+
+- Reduced memory usage for standard Triton IF and LIF neurons with
+  ``store_v_seq=False`` by retaining only the final membrane potential instead of
+  materializing the full voltage sequence.
+
 Distributed Training
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -89,14 +89,14 @@ Bug Fixes
 Improvements
 ~~~~~~~~~~~~
 
-Triton Neuron Kernels
-^^^^^^^^^^^^^^^^^^^^^
+Triton IF/LIF Memory Optimisation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Module: ``spikingjelly.activation_based.triton_kernel.neuron_kernel``.
 
 - Reduced memory usage for standard Triton IF and LIF neurons with
   ``store_v_seq=False`` by retaining only the final membrane potential instead of
-  materializing the full voltage sequence.
+  materialising the full voltage sequence.
 
 Distributed Training
 ^^^^^^^^^^^^^^^^^^^^

--- a/spikingjelly/activation_based/neuron/integrate_and_fire.py
+++ b/spikingjelly/activation_based/neuron/integrate_and_fire.py
@@ -409,17 +409,20 @@ class IFNode(BaseNode):
                 return spike_seq
             elif self.backend == "triton":
                 self.v_float_to_tensor(x_seq[0])
-                spike_seq, v_seq = triton_kernel.multistep_if(
+                spike_seq, v_out = triton_kernel.multistep_if(
                     x_seq,
                     self.v,
                     self.v_threshold,
                     self.v_reset,
                     self.detach_reset,
                     self.surrogate_function,
+                    self.store_v_seq,
                 )
                 if self.store_v_seq:
-                    self.v_seq = v_seq
-                self.v = v_seq[-1].clone()
+                    self.v_seq = v_out
+                    self.v = v_out[-1].clone()
+                else:
+                    self.v = v_out
                 return spike_seq
             else:
                 raise ValueError(self.backend)
@@ -433,19 +436,20 @@ class IFNode(BaseNode):
                         "Triton backend only supports spiking surrogate functions. "
                         "Use backend='torch' for non-spiking surrogate functions."
                     )
-                spike_seq, v_seq = triton_kernel.multistep_if(
+                spike_seq, v_out = triton_kernel.multistep_if(
                     x_seq,
                     self.v,
                     self.v_threshold,
                     self.v_reset,
                     self.detach_reset,
                     self.surrogate_function,
+                    self.store_v_seq,
                 )
                 if self.store_v_seq:
-                    self.v_seq = v_seq
-                    self.v = v_seq[-1]
+                    self.v_seq = v_out
+                    self.v = v_out[-1]
                 else:
-                    self.v = v_seq[-1].clone()
+                    self.v = v_out
                 return spike_seq
             elif self.backend == "cupy":
                 spike_seq, v_seq = ac_neuron_kernel.multistep_if(

--- a/spikingjelly/activation_based/neuron/lif.py
+++ b/spikingjelly/activation_based/neuron/lif.py
@@ -538,7 +538,7 @@ class LIFNode(BaseNode):
                 return spike_seq
             elif self.backend == "triton":
                 self.v_float_to_tensor(x_seq[0])
-                spike_seq, v_seq = triton_kernel.multistep_lif(
+                spike_seq, v_out = triton_kernel.multistep_lif(
                     x_seq,
                     self.v,
                     self.decay_input,
@@ -547,12 +547,13 @@ class LIFNode(BaseNode):
                     self.v_reset,
                     self.detach_reset,
                     self.surrogate_function,
+                    self.store_v_seq,
                 )
                 if self.store_v_seq:
-                    self.v_seq = v_seq
-                    self.v = v_seq[-1]
+                    self.v_seq = v_out
+                    self.v = v_out[-1]
                 else:
-                    self.v = v_seq[-1].clone()
+                    self.v = v_out
                 return spike_seq
             else:
                 raise ValueError(self.backend)
@@ -566,7 +567,7 @@ class LIFNode(BaseNode):
                         "Triton backend only supports spiking surrogate functions. "
                         "Use backend='torch' for non-spiking surrogate functions."
                     )
-                spike_seq, v_seq = triton_kernel.multistep_lif(
+                spike_seq, v_out = triton_kernel.multistep_lif(
                     x_seq,
                     self.v,
                     self.decay_input,
@@ -575,12 +576,13 @@ class LIFNode(BaseNode):
                     self.v_reset,
                     self.detach_reset,
                     self.surrogate_function,
+                    self.store_v_seq,
                 )
                 if self.store_v_seq:
-                    self.v_seq = v_seq
-                    self.v = v_seq[-1]
+                    self.v_seq = v_out
+                    self.v = v_out[-1]
                 else:
-                    self.v = v_seq[-1].clone()
+                    self.v = v_out
                 return spike_seq
             elif self.backend == "cupy":
                 spike_seq, v_seq = ac_neuron_kernel.multistep_lif(

--- a/spikingjelly/activation_based/neuron/lif.py
+++ b/spikingjelly/activation_based/neuron/lif.py
@@ -551,7 +551,7 @@ class LIFNode(BaseNode):
                 )
                 if self.store_v_seq:
                     self.v_seq = v_out
-                    self.v = v_out[-1]
+                    self.v = v_out[-1].clone()
                 else:
                     self.v = v_out
                 return spike_seq

--- a/spikingjelly/activation_based/triton_kernel/neuron_kernel/integrate_and_fire.py
+++ b/spikingjelly/activation_based/triton_kernel/neuron_kernel/integrate_and_fire.py
@@ -43,7 +43,14 @@ __all__ = ["multistep_if"]
         for f in [1, 2]
         for w in [4, 8]
     ],
-    key=["T", "NCL", "compute_dtype", "soft_reset", "save_intermediates"],
+    key=[
+        "T",
+        "NCL",
+        "compute_dtype",
+        "soft_reset",
+        "save_intermediates",
+        "store_v_seq",
+    ],
     restore_value=["s_seq_ptr", "h_seq_ptr", "v_seq_ptr"],
 )
 @triton.jit
@@ -61,6 +68,7 @@ def _multistep_if_forward_kernel_static(
     compute_dtype: tl.constexpr,
     soft_reset: tl.constexpr,
     save_intermediates: tl.constexpr,
+    store_v_seq: tl.constexpr,
 ):
     pid_ncl = tl.program_id(0)
     ncl_offset = pid_ncl * BLOCK_NCL
@@ -108,15 +116,16 @@ def _multistep_if_forward_kernel_static(
             order=(1, 0),
         )
         convert_and_store(s_ptrs, s, boundary_check=(1,))
-        v_ptrs = tl.make_block_ptr(
-            v_seq_ptr,
-            shape=(T, NCL),
-            strides=(NCL, 1),
-            offsets=(t, ncl_offset),
-            block_shape=(1, BLOCK_NCL),
-            order=(1, 0),
-        )
-        convert_and_store(v_ptrs, v, boundary_check=(1,))
+        if store_v_seq:
+            v_ptrs = tl.make_block_ptr(
+                v_seq_ptr,
+                shape=(T, NCL),
+                strides=(NCL, 1),
+                offsets=(t, ncl_offset),
+                block_shape=(1, BLOCK_NCL),
+                order=(1, 0),
+            )
+            convert_and_store(v_ptrs, v, boundary_check=(1,))
         if save_intermediates:
             h_ptrs = tl.make_block_ptr(
                 h_seq_ptr,
@@ -128,6 +137,17 @@ def _multistep_if_forward_kernel_static(
             )
             convert_and_store(h_ptrs, h, boundary_check=(1,))
 
+    if not store_v_seq:
+        v_last_ptrs = tl.make_block_ptr(
+            v_seq_ptr,
+            shape=(1, NCL),
+            strides=(NCL, 1),
+            offsets=(0, ncl_offset),
+            block_shape=(1, BLOCK_NCL),
+            order=(1, 0),
+        )
+        convert_and_store(v_last_ptrs, v, boundary_check=(1,))
+
 
 @triton.autotune(
     configs=[
@@ -135,7 +155,13 @@ def _multistep_if_forward_kernel_static(
         for f in [1, 2]
         for w in [4, 8]
     ],
-    key=["NCL", "compute_dtype", "soft_reset", "save_intermediates"],
+    key=[
+        "NCL",
+        "compute_dtype",
+        "soft_reset",
+        "save_intermediates",
+        "store_v_seq",
+    ],
     restore_value=["s_seq_ptr", "h_seq_ptr", "v_seq_ptr"],
 )
 @triton.jit
@@ -153,6 +179,7 @@ def _multistep_if_forward_kernel_dynamic(
     compute_dtype: tl.constexpr,
     soft_reset: tl.constexpr,
     save_intermediates: tl.constexpr,
+    store_v_seq: tl.constexpr,
 ):
     pid_ncl = tl.program_id(0)
     ncl_offset = pid_ncl * BLOCK_NCL
@@ -200,15 +227,16 @@ def _multistep_if_forward_kernel_dynamic(
             order=(1, 0),
         )
         convert_and_store(s_ptrs, s, boundary_check=(1,))
-        v_ptrs = tl.make_block_ptr(
-            v_seq_ptr,
-            shape=(T, NCL),
-            strides=(NCL, 1),
-            offsets=(t, ncl_offset),
-            block_shape=(1, BLOCK_NCL),
-            order=(1, 0),
-        )
-        convert_and_store(v_ptrs, v, boundary_check=(1,))
+        if store_v_seq:
+            v_ptrs = tl.make_block_ptr(
+                v_seq_ptr,
+                shape=(T, NCL),
+                strides=(NCL, 1),
+                offsets=(t, ncl_offset),
+                block_shape=(1, BLOCK_NCL),
+                order=(1, 0),
+            )
+            convert_and_store(v_ptrs, v, boundary_check=(1,))
         if save_intermediates:
             h_ptrs = tl.make_block_ptr(
                 h_seq_ptr,
@@ -220,6 +248,17 @@ def _multistep_if_forward_kernel_dynamic(
             )
             convert_and_store(h_ptrs, h, boundary_check=(1,))
 
+    if not store_v_seq:
+        v_last_ptrs = tl.make_block_ptr(
+            v_seq_ptr,
+            shape=(1, NCL),
+            strides=(NCL, 1),
+            offsets=(0, ncl_offset),
+            block_shape=(1, BLOCK_NCL),
+            order=(1, 0),
+        )
+        convert_and_store(v_last_ptrs, v, boundary_check=(1,))
+
 
 @triton.autotune(
     configs=[
@@ -227,7 +266,14 @@ def _multistep_if_forward_kernel_dynamic(
         for f in [1, 2]
         for w in [4, 8]
     ],
-    key=["T", "NCL", "compute_dtype", "soft_reset", "detach_reset"],
+    key=[
+        "T",
+        "NCL",
+        "compute_dtype",
+        "soft_reset",
+        "detach_reset",
+        "store_v_seq",
+    ],
     restore_value=["grad_x_seq_ptr"],
 )
 @triton.jit
@@ -247,13 +293,27 @@ def _multistep_if_backward_kernel_static(
     sg_triton_id: tl.constexpr,
     soft_reset: tl.constexpr,
     detach_reset: tl.constexpr,
+    store_v_seq: tl.constexpr,
 ):
     pid_ncl = tl.program_id(0)
     ncl_offset = pid_ncl * BLOCK_NCL
     v_threshold = tl.full([1], v_threshold, dtype=compute_dtype)
     v_reset = tl.full([1], v_reset, dtype=compute_dtype)
 
-    grad_v_acc = tl.zeros([1, BLOCK_NCL], dtype=compute_dtype)
+    if store_v_seq:
+        grad_v_acc = tl.zeros([1, BLOCK_NCL], dtype=compute_dtype)
+    else:
+        grad_v_last_ptrs = tl.make_block_ptr(
+            grad_v_seq_ptr,
+            shape=(1, NCL),
+            strides=(NCL, 1),
+            offsets=(0, ncl_offset),
+            block_shape=(1, BLOCK_NCL),
+            order=(1, 0),
+        )
+        grad_v_acc = tl.load(
+            grad_v_last_ptrs, boundary_check=(1,), padding_option="zero"
+        ).to(compute_dtype)
 
     for t in tl.static_range(T - 1, -1, -1):
         grad_s_ptrs = tl.make_block_ptr(
@@ -264,20 +324,21 @@ def _multistep_if_backward_kernel_static(
             block_shape=(1, BLOCK_NCL),
             order=(1, 0),
         )
-        grad_s = tl.load(
-            grad_s_ptrs, boundary_check=(1,), padding_option="zero"
-        ).to(compute_dtype)
-        grad_v_ptrs = tl.make_block_ptr(
-            grad_v_seq_ptr,
-            shape=(T, NCL),
-            strides=(NCL, 1),
-            offsets=(t, ncl_offset),
-            block_shape=(1, BLOCK_NCL),
-            order=(1, 0),
+        grad_s = tl.load(grad_s_ptrs, boundary_check=(1,), padding_option="zero").to(
+            compute_dtype
         )
-        grad_v = tl.load(
-            grad_v_ptrs, boundary_check=(1,), padding_option="zero"
-        ).to(compute_dtype)
+        if store_v_seq:
+            grad_v_ptrs = tl.make_block_ptr(
+                grad_v_seq_ptr,
+                shape=(T, NCL),
+                strides=(NCL, 1),
+                offsets=(t, ncl_offset),
+                block_shape=(1, BLOCK_NCL),
+                order=(1, 0),
+            )
+            grad_v = tl.load(
+                grad_v_ptrs, boundary_check=(1,), padding_option="zero"
+            ).to(compute_dtype)
         h_ptrs = tl.make_block_ptr(
             h_seq_ptr,
             shape=(T, NCL),
@@ -291,7 +352,10 @@ def _multistep_if_backward_kernel_static(
         )
 
         sg = sg_triton(h - v_threshold, sg_alpha, sg_triton_id)
-        grad_v_combined = grad_v + grad_v_acc
+        if store_v_seq:
+            grad_v_combined = grad_v + grad_v_acc
+        else:
+            grad_v_combined = grad_v_acc
         if soft_reset:
             if detach_reset:
                 grad_h = tl.fma(grad_s, sg, grad_v_combined)
@@ -339,7 +403,13 @@ def _multistep_if_backward_kernel_static(
         for f in [1, 2]
         for w in [4, 8]
     ],
-    key=["NCL", "compute_dtype", "soft_reset", "detach_reset"],
+    key=[
+        "NCL",
+        "compute_dtype",
+        "soft_reset",
+        "detach_reset",
+        "store_v_seq",
+    ],
     restore_value=["grad_x_seq_ptr"],
 )
 @triton.jit
@@ -359,13 +429,27 @@ def _multistep_if_backward_kernel_dynamic(
     sg_triton_id: tl.constexpr,
     soft_reset: tl.constexpr,
     detach_reset: tl.constexpr,
+    store_v_seq: tl.constexpr,
 ):
     pid_ncl = tl.program_id(0)
     ncl_offset = pid_ncl * BLOCK_NCL
     v_threshold = tl.full([1], v_threshold, dtype=compute_dtype)
     v_reset = tl.full([1], v_reset, dtype=compute_dtype)
 
-    grad_v_acc = tl.zeros([1, BLOCK_NCL], dtype=compute_dtype)
+    if store_v_seq:
+        grad_v_acc = tl.zeros([1, BLOCK_NCL], dtype=compute_dtype)
+    else:
+        grad_v_last_ptrs = tl.make_block_ptr(
+            grad_v_seq_ptr,
+            shape=(1, NCL),
+            strides=(NCL, 1),
+            offsets=(0, ncl_offset),
+            block_shape=(1, BLOCK_NCL),
+            order=(1, 0),
+        )
+        grad_v_acc = tl.load(
+            grad_v_last_ptrs, boundary_check=(1,), padding_option="zero"
+        ).to(compute_dtype)
 
     for t in tl.range(T - 1, -1, -1):
         grad_s_ptrs = tl.make_block_ptr(
@@ -376,20 +460,21 @@ def _multistep_if_backward_kernel_dynamic(
             block_shape=(1, BLOCK_NCL),
             order=(1, 0),
         )
-        grad_s = tl.load(
-            grad_s_ptrs, boundary_check=(1,), padding_option="zero"
-        ).to(compute_dtype)
-        grad_v_ptrs = tl.make_block_ptr(
-            grad_v_seq_ptr,
-            shape=(T, NCL),
-            strides=(NCL, 1),
-            offsets=(t, ncl_offset),
-            block_shape=(1, BLOCK_NCL),
-            order=(1, 0),
+        grad_s = tl.load(grad_s_ptrs, boundary_check=(1,), padding_option="zero").to(
+            compute_dtype
         )
-        grad_v = tl.load(
-            grad_v_ptrs, boundary_check=(1,), padding_option="zero"
-        ).to(compute_dtype)
+        if store_v_seq:
+            grad_v_ptrs = tl.make_block_ptr(
+                grad_v_seq_ptr,
+                shape=(T, NCL),
+                strides=(NCL, 1),
+                offsets=(t, ncl_offset),
+                block_shape=(1, BLOCK_NCL),
+                order=(1, 0),
+            )
+            grad_v = tl.load(
+                grad_v_ptrs, boundary_check=(1,), padding_option="zero"
+            ).to(compute_dtype)
         h_ptrs = tl.make_block_ptr(
             h_seq_ptr,
             shape=(T, NCL),
@@ -403,7 +488,10 @@ def _multistep_if_backward_kernel_dynamic(
         )
 
         sg = sg_triton(h - v_threshold, sg_alpha, sg_triton_id)
-        grad_v_combined = grad_v + grad_v_acc
+        if store_v_seq:
+            grad_v_combined = grad_v + grad_v_acc
+        else:
+            grad_v_combined = grad_v_acc
         if soft_reset:
             if detach_reset:
                 grad_h = tl.fma(grad_s, sg, grad_v_combined)
@@ -480,6 +568,7 @@ def _launch_if_forward_kernel(
     soft_reset: bool,
     compute_dtype,
     save_intermediates: bool,
+    store_v_seq: bool,
     use_torch_wrap: bool,
 ) -> None:
     T = x_seq.shape[0]
@@ -506,6 +595,7 @@ def _launch_if_forward_kernel(
             compute_dtype=compute_dtype,
             soft_reset=soft_reset,
             save_intermediates=save_intermediates,
+            store_v_seq=store_v_seq,
         )
 
 
@@ -523,6 +613,7 @@ def _launch_if_backward_kernel(
     sg_triton_id: int,
     soft_reset: bool,
     detach_reset: bool,
+    store_v_seq: bool,
     use_torch_wrap: bool,
 ) -> None:
     T = grad_s_seq.shape[0]
@@ -551,6 +642,7 @@ def _launch_if_backward_kernel(
             sg_triton_id=sg_triton_id,
             soft_reset=soft_reset,
             detach_reset=detach_reset,
+            store_v_seq=store_v_seq,
         )
 
 
@@ -561,12 +653,13 @@ def multistep_if_inference(
     v_threshold: float,
     v_reset: float,
     soft_reset: bool,
+    store_v_seq: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     x_seq = x_seq.contiguous()
     v_init = v_init.contiguous()
 
     s_seq = torch.empty_like(x_seq)
-    v_seq = torch.empty_like(x_seq)
+    v_seq = torch.empty_like(x_seq) if store_v_seq else torch.empty_like(v_init)
     dtype = x_seq.dtype
     _launch_if_forward_kernel(
         x_seq,
@@ -579,6 +672,7 @@ def multistep_if_inference(
         soft_reset=soft_reset,
         compute_dtype=type_dict[dtype],
         save_intermediates=False,
+        store_v_seq=store_v_seq,
         use_torch_wrap=True,
     )
     return s_seq, v_seq
@@ -591,10 +685,11 @@ def _multistep_if_inference_fake(
     v_threshold: float,
     v_reset: float,
     soft_reset: bool,
+    store_v_seq: bool,
 ):
     return (
         x_seq.new_empty(x_seq.shape),
-        x_seq.new_empty(x_seq.shape),
+        x_seq.new_empty(x_seq.shape if store_v_seq else v_init.shape),
     )
 
 
@@ -608,12 +703,13 @@ def multistep_if_forward(
     detach_reset: bool,
     sg_triton_id: int,
     sg_alpha: float,
+    store_v_seq: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     x_seq = x_seq.contiguous()
     v_init = v_init.contiguous()
 
     s_seq = torch.empty_like(x_seq)
-    v_seq = torch.empty_like(x_seq)
+    v_seq = torch.empty_like(x_seq) if store_v_seq else torch.empty_like(v_init)
     h_seq = torch.empty_like(x_seq)
     dtype = x_seq.dtype
     _launch_if_forward_kernel(
@@ -627,6 +723,7 @@ def multistep_if_forward(
         soft_reset=soft_reset,
         compute_dtype=type_dict[dtype],
         save_intermediates=True,
+        store_v_seq=store_v_seq,
         use_torch_wrap=True,
     )
     return s_seq, v_seq, h_seq
@@ -642,10 +739,11 @@ def _multistep_if_forward_fake(
     detach_reset: bool,
     sg_triton_id: int,
     sg_alpha: float,
+    store_v_seq: bool,
 ):
     return (
         x_seq.new_empty(x_seq.shape),
-        x_seq.new_empty(x_seq.shape),
+        x_seq.new_empty(x_seq.shape if store_v_seq else v_init.shape),
         x_seq.new_empty(x_seq.shape),
     )
 
@@ -690,6 +788,7 @@ def multistep_if_mp_inference(
         soft_reset=soft_reset,
         compute_dtype=compute_tl_dtype,
         save_intermediates=save_intermediates,
+        store_v_seq=True,
         use_torch_wrap=True,
     )
     return s_seq, v_seq, h_seq
@@ -757,6 +856,7 @@ def multistep_if_mp_forward(
         soft_reset=soft_reset,
         compute_dtype=compute_tl_dtype,
         save_intermediates=True,
+        store_v_seq=True,
         use_torch_wrap=True,
     )
     return s_seq, v_seq, h_seq
@@ -960,9 +1060,23 @@ def _multistep_if_mp_backward(ctx, grad_s_seq, grad_v_seq, grad_h_seq):
         sg_triton_id=ctx.sg_triton_id,
         soft_reset=ctx.soft_reset,
         detach_reset=ctx.detach_reset,
+        store_v_seq=True,
         use_torch_wrap=True,
     )
-    return grad_x_seq, grad_v_init, None, None, None, None, None, None, None, None, None, None
+    return (
+        grad_x_seq,
+        grad_v_init,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
 
 
 torch.library.register_autograd(
@@ -973,7 +1087,15 @@ torch.library.register_autograd(
 
 
 def _setup_context(ctx, inputs, output):
-    v_threshold, v_reset, soft_reset, detach_reset, sg_triton_id, sg_alpha = inputs[2:]
+    (
+        v_threshold,
+        v_reset,
+        soft_reset,
+        detach_reset,
+        sg_triton_id,
+        sg_alpha,
+        store_v_seq,
+    ) = inputs[2:]
     h_seq = output[2]
     ctx.save_for_backward(h_seq)
     ctx.v_threshold = v_threshold
@@ -982,6 +1104,7 @@ def _setup_context(ctx, inputs, output):
     ctx.detach_reset = detach_reset
     ctx.sg_triton_id = sg_triton_id
     ctx.sg_alpha = sg_alpha
+    ctx.store_v_seq = store_v_seq
 
 
 def _multistep_if_backward(ctx, grad_s_seq, grad_v_seq, grad_h_seq):
@@ -990,7 +1113,7 @@ def _multistep_if_backward(ctx, grad_s_seq, grad_v_seq, grad_h_seq):
         raise RuntimeError("backward called without saved intermediates")
 
     grad_x_seq = torch.empty_like(grad_s_seq)
-    grad_v_init = torch.empty_like(grad_v_seq[0])
+    grad_v_init = torch.empty_like(h_seq[0])
     dtype = grad_s_seq.dtype
     if dtype not in type_dict:
         raise NotImplementedError(dtype)
@@ -1007,9 +1130,10 @@ def _multistep_if_backward(ctx, grad_s_seq, grad_v_seq, grad_h_seq):
         sg_triton_id=ctx.sg_triton_id,
         soft_reset=ctx.soft_reset,
         detach_reset=ctx.detach_reset,
+        store_v_seq=ctx.store_v_seq,
         use_torch_wrap=True,
     )
-    return grad_x_seq, grad_v_init, None, None, None, None, None, None
+    return grad_x_seq, grad_v_init, None, None, None, None, None, None, None
 
 
 torch.library.register_autograd(
@@ -1024,6 +1148,7 @@ def multistep_if(
     v_reset: Optional[float],
     detach_reset: bool,
     surrogate_function,
+    store_v_seq: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Multi-step IF neuron forward pass via Triton kernel.
 
@@ -1049,7 +1174,11 @@ def multistep_if(
     :type detach_reset: bool
     :param surrogate_function: Surrogate gradient function
     :type surrogate_function: ``surrogate.SurrogateFunctionBase``
-    :return: Tuple of (spike_seq, v_seq)
+    :param store_v_seq: Whether to return the full membrane-potential sequence. If
+        ``False``, the second output contains only the final membrane potential.
+    :type store_v_seq: bool
+    :return: Tuple of ``(spike_seq, v_seq)`` when ``store_v_seq=True`` or
+        ``(spike_seq, v_last)`` otherwise
     :rtype: tuple[torch.Tensor, torch.Tensor]
 
     ----
@@ -1072,7 +1201,11 @@ def multistep_if(
     :type v_reset: Optional[float]
     :type detach_reset: bool
     :type surrogate_function: ``surrogate.SurrogateFunctionBase``
-    :return: Tuple of (spike_seq, v_seq)
+    :param store_v_seq: Whether to return the full membrane-potential sequence. If
+        ``False``, the second output contains only the final membrane potential.
+    :type store_v_seq: bool
+    :return: Tuple of ``(spike_seq, v_seq)`` when ``store_v_seq=True`` or
+        ``(spike_seq, v_last)`` otherwise
     :rtype: tuple[torch.Tensor, torch.Tensor]
     """
     soft_reset = v_reset is None
@@ -1091,6 +1224,7 @@ def multistep_if(
             detach_reset,
             sg_triton_id,
             sg_alpha,
+            store_v_seq,
         )
     else:
         s_seq, v_seq = multistep_if_inference(
@@ -1099,5 +1233,6 @@ def multistep_if(
             v_threshold,
             v_reset,
             soft_reset,
+            store_v_seq,
         )
     return s_seq, v_seq

--- a/spikingjelly/activation_based/triton_kernel/neuron_kernel/integrate_and_fire.py
+++ b/spikingjelly/activation_based/triton_kernel/neuron_kernel/integrate_and_fire.py
@@ -1174,11 +1174,11 @@ def multistep_if(
     :type detach_reset: bool
     :param surrogate_function: Surrogate gradient function
     :type surrogate_function: ``surrogate.SurrogateFunctionBase``
-    :param store_v_seq: Whether to return the full membrane-potential sequence. If
-        ``False``, the second output contains only the final membrane potential.
+    :param store_v_seq: 是否返回完整的膜电位序列，默认为 ``True``。设置为 ``False`` 时，
+        第二个输出仅包含最终膜电位，其形状与 ``v_init`` 相同。
     :type store_v_seq: bool
-    :return: Tuple of ``(spike_seq, v_seq)`` when ``store_v_seq=True`` or
-        ``(spike_seq, v_last)`` otherwise
+    :return: 当 ``store_v_seq=True`` 时返回 ``(spike_seq, v_seq)``，否则返回
+        ``(spike_seq, v_last)``，其中 ``v_last`` 的形状与 ``v_init`` 相同。
     :rtype: tuple[torch.Tensor, torch.Tensor]
 
     ----
@@ -1201,11 +1201,13 @@ def multistep_if(
     :type v_reset: Optional[float]
     :type detach_reset: bool
     :type surrogate_function: ``surrogate.SurrogateFunctionBase``
-    :param store_v_seq: Whether to return the full membrane-potential sequence. If
-        ``False``, the second output contains only the final membrane potential.
+    :param store_v_seq: Whether to return the full membrane-potential sequence.
+        Defaults to ``True``. If ``False``, the second output contains only the
+        final membrane potential and has the same shape as ``v_init``.
     :type store_v_seq: bool
     :return: Tuple of ``(spike_seq, v_seq)`` when ``store_v_seq=True`` or
-        ``(spike_seq, v_last)`` otherwise
+        ``(spike_seq, v_last)`` otherwise, where ``v_last`` has the same shape as
+        ``v_init``
     :rtype: tuple[torch.Tensor, torch.Tensor]
     """
     soft_reset = v_reset is None

--- a/spikingjelly/activation_based/triton_kernel/neuron_kernel/lif.py
+++ b/spikingjelly/activation_based/triton_kernel/neuron_kernel/lif.py
@@ -42,7 +42,14 @@ __all__ = ["multistep_lif"]
         for f in [1, 2]
         for w in [4, 8]
     ],
-    key=["T", "NCL", "compute_dtype", "soft_reset", "save_intermediates"],
+    key=[
+        "T",
+        "NCL",
+        "compute_dtype",
+        "soft_reset",
+        "save_intermediates",
+        "store_v_seq",
+    ],
     restore_value=["s_seq_ptr", "h_seq_ptr", "v_seq_ptr"],
 )
 @triton.jit
@@ -62,6 +69,7 @@ def _multistep_lif_forward_kernel_static(
     decay_input: tl.constexpr,
     soft_reset: tl.constexpr,
     save_intermediates: tl.constexpr,
+    store_v_seq: tl.constexpr,
 ):
     pid_ncl = tl.program_id(0)
     ncl_offset = pid_ncl * BLOCK_NCL
@@ -114,15 +122,16 @@ def _multistep_lif_forward_kernel_static(
             order=(1, 0),
         )
         convert_and_store(s_ptrs, s, boundary_check=(1,))
-        v_ptrs = tl.make_block_ptr(
-            v_seq_ptr,
-            shape=(T, NCL),
-            strides=(NCL, 1),
-            offsets=(t, ncl_offset),
-            block_shape=(1, BLOCK_NCL),
-            order=(1, 0),
-        )
-        convert_and_store(v_ptrs, v, boundary_check=(1,))
+        if store_v_seq:
+            v_ptrs = tl.make_block_ptr(
+                v_seq_ptr,
+                shape=(T, NCL),
+                strides=(NCL, 1),
+                offsets=(t, ncl_offset),
+                block_shape=(1, BLOCK_NCL),
+                order=(1, 0),
+            )
+            convert_and_store(v_ptrs, v, boundary_check=(1,))
         if save_intermediates:
             h_ptrs = tl.make_block_ptr(
                 h_seq_ptr,
@@ -134,6 +143,17 @@ def _multistep_lif_forward_kernel_static(
             )
             convert_and_store(h_ptrs, h, boundary_check=(1,))
 
+    if not store_v_seq:
+        v_last_ptrs = tl.make_block_ptr(
+            v_seq_ptr,
+            shape=(1, NCL),
+            strides=(NCL, 1),
+            offsets=(0, ncl_offset),
+            block_shape=(1, BLOCK_NCL),
+            order=(1, 0),
+        )
+        convert_and_store(v_last_ptrs, v, boundary_check=(1,))
+
 
 @triton.autotune(
     configs=[
@@ -141,7 +161,13 @@ def _multistep_lif_forward_kernel_static(
         for f in [1, 2]
         for w in [4, 8]
     ],
-    key=["NCL", "compute_dtype", "soft_reset", "save_intermediates"],
+    key=[
+        "NCL",
+        "compute_dtype",
+        "soft_reset",
+        "save_intermediates",
+        "store_v_seq",
+    ],
     restore_value=["s_seq_ptr", "h_seq_ptr", "v_seq_ptr"],
 )
 @triton.jit
@@ -161,6 +187,7 @@ def _multistep_lif_forward_kernel_dynamic(
     decay_input: tl.constexpr,
     soft_reset: tl.constexpr,
     save_intermediates: tl.constexpr,
+    store_v_seq: tl.constexpr,
 ):
     pid_ncl = tl.program_id(0)
     ncl_offset = pid_ncl * BLOCK_NCL
@@ -213,15 +240,16 @@ def _multistep_lif_forward_kernel_dynamic(
             order=(1, 0),
         )
         convert_and_store(s_ptrs, s, boundary_check=(1,))
-        v_ptrs = tl.make_block_ptr(
-            v_seq_ptr,
-            shape=(T, NCL),
-            strides=(NCL, 1),
-            offsets=(t, ncl_offset),
-            block_shape=(1, BLOCK_NCL),
-            order=(1, 0),
-        )
-        convert_and_store(v_ptrs, v, boundary_check=(1,))
+        if store_v_seq:
+            v_ptrs = tl.make_block_ptr(
+                v_seq_ptr,
+                shape=(T, NCL),
+                strides=(NCL, 1),
+                offsets=(t, ncl_offset),
+                block_shape=(1, BLOCK_NCL),
+                order=(1, 0),
+            )
+            convert_and_store(v_ptrs, v, boundary_check=(1,))
         if save_intermediates:
             h_ptrs = tl.make_block_ptr(
                 h_seq_ptr,
@@ -233,6 +261,17 @@ def _multistep_lif_forward_kernel_dynamic(
             )
             convert_and_store(h_ptrs, h, boundary_check=(1,))
 
+    if not store_v_seq:
+        v_last_ptrs = tl.make_block_ptr(
+            v_seq_ptr,
+            shape=(1, NCL),
+            strides=(NCL, 1),
+            offsets=(0, ncl_offset),
+            block_shape=(1, BLOCK_NCL),
+            order=(1, 0),
+        )
+        convert_and_store(v_last_ptrs, v, boundary_check=(1,))
+
 
 @triton.autotune(
     configs=[
@@ -240,7 +279,14 @@ def _multistep_lif_forward_kernel_dynamic(
         for f in [1, 2]
         for w in [4, 8]
     ],
-    key=["T", "NCL", "compute_dtype", "soft_reset", "detach_reset"],
+    key=[
+        "T",
+        "NCL",
+        "compute_dtype",
+        "soft_reset",
+        "detach_reset",
+        "store_v_seq",
+    ],
     restore_value=["grad_x_seq_ptr", "grad_v_init_ptr"],
 )
 @triton.jit
@@ -262,6 +308,7 @@ def _multistep_lif_backward_kernel_static(
     decay_input: tl.constexpr,
     soft_reset: tl.constexpr,
     detach_reset: tl.constexpr,
+    store_v_seq: tl.constexpr,
 ):
     pid_ncl = tl.program_id(0)
     ncl_offset = pid_ncl * BLOCK_NCL
@@ -269,7 +316,20 @@ def _multistep_lif_backward_kernel_static(
     v_reset = tl.full([1], v_reset, dtype=compute_dtype)
 
     r_tau = tl.full([1], 1.0 / tau, dtype=compute_dtype)
-    grad_v_acc = tl.zeros([1, BLOCK_NCL], dtype=compute_dtype)
+    if store_v_seq:
+        grad_v_acc = tl.zeros([1, BLOCK_NCL], dtype=compute_dtype)
+    else:
+        grad_v_last_ptrs = tl.make_block_ptr(
+            grad_v_seq_ptr,
+            shape=(1, NCL),
+            strides=(NCL, 1),
+            offsets=(0, ncl_offset),
+            block_shape=(1, BLOCK_NCL),
+            order=(1, 0),
+        )
+        grad_v_acc = tl.load(
+            grad_v_last_ptrs, boundary_check=(1,), padding_option="zero"
+        ).to(compute_dtype)
 
     for t in tl.static_range(T - 1, -1, -1):
         grad_s_ptrs = tl.make_block_ptr(
@@ -280,20 +340,21 @@ def _multistep_lif_backward_kernel_static(
             block_shape=(1, BLOCK_NCL),
             order=(1, 0),
         )
-        grad_s = tl.load(
-            grad_s_ptrs, boundary_check=(1,), padding_option="zero"
-        ).to(compute_dtype)
-        grad_v_ptrs = tl.make_block_ptr(
-            grad_v_seq_ptr,
-            shape=(T, NCL),
-            strides=(NCL, 1),
-            offsets=(t, ncl_offset),
-            block_shape=(1, BLOCK_NCL),
-            order=(1, 0),
+        grad_s = tl.load(grad_s_ptrs, boundary_check=(1,), padding_option="zero").to(
+            compute_dtype
         )
-        grad_v = tl.load(
-            grad_v_ptrs, boundary_check=(1,), padding_option="zero"
-        ).to(compute_dtype)
+        if store_v_seq:
+            grad_v_ptrs = tl.make_block_ptr(
+                grad_v_seq_ptr,
+                shape=(T, NCL),
+                strides=(NCL, 1),
+                offsets=(t, ncl_offset),
+                block_shape=(1, BLOCK_NCL),
+                order=(1, 0),
+            )
+            grad_v = tl.load(
+                grad_v_ptrs, boundary_check=(1,), padding_option="zero"
+            ).to(compute_dtype)
         h_ptrs = tl.make_block_ptr(
             h_seq_ptr,
             shape=(T, NCL),
@@ -307,7 +368,8 @@ def _multistep_lif_backward_kernel_static(
         )
 
         sg = sg_triton(h - v_threshold, sg_alpha, sg_triton_id)
-        grad_v_acc = grad_v + grad_v_acc
+        if store_v_seq:
+            grad_v_acc = grad_v + grad_v_acc
         if soft_reset:
             if detach_reset:
                 grad_h = tl.fma(grad_s, sg, grad_v_acc)
@@ -356,7 +418,13 @@ def _multistep_lif_backward_kernel_static(
         for f in [1, 2]
         for w in [4, 8]
     ],
-    key=["NCL", "compute_dtype", "soft_reset", "detach_reset"],
+    key=[
+        "NCL",
+        "compute_dtype",
+        "soft_reset",
+        "detach_reset",
+        "store_v_seq",
+    ],
     restore_value=["grad_x_seq_ptr", "grad_v_init_ptr"],
 )
 @triton.jit
@@ -378,6 +446,7 @@ def _multistep_lif_backward_kernel_dynamic(
     decay_input: tl.constexpr,
     soft_reset: tl.constexpr,
     detach_reset: tl.constexpr,
+    store_v_seq: tl.constexpr,
 ):
     pid_ncl = tl.program_id(0)
     ncl_offset = pid_ncl * BLOCK_NCL
@@ -385,7 +454,20 @@ def _multistep_lif_backward_kernel_dynamic(
     v_reset = tl.full([1], v_reset, dtype=compute_dtype)
 
     r_tau = tl.full([1], 1.0 / tau, dtype=compute_dtype)
-    grad_v_acc = tl.zeros([1, BLOCK_NCL], dtype=compute_dtype)
+    if store_v_seq:
+        grad_v_acc = tl.zeros([1, BLOCK_NCL], dtype=compute_dtype)
+    else:
+        grad_v_last_ptrs = tl.make_block_ptr(
+            grad_v_seq_ptr,
+            shape=(1, NCL),
+            strides=(NCL, 1),
+            offsets=(0, ncl_offset),
+            block_shape=(1, BLOCK_NCL),
+            order=(1, 0),
+        )
+        grad_v_acc = tl.load(
+            grad_v_last_ptrs, boundary_check=(1,), padding_option="zero"
+        ).to(compute_dtype)
 
     for t in tl.range(T - 1, -1, -1):
         grad_s_ptrs = tl.make_block_ptr(
@@ -396,20 +478,21 @@ def _multistep_lif_backward_kernel_dynamic(
             block_shape=(1, BLOCK_NCL),
             order=(1, 0),
         )
-        grad_s = tl.load(
-            grad_s_ptrs, boundary_check=(1,), padding_option="zero"
-        ).to(compute_dtype)
-        grad_v_ptrs = tl.make_block_ptr(
-            grad_v_seq_ptr,
-            shape=(T, NCL),
-            strides=(NCL, 1),
-            offsets=(t, ncl_offset),
-            block_shape=(1, BLOCK_NCL),
-            order=(1, 0),
+        grad_s = tl.load(grad_s_ptrs, boundary_check=(1,), padding_option="zero").to(
+            compute_dtype
         )
-        grad_v = tl.load(
-            grad_v_ptrs, boundary_check=(1,), padding_option="zero"
-        ).to(compute_dtype)
+        if store_v_seq:
+            grad_v_ptrs = tl.make_block_ptr(
+                grad_v_seq_ptr,
+                shape=(T, NCL),
+                strides=(NCL, 1),
+                offsets=(t, ncl_offset),
+                block_shape=(1, BLOCK_NCL),
+                order=(1, 0),
+            )
+            grad_v = tl.load(
+                grad_v_ptrs, boundary_check=(1,), padding_option="zero"
+            ).to(compute_dtype)
         h_ptrs = tl.make_block_ptr(
             h_seq_ptr,
             shape=(T, NCL),
@@ -423,7 +506,8 @@ def _multistep_lif_backward_kernel_dynamic(
         )
 
         sg = sg_triton(h - v_threshold, sg_alpha, sg_triton_id)
-        grad_v_acc = grad_v + grad_v_acc
+        if store_v_seq:
+            grad_v_acc = grad_v + grad_v_acc
         if soft_reset:
             if detach_reset:
                 grad_h = tl.fma(grad_s, sg, grad_v_acc)
@@ -503,6 +587,7 @@ def _launch_lif_forward_kernel(
     soft_reset: bool,
     compute_dtype,
     save_intermediates: bool,
+    store_v_seq: bool,
     use_torch_wrap: bool,
 ) -> None:
     T = x_seq.shape[0]
@@ -531,6 +616,7 @@ def _launch_lif_forward_kernel(
             decay_input=decay_input,
             soft_reset=soft_reset,
             save_intermediates=save_intermediates,
+            store_v_seq=store_v_seq,
         )
 
 
@@ -550,6 +636,7 @@ def _launch_lif_backward_kernel(
     decay_input: bool,
     soft_reset: bool,
     detach_reset: bool,
+    store_v_seq: bool,
     use_torch_wrap: bool,
 ) -> None:
     T = grad_s_seq.shape[0]
@@ -580,6 +667,7 @@ def _launch_lif_backward_kernel(
             decay_input=decay_input,
             soft_reset=soft_reset,
             detach_reset=detach_reset,
+            store_v_seq=store_v_seq,
         )
 
 
@@ -592,12 +680,13 @@ def multistep_lif_inference(
     v_threshold: float,
     v_reset: float,
     soft_reset: bool,
+    store_v_seq: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     x_seq = x_seq.contiguous()
     v_init = v_init.contiguous()
 
     s_seq = torch.empty_like(x_seq)
-    v_seq = torch.empty_like(x_seq)
+    v_seq = torch.empty_like(x_seq) if store_v_seq else torch.empty_like(v_init)
     dtype = x_seq.dtype
     _launch_lif_forward_kernel(
         x_seq,
@@ -612,6 +701,7 @@ def multistep_lif_inference(
         soft_reset=soft_reset,
         compute_dtype=type_dict[dtype],
         save_intermediates=False,
+        store_v_seq=store_v_seq,
         use_torch_wrap=True,
     )
     return s_seq, v_seq
@@ -626,10 +716,11 @@ def _multistep_lif_inference_fake(
     v_threshold: float,
     v_reset: float,
     soft_reset: bool,
+    store_v_seq: bool,
 ):
     return (
         x_seq.new_empty(x_seq.shape),
-        x_seq.new_empty(x_seq.shape),
+        x_seq.new_empty(x_seq.shape if store_v_seq else v_init.shape),
     )
 
 
@@ -645,12 +736,13 @@ def multistep_lif_forward(
     detach_reset: bool,
     sg_triton_id: int,
     sg_alpha: float,
+    store_v_seq: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     x_seq = x_seq.contiguous()
     v_init = v_init.contiguous()
 
     s_seq = torch.empty_like(x_seq)
-    v_seq = torch.empty_like(x_seq)
+    v_seq = torch.empty_like(x_seq) if store_v_seq else torch.empty_like(v_init)
     h_seq = torch.empty_like(x_seq)
     dtype = x_seq.dtype
     _launch_lif_forward_kernel(
@@ -666,6 +758,7 @@ def multistep_lif_forward(
         soft_reset=soft_reset,
         compute_dtype=type_dict[dtype],
         save_intermediates=True,
+        store_v_seq=store_v_seq,
         use_torch_wrap=True,
     )
     return s_seq, v_seq, h_seq
@@ -683,10 +776,11 @@ def _multistep_lif_forward_fake(
     detach_reset: bool,
     sg_triton_id: int,
     sg_alpha: float,
+    store_v_seq: bool,
 ):
     return (
         x_seq.new_empty(x_seq.shape),
-        x_seq.new_empty(x_seq.shape),
+        x_seq.new_empty(x_seq.shape if store_v_seq else v_init.shape),
         x_seq.new_empty(x_seq.shape),
     )
 
@@ -735,6 +829,7 @@ def multistep_lif_mp_inference(
         soft_reset=soft_reset,
         compute_dtype=compute_tl_dtype,
         save_intermediates=save_intermediates,
+        store_v_seq=True,
         use_torch_wrap=True,
     )
     return s_seq, v_seq, h_seq
@@ -816,6 +911,7 @@ def multistep_lif_mp_forward(
         soft_reset=soft_reset,
         compute_dtype=compute_tl_dtype,
         save_intermediates=True,
+        store_v_seq=True,
         use_torch_wrap=True,
     )
     return s_seq, v_seq, h_seq
@@ -1039,6 +1135,7 @@ def _multistep_lif_mp_backward(ctx, grad_s_seq, grad_v_seq, grad_h_seq):
         decay_input=ctx.decay_input,
         soft_reset=ctx.soft_reset,
         detach_reset=ctx.detach_reset,
+        store_v_seq=True,
         use_torch_wrap=True,
     )
     return (
@@ -1076,6 +1173,7 @@ def _setup_context(ctx, inputs, output):
         detach_reset,
         sg_triton_id,
         sg_alpha,
+        store_v_seq,
     ) = inputs[2:]
     h_seq = output[2]
     ctx.save_for_backward(h_seq)
@@ -1087,12 +1185,13 @@ def _setup_context(ctx, inputs, output):
     ctx.detach_reset = detach_reset
     ctx.sg_triton_id = sg_triton_id
     ctx.sg_alpha = sg_alpha
+    ctx.store_v_seq = store_v_seq
 
 
 def _multistep_lif_backward(ctx, grad_s_seq, grad_v_seq, grad_h_seq):
     (h_seq,) = ctx.saved_tensors
     grad_x_seq = torch.empty_like(grad_s_seq)
-    grad_v_init = torch.empty_like(grad_v_seq[0])
+    grad_v_init = torch.empty_like(h_seq[0])
     dtype = grad_s_seq.dtype
     _launch_lif_backward_kernel(
         grad_s_seq.contiguous(),
@@ -1109,9 +1208,22 @@ def _multistep_lif_backward(ctx, grad_s_seq, grad_v_seq, grad_h_seq):
         decay_input=ctx.decay_input,
         soft_reset=ctx.soft_reset,
         detach_reset=ctx.detach_reset,
+        store_v_seq=ctx.store_v_seq,
         use_torch_wrap=True,
     )
-    return grad_x_seq, grad_v_init, None, None, None, None, None, None, None, None
+    return (
+        grad_x_seq,
+        grad_v_init,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
 
 
 torch.library.register_autograd(
@@ -1130,6 +1242,7 @@ def multistep_lif(
     v_reset: Optional[float],
     detach_reset: bool,
     surrogate_function,
+    store_v_seq: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Multi-step LIF neuron forward pass via Triton kernel.
 
@@ -1159,7 +1272,11 @@ def multistep_lif(
     :type detach_reset: bool
     :param surrogate_function: Surrogate gradient function
     :type surrogate_function: ``surrogate.SurrogateFunctionBase``
-    :return: Tuple of (spike_seq, v_seq)
+    :param store_v_seq: Whether to return the full membrane-potential sequence. If
+        ``False``, the second output contains only the final membrane potential.
+    :type store_v_seq: bool
+    :return: Tuple of ``(spike_seq, v_seq)`` when ``store_v_seq=True`` or
+        ``(spike_seq, v_last)`` otherwise
     :rtype: tuple[torch.Tensor, torch.Tensor]
 
     ----
@@ -1186,7 +1303,11 @@ def multistep_lif(
     :type v_reset: Optional[float]
     :type detach_reset: bool
     :type surrogate_function: ``surrogate.SurrogateFunctionBase``
-    :return: Tuple of (spike_seq, v_seq)
+    :param store_v_seq: Whether to return the full membrane-potential sequence. If
+        ``False``, the second output contains only the final membrane potential.
+    :type store_v_seq: bool
+    :return: Tuple of ``(spike_seq, v_seq)`` when ``store_v_seq=True`` or
+        ``(spike_seq, v_last)`` otherwise
     :rtype: tuple[torch.Tensor, torch.Tensor]
     """
     soft_reset = v_reset is None
@@ -1207,6 +1328,7 @@ def multistep_lif(
             detach_reset,
             sg_triton_id,
             sg_alpha,
+            store_v_seq,
         )
     else:
         s_seq, v_seq = multistep_lif_inference(
@@ -1217,5 +1339,6 @@ def multistep_lif(
             v_threshold,
             v_reset,
             soft_reset,
+            store_v_seq,
         )
     return s_seq, v_seq

--- a/spikingjelly/activation_based/triton_kernel/neuron_kernel/lif.py
+++ b/spikingjelly/activation_based/triton_kernel/neuron_kernel/lif.py
@@ -1272,11 +1272,11 @@ def multistep_lif(
     :type detach_reset: bool
     :param surrogate_function: Surrogate gradient function
     :type surrogate_function: ``surrogate.SurrogateFunctionBase``
-    :param store_v_seq: Whether to return the full membrane-potential sequence. If
-        ``False``, the second output contains only the final membrane potential.
+    :param store_v_seq: 是否返回完整的膜电位序列，默认为 ``True``。设置为 ``False`` 时，
+        第二个输出仅包含最终膜电位，其形状与 ``v_init`` 相同。
     :type store_v_seq: bool
-    :return: Tuple of ``(spike_seq, v_seq)`` when ``store_v_seq=True`` or
-        ``(spike_seq, v_last)`` otherwise
+    :return: 当 ``store_v_seq=True`` 时返回 ``(spike_seq, v_seq)``，否则返回
+        ``(spike_seq, v_last)``，其中 ``v_last`` 的形状与 ``v_init`` 相同。
     :rtype: tuple[torch.Tensor, torch.Tensor]
 
     ----
@@ -1303,11 +1303,13 @@ def multistep_lif(
     :type v_reset: Optional[float]
     :type detach_reset: bool
     :type surrogate_function: ``surrogate.SurrogateFunctionBase``
-    :param store_v_seq: Whether to return the full membrane-potential sequence. If
-        ``False``, the second output contains only the final membrane potential.
+    :param store_v_seq: Whether to return the full membrane-potential sequence.
+        Defaults to ``True``. If ``False``, the second output contains only the
+        final membrane potential and has the same shape as ``v_init``.
     :type store_v_seq: bool
     :return: Tuple of ``(spike_seq, v_seq)`` when ``store_v_seq=True`` or
-        ``(spike_seq, v_last)`` otherwise
+        ``(spike_seq, v_last)`` otherwise, where ``v_last`` has the same shape as
+        ``v_init``
     :rtype: tuple[torch.Tensor, torch.Tensor]
     """
     soft_reset = v_reset is None

--- a/test/activation_based/test_compile_compat.py
+++ b/test/activation_based/test_compile_compat.py
@@ -387,6 +387,8 @@ def test_triton_last_state_matches_full_voltage_sequence(
     assert torch.allclose(spike_full, spike_last, atol=atol, rtol=rtol)
     assert torch.allclose(full_node.v, last_node.v, atol=atol, rtol=rtol)
     assert torch.allclose(x_full.grad, x_last.grad, atol=atol, rtol=rtol)
+    full_node.detach()
+    last_node.detach()
 
 
 @pytest.mark.parametrize("kind", ["lif", "if"])

--- a/test/activation_based/test_compile_compat.py
+++ b/test/activation_based/test_compile_compat.py
@@ -9,6 +9,12 @@ import pytest
 import torch
 
 from spikingjelly.activation_based import functional, neuron, surrogate
+from spikingjelly.activation_based.triton_kernel.neuron_kernel import (
+    integrate_and_fire as triton_if_kernel,
+)
+from spikingjelly.activation_based.triton_kernel.neuron_kernel import (
+    lif as triton_lif_kernel,
+)
 
 
 def _triton_available() -> bool:
@@ -326,6 +332,132 @@ def test_triton_vs_torch_forward_backward_consistency(kind, sg_name):
         assert torch.allclose(
             torch_node.w.grad, triton_node.w.grad, atol=1e-5, rtol=1e-4
         )
+
+
+@pytest.mark.parametrize("kind", ["lif", "if"])
+@pytest.mark.parametrize("T", [7, 65])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("v_reset,detach_reset", [(0.0, False), (None, True)])
+def test_triton_last_state_matches_full_voltage_sequence(
+    kind, T, dtype, v_reset, detach_reset
+):
+    _require_cuda_triton_compile()
+    if dtype == torch.bfloat16 and not torch.cuda.is_bf16_supported():
+        pytest.skip("CUDA device does not support bfloat16")
+
+    def make_node(store_v_seq):
+        common = {
+            "v_threshold": 1.0,
+            "v_reset": v_reset,
+            "surrogate_function": surrogate.ATan(alpha=2.0),
+            "detach_reset": detach_reset,
+            "step_mode": "m",
+            "backend": "triton",
+            "store_v_seq": store_v_seq,
+        }
+        if kind == "lif":
+            return neuron.LIFNode(tau=2.0, decay_input=True, **common)
+        return neuron.IFNode(**common)
+
+    torch.manual_seed(20260718)
+    torch.cuda.manual_seed_all(20260718)
+    full_node = make_node(True).cuda().train()
+    last_node = make_node(False).cuda().train()
+    x = torch.randn(T, 3, 37, device="cuda", dtype=dtype)
+    grad_spike = torch.randn_like(x)
+    grad_v = torch.randn_like(x[0])
+    x_full = x.detach().clone().requires_grad_(True)
+    x_last = x.detach().clone().requires_grad_(True)
+
+    spike_full = full_node(x_full)
+    spike_last = last_node(x_last)
+    loss_full = (spike_full * grad_spike).sum() + (full_node.v * grad_v).sum()
+    loss_last = (spike_last * grad_spike).sum() + (last_node.v * grad_v).sum()
+    loss_full.backward()
+    loss_last.backward()
+
+    assert full_node.v_seq.shape == x.shape
+    assert last_node.v.shape == x.shape[1:]
+    if dtype == torch.float32:
+        atol, rtol = 1e-5, 1e-4
+    elif dtype == torch.float16:
+        atol, rtol = 1e-3, 1e-3
+    else:
+        atol, rtol = 1e-2, 1e-2
+    assert torch.allclose(spike_full, spike_last, atol=atol, rtol=rtol)
+    assert torch.allclose(full_node.v, last_node.v, atol=atol, rtol=rtol)
+    assert torch.allclose(x_full.grad, x_last.grad, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("kind", ["lif", "if"])
+@pytest.mark.parametrize("T", [1, 65])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("v_reset", [0.0, None])
+def test_triton_last_state_inference_matches_full_voltage_sequence(
+    kind, T, dtype, v_reset
+):
+    _require_cuda_triton_compile()
+    if dtype == torch.bfloat16 and not torch.cuda.is_bf16_supported():
+        pytest.skip("CUDA device does not support bfloat16")
+
+    common = {
+        "v_threshold": 1.0,
+        "v_reset": v_reset,
+        "step_mode": "m",
+        "backend": "triton",
+    }
+    cls = neuron.LIFNode if kind == "lif" else neuron.IFNode
+    full_node = cls(store_v_seq=True, **common).cuda().eval()
+    last_node = cls(store_v_seq=False, **common).cuda().eval()
+    torch.manual_seed(20260718)
+    torch.cuda.manual_seed_all(20260718)
+    x = torch.randn(T, 3, 37, device="cuda", dtype=dtype)
+
+    with torch.inference_mode():
+        spike_full = full_node(x)
+        spike_last = last_node(x)
+
+    if dtype == torch.float32:
+        atol, rtol = 1e-5, 1e-4
+    elif dtype == torch.float16:
+        atol, rtol = 1e-3, 1e-3
+    else:
+        atol, rtol = 1e-2, 1e-2
+    assert full_node.v_seq.shape == x.shape
+    assert last_node.v.shape == x.shape[1:]
+    assert torch.allclose(spike_full, spike_last, atol=atol, rtol=rtol)
+    assert torch.allclose(full_node.v, last_node.v, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("kind", ["lif", "if"])
+def test_triton_last_state_fake_output_shapes(kind):
+    x_seq = torch.empty(7, 3, 37)
+    v_init = torch.empty(3, 37)
+
+    if kind == "lif":
+        inference_outputs = triton_lif_kernel._multistep_lif_inference_fake(
+            x_seq, v_init, True, 2.0, 1.0, 0.0, False, False
+        )
+        forward_outputs = triton_lif_kernel._multistep_lif_forward_fake(
+            x_seq, v_init, True, 2.0, 1.0, 0.0, False, False, 0, 2.0, False
+        )
+    else:
+        inference_outputs = triton_if_kernel._multistep_if_inference_fake(
+            x_seq, v_init, 1.0, 0.0, False, False
+        )
+        forward_outputs = triton_if_kernel._multistep_if_forward_fake(
+            x_seq, v_init, 1.0, 0.0, False, False, 0, 2.0, False
+        )
+
+    assert tuple(output.shape for output in inference_outputs) == (
+        x_seq.shape,
+        v_init.shape,
+    )
+    assert tuple(output.shape for output in forward_outputs) == (
+        x_seq.shape,
+        v_init.shape,
+        x_seq.shape,
+    )
 
 
 _SUBPROCESS_SCRIPT = textwrap.dedent(

--- a/test/activation_based/test_compile_compat.py
+++ b/test/activation_based/test_compile_compat.py
@@ -341,11 +341,13 @@ def test_triton_vs_torch_forward_backward_consistency(kind, sg_name):
 def test_triton_last_state_matches_full_voltage_sequence(
     kind, T, dtype, v_reset, detach_reset
 ):
+    """Match training results and gradients against full voltage storage."""
     _require_cuda_triton_compile()
     if dtype == torch.bfloat16 and not torch.cuda.is_bf16_supported():
         pytest.skip("CUDA device does not support bfloat16")
 
     def make_node(store_v_seq):
+        """Create a Triton node with the requested voltage storage mode."""
         common = {
             "v_threshold": 1.0,
             "v_reset": v_reset,
@@ -398,6 +400,7 @@ def test_triton_last_state_matches_full_voltage_sequence(
 def test_triton_last_state_inference_matches_full_voltage_sequence(
     kind, T, dtype, v_reset
 ):
+    """Match inference results against full voltage storage."""
     _require_cuda_triton_compile()
     if dtype == torch.bfloat16 and not torch.cuda.is_bf16_supported():
         pytest.skip("CUDA device does not support bfloat16")
@@ -433,6 +436,7 @@ def test_triton_last_state_inference_matches_full_voltage_sequence(
 
 @pytest.mark.parametrize("kind", ["lif", "if"])
 def test_triton_last_state_fake_output_shapes(kind):
+    """Check fake operators return final-state voltage shapes."""
     x_seq = torch.empty(7, 3, 37)
     v_init = torch.empty(3, 37)
 


### PR DESCRIPTION
## Summary

This change makes the standard Triton IF/LIF multi-step path honour `store_v_seq=False` at allocation and kernel level. Instead of materialising a `[T, N, ...]` membrane-potential sequence and discarding all but its last row, the kernels write a final-state-sized output and the backward recurrence consumes only its final-state gradient.

## Motivation

`store_v_seq=False` is the node default and communicates that only the last membrane potential is retained. The previous Triton implementation still allocated and wrote the full voltage sequence. The redundant sequence accounted for almost half of measured inference peak allocation and roughly one sixth of training peak allocation in the tested cases.

## Root cause

The standard `multistep_if` and `multistep_lif` custom operators always allocated `v_seq` with `torch.empty_like(x_seq)`. Their Triton forward kernels stored `v` at every timestep, and the node selected/cloned `v_seq[-1]`. Autograd consequently exposed a full voltage-gradient output to backward even when the node only retained the last state.

## Changes

- Add `store_v_seq` as a compile-time flag and autotune key for standard IF/LIF forward and backward kernels.
- Allocate `v_init`-shaped output storage when only the final state is required.
- Skip per-timestep voltage stores and write the final state once.
- Initialise backward's voltage-gradient accumulator from the final-state gradient and skip sequence gradient loads in last-state mode.
- Update fake/meta registrations so spike, voltage, and intermediate shapes match eager execution.
- Thread the existing node flag through IF/LIF Triton dispatch.
- Preserve full-sequence behaviour by default in the low-level helpers and preserve mixed-precision/PLIF paths.
- Add a fixed-seed CUDA-event and peak-allocation benchmark.

## Correctness

The regression matrix compares `store_v_seq=True` with `False` for:

- IF and LIF;
- inference and training;
- static Triton loops (`T=1` or `T=7`) and the dynamic loop (`T=65`);
- FP32, FP16, and BF16;
- hard and soft reset;
- detach-reset in training;
- spike output, final membrane state, and input gradients;
- fake/meta output shapes and real Inductor forward/backward execution.

Tolerances are `atol=1e-5, rtol=1e-4` for FP32, `1e-3/1e-3` for FP16, and `1e-2/1e-2` for BF16. The two paths retain the same arithmetic recurrence; the wider low-precision tolerances match their storage precision.

Final compile-compat result: **78 passed, 3 skipped**. The skips require a second CUDA device.

## Performance

End-to-end latency was mixed and order-sensitive across four paired runs on the laptop GPU, so this PR does not claim a universal latency speedup. Median paired changes across the four trials ranged from a 28.5% slowdown to a 27.7% speedup depending on case. Raw samples, P25/P75 values, and negative results were retained and are available on request.

Kernel-level profiler evidence for IF training at `T=65, N=16381`, FP32 (10 iterations):

| Event | Baseline | Proposed | Change |
|---|---:|---:|---:|
| Forward Triton kernel device time | 219.452 us | 199.262 us | -9.2% |
| Backward Triton kernel device time | 219.868 us | 132.890 us | -39.6% |
| `aten::copy_` count | 20 | 10 | -10 calls |
| DtoD-copy count | 10 | 0 | -10 calls |

These profiler timings are one capture and are supporting evidence, not a cross-hardware speed claim.

## Memory

The memory result was identical across all four counter-ordered benchmark pairs and for IF/LIF:

| Mode | Shape / dtype | Baseline peak | Proposed peak | Reduction |
|---|---:|---:|---:|---:|
| Inference | `T=16, N=4096`, FP32 | 0.531 MiB | 0.281 MiB | 47.1% |
| Inference | `T=32, N=16381`, FP16 | 2.062 MiB | 1.062 MiB | 48.5% |
| Inference | `T=65, N=16381`, FP32 | 8.249 MiB | 4.187 MiB | 49.2% |
| Training | `T=16, N=4096`, FP32 | 1.532 MiB | 1.298 MiB | 15.3% |
| Training | `T=32, N=16381`, FP16 | 6.063 MiB | 5.095 MiB | 16.0% |
| Training | `T=65, N=16381`, FP32 | 24.498 MiB | 20.499 MiB | 16.3% |

## Benchmark methodology

- Baseline commit: `2797c5575515b59d7f09a3d5b732d6d25e148d13`
- GPU: NVIDIA GeForce RTX 4070 Laptop GPU, 8 GiB, driver 596.36
- Python 3.11.15; PyTorch 2.7.1+cu128; Triton 3.3.1
- Fixed seed `20260717`
- 5 warm-ups, 25 repetitions, 10 iterations per repetition
- CUDA events with synchronisation; compilation excluded after warm-up
- Median plus P25/P75 and all raw samples retained
- Four baseline/working-tree pairs in alternating order
- Peak delta from `torch.cuda.max_memory_allocated()` after allocator reset

Reproduce:

```bash
python benchmark/benchmark_triton_last_state.py --output optimised.json
```

Set `SJ_BENCH_SOURCE_ROOT` to a clean baseline worktree for the baseline run.

## Compatibility

- Node-level public API and default behaviour are unchanged.
- Low-level helpers keep full-sequence output by default through the optional `store_v_seq=True` parameter.
- Torch, CuPy, PLIF, CPU, and mixed-precision paths are unchanged.
- FP32, FP16, and BF16 were tested on CUDA compute capability 8.9.
- No dependency or minimum-version change.
- `store_v_seq` adds a compile-time/autotune specialisation dimension to the standard IF/LIF kernels.

## Testing

```text
uv format
ruff 0.15.22 format <six touched files>
ruff 0.15.22 check <six touched files>
PYTHONUTF8=1 python -m pytest test/activation_based/test_compile_compat.py -v
PYTHONUTF8=1 python -m pytest test/activation_based/test_triton_neuron.py -v
python benchmark/benchmark_triton_last_state.py --output <result.json>
sphinx-build -b html --keep-going docs/source <output-dir>
```

Results:

- Ruff: all checks passed; six task files formatted.
- Compile compatibility: 78 passed, 3 skipped. The skips require a second CUDA device.
- Shared Triton-neuron tests: 179 passed, 11 skipped in 452.70 seconds. Five skips require CuPy, and six pure-FP8-compute cases were rejected by the existing Triton capability probes on the test GPU.
- Normal Sphinx HTML build: succeeded.
- Strict `-W` Sphinx build generated the HTML but exited nonzero on two existing warnings in untouched `triton_kernel/torch2triton/torch2graph.py` docstrings.
- The Windows non-UTF-8 Inductor run initially failed with `UnicodeEncodeError`; the clean baseline reproduced the same failure. `PYTHONUTF8=1` made all three actual Inductor cases pass.

## Limitations

- Tested on one NVIDIA Ada GPU and Windows only.
- BF16 was tested; FP8/mixed-precision neuron operators were intentionally not changed.
- No Nsight Systems/Compute results were collected.
- End-to-end latency is noisy and not claimed as a guaranteed improvement.
- The complete repository-wide test suite was not run; the complete relevant compile-compatibility and shared Triton-neuron modules were run.

## Related issue

Closes #706.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `store_v_seq` option for Triton-based multi-step IF/LIF to store only the final membrane potential (lower memory usage when disabled).
  * Introduced a Triton benchmark script to report latency and peak GPU memory across configurations.
* **Bug Fixes**
  * Improved consistency of spikes, gradients, and final neuron voltage across training and inference when toggling `store_v_seq`.
* **Tests**
  * Added Triton “last state” validation for training, inference, gradient equivalence, and fake-op output shapes.
* **Documentation**
  * Updated the changelog with the Triton IF/LIF memory optimization note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->