### PR TITLE
Add ILIF neuron and spike-count surrogate

### DIFF
--- a/benchmark/snn_llm/qwen_conversion/README.md
+++ b/benchmark/snn_llm/qwen_conversion/README.md
@@ -87,8 +87,8 @@ are private benchmark contracts rather than public SpikingJelly APIs.
 
 - The converted model is an offline multistep SNN with explicit time; it is not
   online whole-model T-step inference.
-- The conversion model is frozen and inference-only. Direct SNN training is a
-  separate model and recipe.
+- These benchmark runners execute the converted model in inference mode. Direct
+  SNN training is outside this benchmark contract.
 - No runner downloads data or checkpoints, silently changes precision/backend,
   or falls back to CPU or one GPU.
 - The final supported conversion evidence covers Qwen2.5 Base 0.5B, 1.5B, and

--- a/docs/source/APIs/spikingjelly.activation_based.neuron.research.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.neuron.research.rst
@@ -97,6 +97,15 @@ SpikeZIP Neuron Primitives
    :show-inheritance:
    :exclude-members: supported_backends, extra_repr
 
+Integer-Valued Training Neurons
+--------------------------------------------------
+
+.. automodule:: spikingjelly.activation_based.neuron.ilif
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: supported_backends, extra_repr
+
 Neurons with Inter-layer Connection
 --------------------------------------------------
 

--- a/docs/source/APIs/spikingjelly.activation_based.neuron.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.neuron.rst
@@ -212,6 +212,14 @@ SpikeZIP Neuron Primitives
    * - :class:`STBIFNeuron <spikingjelly.activation_based.neuron.spikezip.STBIFNeuron>`
      - Signed ternary BIF neuron for SpikeZIP QANN-to-SNN conversion.
 
+Integer-Valued Training Neurons
+--------------------------------------------------
+
+.. list-table::
+
+   * - :class:`ILIFNode <spikingjelly.activation_based.neuron.ilif.ILIFNode>`
+     - I-LIF neuron with integer-valued training and strictly binary spike inference.
+
 Neurons with Inter-layer Connection
 --------------------------------------------------
 

--- a/docs/source/APIs/spikingjelly.activation_based.surrogate.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.surrogate.rst
@@ -2,7 +2,7 @@ spikingjelly.activation_based.surrogate module
 =================================================
 
 .. automodule:: spikingjelly.activation_based.surrogate
-   :members: heaviside, check_manual_grad, check_cuda_grad, plot_surrogate_function, SurrogateFunctionBase, PiecewiseQuadratic, PiecewiseExp, Sigmoid, SoftSign, SuperSpike, ATan, NonzeroSignLogAbs, Erf, PiecewiseLeakyReLU, SquarewaveFourierSeries, S2NN, QPseudoSpike, LeakyKReLU, FakeNumericalGradient, LogTailedReLU, DeterministicPass, PoissonPass, Rect
+   :members: heaviside, check_manual_grad, check_cuda_grad, plot_surrogate_function, SurrogateFunctionBase, PiecewiseQuadratic, PiecewiseExp, Sigmoid, SoftSign, SuperSpike, ATan, NonzeroSignLogAbs, Erf, PiecewiseLeakyReLU, SquarewaveFourierSeries, S2NN, QPseudoSpike, LeakyKReLU, FakeNumericalGradient, LogTailedReLU, DeterministicPass, MultiLevelSpikeCount, PoissonPass, Rect
    :undoc-members:
    :show-inheritance:
 

--- a/spikingjelly/activation_based/ann2snn/qcfs.py
+++ b/spikingjelly/activation_based/ann2snn/qcfs.py
@@ -7,7 +7,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from spikingjelly.activation_based import neuron, surrogate
+from spikingjelly.activation_based import neuron, quantize, surrogate
 
 __all__ = ["SignedQCFSSequenceEncoder"]
 
@@ -305,6 +305,7 @@ class SignedQCFSSequenceEncoder(nn.Module):
 
         直接计算 :meth:`encode` 所生成多步脉冲序列的时间和，不执行神经元时间
         循环。该方法使用完全相同的逐通道 scale、round-to-even 和计数裁剪规则，
+        并通过多级脉冲计数替代函数为后训练保留直通梯度。
         用于验证或加速只依赖时间聚合值的离线逐层推理；返回值本身不是脉冲序列。
 
         :param value: 浮点激活张量，通道维必须与 scale 对齐。
@@ -321,7 +322,8 @@ class SignedQCFSSequenceEncoder(nn.Module):
 
         Compute the temporal sum of the multi-step spike sequence produced by
         :meth:`encode` without running the neuron time loop. This method uses the
-        same per-channel scale, round-to-even operation, and count clipping. It
+        same per-channel scale, round-to-even operation, and count clipping, with
+        a multi-level spike-count surrogate gradient for post-training. It
         supports validation or acceleration of offline layerwise inference that
         depends only on temporal aggregates; the returned value is not itself a
         spike sequence.
@@ -347,8 +349,14 @@ class SignedQCFSSequenceEncoder(nn.Module):
         shape = [1] * value.dim()
         shape[channel_dim] = scale.numel()
         scale = scale.reshape(shape)
-        positive = torch.round(F.relu(value) / scale).clamp(0, self.time_steps)
-        negative = torch.round(F.relu(-value) / scale).clamp(0, self.time_steps)
+        positive = quantize.multi_level_spike_count(
+            F.relu(value) / scale,
+            self.time_steps,
+        )
+        negative = quantize.multi_level_spike_count(
+            F.relu(-value) / scale,
+            self.time_steps,
+        )
         return (positive - negative) * scale
 
     def forward(

--- a/spikingjelly/activation_based/ann2snn/recipes/qwen2.py
+++ b/spikingjelly/activation_based/ann2snn/recipes/qwen2.py
@@ -387,7 +387,7 @@ def _validate_qwen2(model: nn.Module) -> Sequence[nn.Module]:
     if getattr(config, "hidden_act", "silu") != "silu":
         raise ValueError("Qwen2SNNRecipe requires hidden_act='silu'.")
     if model.training:
-        raise ValueError("Qwen2SNNRecipe is inference-only; call model.eval().")
+        raise ValueError("Qwen2SNNRecipe requires evaluation-mode source; call eval().")
     layers = _qwen_layers(model)
     if len(layers) != int(config.num_hidden_layers):
         raise ValueError("Qwen2 config and concrete decoder layer count disagree.")
@@ -558,6 +558,11 @@ class _Qwen2Decoder(nn.Module):
         dense = sequence.sum(0)
         if mode == "exact_td":
             return _exact_sequence(dense, self.time_steps)
+        if mode == "qcfs_sg":
+            return _exact_sequence(
+                self.encoders[name].reconstruct(dense),
+                self.time_steps,
+            )
         return self.encoders[name].encode(dense, mask)
 
     def _attend(
@@ -667,11 +672,10 @@ class Qwen2SNNModel(nn.Module):
 
         * **中文**
 
-        Qwen2 的只读离线多步 SNN 推理模型。通常应通过
-        :class:`Qwen2SNNRecipe` 和 :class:`ModuleConverter` 创建。模型冻结全部
-        参数；``signed_if`` 路径在每个转换阶段显式构造 ``[T,B,S,H]`` 时间序列，
-        ``exact_td`` 仅供 TD 等价性验证。调用 :meth:`forward` 时必须处于
-        :func:`torch.inference_mode` 或 no-grad 上下文。
+        Qwen2 的离线多步 SNN 转换模型。通常应通过
+        :class:`Qwen2SNNRecipe` 和 :class:`ModuleConverter` 创建。``signed_if``
+        路径在每个转换阶段显式构造 ``[T,B,S,H]`` 时间序列，``qcfs_sg`` 使用
+        可微分的 QCFS 计数重建用于后训练，``exact_td`` 仅供 TD 等价性验证。
 
         :param source: 已进入 evaluation mode 的 Hugging Face Qwen2 causal LM。
         :type source: torch.nn.Module
@@ -686,12 +690,11 @@ class Qwen2SNNModel(nn.Module):
 
         * **English**
 
-        Read-only, offline multi-step SNN inference model for Qwen2. Normally create
-        it through :class:`Qwen2SNNRecipe` and :class:`ModuleConverter`. All
-        parameters are frozen. The ``signed_if`` path constructs an explicit
-        ``[T,B,S,H]`` sequence at every converted stage; ``exact_td`` is only for TD
-        equivalence checks. Call :meth:`forward` under :func:`torch.inference_mode`
-        or another no-grad context.
+        Offline multi-step SNN conversion model for Qwen2. Normally create it
+        through :class:`Qwen2SNNRecipe` and :class:`ModuleConverter`. The
+        ``signed_if`` path constructs an explicit ``[T,B,S,H]`` sequence at every
+        converted stage; ``qcfs_sg`` uses differentiable QCFS count reconstruction
+        for post-training; ``exact_td`` is only for TD equivalence checks.
 
         :param source: Evaluation-mode Hugging Face Qwen2 causal LM.
         :type source: torch.nn.Module
@@ -720,8 +723,6 @@ class Qwen2SNNModel(nn.Module):
         )
         self.norm = _copy_norm(inner.norm)
         self.lm_head = _td_module_from_ann(source.lm_head)
-        for parameter in self.parameters():
-            parameter.requires_grad_(False)
         if bool(getattr(self.config, "tie_word_embeddings", False)):
             self.lm_head.weight = self.embed_tokens.weight
         self.input_encoder = SignedQCFSSequenceEncoder(
@@ -991,7 +992,8 @@ class Qwen2SNNModel(nn.Module):
 
         执行 Qwen2 离线多步推理。``signed_if`` 使用真实 activation-aware IF
         时间序列；``exact_td`` 仅用于数值 reference。返回对象包含 ``logits`` 和
-        ``past_key_values``。
+        ``past_key_values``。``qcfs_sg`` 使用 QCFS 计数重建和多级脉冲计数
+        surrogate gradient，适合后训练；它不是严格二值多步脉冲 replay。
 
         :param input_ids: 输入 token，形状 ``[B,S]``。
         :type input_ids: torch.Tensor
@@ -1000,7 +1002,8 @@ class Qwen2SNNModel(nn.Module):
         :param position_ids: 可选 ``[B,S]`` RoPE 位置；省略时从 attention mask
             计算，以正确处理左 padding 和 cache continuation。
         :type position_ids: Optional[torch.Tensor]
-        :param encoding_mode: ``"signed_if"``（默认）或 ``"exact_td"``。
+        :param encoding_mode: ``"signed_if"``（默认）、``"qcfs_sg"`` 或
+            ``"exact_td"``。
         :type encoding_mode: Optional[str]
         :param past_key_values: 此模型上次返回的私有 cache 对象。
         :type past_key_values: Optional[_Qwen2Cache]
@@ -1008,7 +1011,7 @@ class Qwen2SNNModel(nn.Module):
         :type use_cache: bool
         :return: 含 ``logits`` 与 ``past_key_values`` 的 namespace。
         :rtype: types.SimpleNamespace
-        :raises RuntimeError: 模型处于 training mode 或启用了 autograd。
+        :raises RuntimeError: 保留给运行时错误。
         :raises ValueError: ``encoding_mode``、position shape 或 cache 参数组合无效。
 
         ----
@@ -1019,7 +1022,10 @@ class Qwen2SNNModel(nn.Module):
 
         Run offline multi-step Qwen2 inference. ``signed_if`` uses actual
         activation-aware IF temporal sequences; ``exact_td`` is only a numerical
-        reference. The result contains ``logits`` and ``past_key_values``.
+        reference. ``qcfs_sg`` uses QCFS count reconstruction with a multi-level
+        spike-count surrogate gradient for post-training; it is not strict binary
+        multi-step spike replay. The result contains ``logits`` and
+        ``past_key_values``.
 
         :param input_ids: Input tokens with shape ``[B,S]``.
         :type input_ids: torch.Tensor
@@ -1029,7 +1035,8 @@ class Qwen2SNNModel(nn.Module):
             are derived from the attention mask for left padding and cache
             continuation.
         :type position_ids: Optional[torch.Tensor]
-        :param encoding_mode: ``"signed_if"`` (default) or ``"exact_td"``.
+        :param encoding_mode: ``"signed_if"`` (default), ``"qcfs_sg"``, or
+            ``"exact_td"``.
         :type encoding_mode: Optional[str]
         :param past_key_values: Private cache object returned by a previous call.
         :type past_key_values: Optional[_Qwen2Cache]
@@ -1037,18 +1044,12 @@ class Qwen2SNNModel(nn.Module):
         :type use_cache: bool
         :return: Namespace containing ``logits`` and ``past_key_values``.
         :rtype: types.SimpleNamespace
-        :raises RuntimeError: If the model is training or autograd is enabled.
+        :raises RuntimeError: Reserved for runtime failures.
         :raises ValueError: If ``encoding_mode``, the position shape, or the cache
             argument combination is invalid.
         """
-        if self.training:
-            raise RuntimeError("Converted Qwen2 SNN is inference-only; call eval().")
-        if torch.is_grad_enabled():
-            raise RuntimeError(
-                "Converted Qwen2 SNN does not support autograd; use inference_mode()."
-            )
         encoding_mode = encoding_mode or "signed_if"
-        if encoding_mode not in ("signed_if", "exact_td"):
+        if encoding_mode not in ("signed_if", "qcfs_sg", "exact_td"):
             raise ValueError(f"Unsupported encoding_mode={encoding_mode!r}.")
         if attention_mask is None:
             attention_mask = torch.ones_like(input_ids)
@@ -1070,6 +1071,10 @@ class Qwen2SNNModel(nn.Module):
         value_mask = attention_mask[:, -input_ids.shape[1] :]
         if encoding_mode == "exact_td":
             hidden = _exact_sequence(embeddings, self.time_steps)
+        elif encoding_mode == "qcfs_sg":
+            hidden = _exact_sequence(
+                self.input_encoder.reconstruct(embeddings), self.time_steps
+            )
         else:
             hidden = self.input_encoder.encode(embeddings, value_mask)
         for layer in self.layers:
@@ -1321,7 +1326,7 @@ class Qwen2SNNRecipe(ModuleConversionRecipe):
 
         * **中文**
 
-        将受支持的 evaluation-mode Qwen2 causal LM 转换为只读离线多步 SNN。
+        将受支持的 evaluation-mode Qwen2 causal LM 转换为离线多步 SNN。
 
         :param converter: 执行此 recipe 的 module converter。
         :type converter: ModuleConverter
@@ -1338,8 +1343,8 @@ class Qwen2SNNRecipe(ModuleConversionRecipe):
 
         * **English**
 
-        Convert a supported evaluation-mode Qwen2 causal LM into a read-only,
-        offline multi-step SNN.
+        Convert a supported evaluation-mode Qwen2 causal LM into an offline
+        multi-step SNN.
 
         :param converter: Module converter executing this recipe.
         :type converter: ModuleConverter

--- a/spikingjelly/activation_based/neuron/__init__.py
+++ b/spikingjelly/activation_based/neuron/__init__.py
@@ -1,6 +1,7 @@
 # core neurons
 from .base_node import *
 from .integrate_and_fire import *
+from .ilif import *
 from .lif import *
 from .plif import *
 from .psn import *

--- a/spikingjelly/activation_based/neuron/ilif.py
+++ b/spikingjelly/activation_based/neuron/ilif.py
@@ -1,0 +1,230 @@
+import numbers
+
+import torch
+
+from .. import surrogate
+from .base_node import BaseNode
+
+__all__ = ["ILIFNode"]
+
+
+class ILIFNode(BaseNode):
+    def __init__(
+        self,
+        v_threshold: float = 1.0,
+        max_spike_count: int = 4,
+        decay: float = 0.25,
+        detach_reset: bool = False,
+        step_mode: str = "s",
+        backend: str = "torch",
+        store_v_seq: bool = False,
+    ):
+        r"""
+        **API Language** - :ref:`中文 <ILIFNode.__init__-cn>` | :ref:`English <ILIFNode.__init__-en>`
+
+        ----
+
+        .. _ILIFNode.__init__-cn:
+
+        * **中文**
+
+        Integer-valued training and strictly binary spike inference I-LIF 神经元。
+        训练时单步动力学为：
+
+        .. math::
+
+            U[t] = \beta V[t - 1] + X[t]
+
+        .. math::
+
+            C[t] = \operatorname{round}(\operatorname{clip}(U[t] / V_{th}, 0, D))
+
+        .. math::
+
+            V[t] = U[t] - C[t] V_{th}
+
+        其中 ``D`` 为 ``max_spike_count``，``beta`` 为 ``decay``。``decay`` 位于
+        充电过程，形式与 :class:`LIFNode` 在 ``decay_input=False`` 且
+        ``v_reset=0`` 时的 charge 方程一致。训练模式 ``self.training == True``
+        返回整数发放计数 ``C[t]``，并使用论文中的矩形窗口直通梯度：仅当
+        ``U[t] / V_th`` 位于 ``[0, D]`` 内时传递梯度。
+
+        推理模式 ``self.training == False`` 返回严格二值 ``0/1`` 脉冲：
+
+        .. math::
+
+            S[t] = \Theta(U[t] - V_{th})
+
+        .. math::
+
+            V[t] = U[t] - S[t] V_{th}
+
+        因此推理前向不会返回 ``C[t]`` 这样的整数计数。若需要和整数训练公平
+        对齐，用户必须在训练/评测 loop 层级组织时间步。
+
+        .. warning::
+
+            严格二值脉冲推理契约：本神经元没有 ``T`` 参数，也不会自动把
+            ``[T, ...]`` 输入展开为 ``[T * D, ...]``。训练时由用户运行 ``T`` 个
+            逻辑步；公平推理时由用户运行 ``T * D`` 个虚拟步，并向本神经元传入
+            已经按虚拟步构造好的电流/脉冲输入。本神经元在每个推理步只输出
+            ``0/1``。下游线性层也必须消费这些 ``0/1`` 脉冲或等价的
+            spike-aware AC 数据流；如果将训练输出的整数 ``C[t]`` 直接送入普通
+            卷积/线性层，就是整数推理，不是 spike-driven inference。
+
+        :param v_threshold: 神经元阈值电压，必须为有限正数
+        :type v_threshold: float
+        :param max_spike_count: 训练时单个逻辑步最多释放的整数计数 ``D``
+        :type max_spike_count: int
+        :param decay: 充电过程中历史膜电位的衰减 ``beta``，必须位于 ``[0, 1]``。
+            当 ``decay=1`` 时退化为无泄漏的整数 IF 形式
+        :type decay: float
+        :param detach_reset: 是否在反向传播时分离 reset 中的发放值
+        :type detach_reset: bool
+        :param step_mode: 步进模式，``"s"`` 为单步，``"m"`` 为多步
+        :type step_mode: str
+        :param backend: 后端名称。当前仅支持 ``"torch"``
+        :type backend: str
+        :param store_v_seq: 多步模式下是否保存每个输入步后的膜电位
+        :type store_v_seq: bool
+
+        ----
+
+        .. _ILIFNode.__init__-en:
+
+        * **English**
+
+        I-LIF neuron for integer-valued training and strictly binary spike
+        inference. The training dynamics are:
+
+        .. math::
+
+            U[t] = \beta V[t - 1] + X[t]
+
+        .. math::
+
+            C[t] = \operatorname{round}(\operatorname{clip}(U[t] / V_{th}, 0, D))
+
+        .. math::
+
+            V[t] = U[t] - C[t] V_{th}
+
+        ``D`` is ``max_spike_count`` and ``beta`` is ``decay``. ``decay`` belongs
+        to the charge process, matching the :class:`LIFNode` charge form when
+        ``decay_input=False`` and ``v_reset=0``. In training mode, the forward
+        output is the integer spike count ``C[t]``. Its backward path uses the
+        rectangular straight-through estimator from the paper: gradients pass only
+        where ``U[t] / V_th`` lies in ``[0, D]``.
+
+        In eval mode this neuron returns strictly binary ``0/1`` spikes:
+
+        .. math::
+
+            S[t] = \Theta(U[t] - V_{th})
+
+        .. math::
+
+            V[t] = U[t] - S[t] V_{th}
+
+        Thus inference forward never returns integer counts such as ``C[t]``. To
+        evaluate fairly against integer-valued training, organize timesteps at
+        the user training/evaluation loop level.
+
+        .. admonition:: Strict binary inference contract
+            :class: warning
+
+            This neuron has no ``T`` parameter and does not automatically expand
+            ``[T, ...]`` inputs to ``[T * D, ...]``. Run ``T`` logical steps in
+            the training loop. For fair inference, run ``T * D`` virtual steps in
+            the evaluation loop and feed this neuron inputs that have already
+            been constructed for those virtual steps. The neuron emits only
+            ``0/1`` at each inference step. Downstream linear layers must consume
+            these ``0/1`` spikes, or an equivalent spike-aware AC dataflow.
+            Feeding the training-time integer count ``C[t]`` directly into dense
+            convolutions or linear layers is integer inference, not spike-driven
+            inference.
+
+        :param v_threshold: Threshold voltage, which must be finite and positive
+        :type v_threshold: float
+        :param max_spike_count: Maximum integer count ``D`` emitted in one
+            logical training step
+        :type max_spike_count: int
+        :param decay: Historical membrane decay ``beta`` in charge, in ``[0, 1]``.
+            ``decay=1`` degenerates to a non-leaky integer IF form
+        :type decay: float
+        :param detach_reset: Whether to detach the emitted value used by reset in
+            backward
+        :type detach_reset: bool
+        :param step_mode: Step mode, ``"s"`` or ``"m"``
+        :type step_mode: str
+        :param backend: Backend name. Only ``"torch"`` is currently supported
+        :type backend: str
+        :param store_v_seq: Whether to store membrane voltage after each input
+            step in multi-step mode
+        :type store_v_seq: bool
+        """
+        if not isinstance(v_threshold, numbers.Real):
+            raise TypeError("v_threshold must be a real number.")
+        v_threshold = float(v_threshold)
+        if not torch.isfinite(torch.tensor(v_threshold)) or v_threshold <= 0.0:
+            raise ValueError("v_threshold must be finite positive.")
+        if not isinstance(decay, numbers.Real):
+            raise TypeError("decay must be a real number.")
+        decay = float(decay)
+        if not torch.isfinite(torch.tensor(decay)) or decay < 0.0 or decay > 1.0:
+            raise ValueError("decay must be finite and in [0, 1].")
+
+        super().__init__(
+            v_threshold=v_threshold,
+            v_reset=None,
+            surrogate_function=surrogate.MultiLevelSpikeCount(max_spike_count),
+            detach_reset=detach_reset,
+            step_mode=step_mode,
+            backend=backend,
+            store_v_seq=store_v_seq,
+        )
+        self.decay = decay
+
+    @property
+    def supported_backends(self):
+        return ("torch",)
+
+    def neuronal_charge(self, x: torch.Tensor):
+        self.v = self.decay * self.v + x
+
+    def neuronal_fire(self):
+        if self.training:
+            return self.surrogate_function(self.v / self.v_threshold)
+        return (self.v >= self.v_threshold).to(self.v)
+
+    def neuronal_reset(self, spike):
+        if self.detach_reset:
+            spike = spike.detach()
+        self.v = self.v - spike * self.v_threshold
+
+    def single_step_forward(self, x: torch.Tensor):
+        self.v_float_to_tensor(x)
+        self.neuronal_charge(x)
+        spike = self.neuronal_fire()
+        self.neuronal_reset(spike)
+        return spike
+
+    def multi_step_forward(self, x_seq: torch.Tensor):
+        spike_seq = []
+        if self.store_v_seq:
+            v_seq = []
+        for t in range(x_seq.shape[0]):
+            spike_seq.append(self.single_step_forward(x_seq[t]))
+            if self.store_v_seq:
+                v_seq.append(self.v)
+        if self.store_v_seq:
+            self.v_seq = torch.stack(v_seq)
+        return torch.stack(spike_seq)
+
+    def extra_repr(self):
+        return (
+            f"v_threshold={self.v_threshold}, "
+            f"max_spike_count={self.surrogate_function.max_spike_count}, "
+            f"decay={self.decay}, detach_reset={self.detach_reset}, "
+            f"step_mode={self.step_mode}, backend={self.backend}"
+        )

--- a/spikingjelly/activation_based/neuron/ilif.py
+++ b/spikingjelly/activation_based/neuron/ilif.py
@@ -168,6 +168,13 @@ class ILIFNode(BaseNode):
         v_threshold = float(v_threshold)
         if not torch.isfinite(torch.tensor(v_threshold)) or v_threshold <= 0.0:
             raise ValueError("v_threshold must be finite positive.")
+        if not isinstance(max_spike_count, numbers.Integral) or isinstance(
+            max_spike_count, bool
+        ):
+            raise TypeError("max_spike_count must be an integer.")
+        max_spike_count = int(max_spike_count)
+        if max_spike_count < 1:
+            raise ValueError("max_spike_count must be >= 1.")
         if not isinstance(decay, numbers.Real):
             raise TypeError("decay must be a real number.")
         decay = float(decay)

--- a/spikingjelly/activation_based/quantize.py
+++ b/spikingjelly/activation_based/quantize.py
@@ -577,6 +577,45 @@ def step_quantize(x: torch.Tensor, step: float):
     return step_quantize_atgf.apply(x, step)
 
 
+class multi_level_spike_count_atgf(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        x: torch.Tensor,
+        max_spike_count: int,
+        grad_min: float,
+        grad_max: float,
+    ):
+        ctx.save_for_backward(x)
+        ctx.grad_min = grad_min
+        ctx.grad_max = grad_max
+        return torch.round(torch.clamp(x, 0, max_spike_count))
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        (x,) = ctx.saved_tensors
+        mask = (x >= ctx.grad_min) & (x <= ctx.grad_max)
+        return grad_output * mask.to(grad_output.dtype), None, None, None
+
+
+def multi_level_spike_count(
+    x: torch.Tensor,
+    max_spike_count: int,
+    grad_window=None,
+):
+    max_spike_count = int(max_spike_count)
+    if grad_window is None:
+        grad_min, grad_max = 0.0, float(max_spike_count)
+    else:
+        grad_min, grad_max = grad_window
+    return multi_level_spike_count_atgf.apply(
+        x,
+        max_spike_count,
+        grad_min,
+        grad_max,
+    )
+
+
 def k_bit_quantize_forward(x: torch.Tensor, k: int):
     r"""
     **API Language** - :ref:`中文 <k_bit_quantize_forward-cn>` | :ref:`English <k_bit_quantize_forward-en>`

--- a/spikingjelly/activation_based/surrogate.py
+++ b/spikingjelly/activation_based/surrogate.py
@@ -1,4 +1,5 @@
 import math
+import numbers
 
 import torch
 import torch.nn as nn
@@ -3325,11 +3326,19 @@ class MultiLevelSpikeCount(SurrogateFunctionBase):
         straight-through estimator. The default gradient window is
         ``[0, max_spike_count]``.
         """
+        if not isinstance(max_spike_count, numbers.Integral) or isinstance(
+            max_spike_count, bool
+        ):
+            raise TypeError("max_spike_count must be an integer.")
         max_spike_count = int(max_spike_count)
+        if max_spike_count < 1:
+            raise ValueError("max_spike_count must be >= 1.")
         if grad_window is None:
             grad_min, grad_max = 0.0, float(max_spike_count)
         else:
             grad_min, grad_max = grad_window
+            if grad_min > grad_max:
+                raise ValueError("grad_window must satisfy grad_min <= grad_max.")
         super().__init__(
             spiking=spiking,
             max_spike_count=max_spike_count,

--- a/spikingjelly/activation_based/surrogate.py
+++ b/spikingjelly/activation_based/surrogate.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from . import quantize
 from .cuda_kernel.auto_cuda import cfunction
 
 tab4_str = "\t\t\t\t"  # used for aligning code
@@ -3309,6 +3310,55 @@ class DeterministicPass(SurrogateFunctionBase):
     @staticmethod
     def backward(grad_output, x, alpha):
         return grad_output
+
+
+class MultiLevelSpikeCount(SurrogateFunctionBase):
+    def __init__(
+        self,
+        max_spike_count: int,
+        spiking: bool = True,
+        grad_window=None,
+    ):
+        r"""
+        Multi-level spike-count surrogate. In spiking mode, forward returns
+        ``round(clamp(x, 0, max_spike_count))`` and backward uses a rectangular
+        straight-through estimator. The default gradient window is
+        ``[0, max_spike_count]``.
+        """
+        max_spike_count = int(max_spike_count)
+        if grad_window is None:
+            grad_min, grad_max = 0.0, float(max_spike_count)
+        else:
+            grad_min, grad_max = grad_window
+        super().__init__(
+            spiking=spiking,
+            max_spike_count=max_spike_count,
+            grad_min=grad_min,
+            grad_max=grad_max,
+        )
+
+    @staticmethod
+    def spiking_function(
+        x: torch.Tensor,
+        max_spike_count: int,
+        grad_min: float,
+        grad_max: float,
+    ):
+        return quantize.multi_level_spike_count(
+            x,
+            max_spike_count,
+            (grad_min, grad_max),
+        )
+
+    @staticmethod
+    def primitive_function(
+        x: torch.Tensor,
+        max_spike_count: int,
+        grad_min: float,
+        grad_max: float,
+    ):
+        del grad_min, grad_max
+        return torch.clamp(x, 0, max_spike_count)
 
 
 class poisson_pass(torch.autograd.Function):

--- a/test/activation_based/test_ann2snn_qcfs.py
+++ b/test/activation_based/test_ann2snn_qcfs.py
@@ -108,6 +108,15 @@ def test_count_domain_reconstruction_equals_multistep_temporal_sum():
     assert torch.equal(encoder.reconstruct(value), sequence.sum(0))
 
 
+def test_count_domain_reconstruction_uses_spike_count_surrogate_gradient():
+    encoder = SignedQCFSSequenceEncoder(torch.tensor([0.25]), time_steps=4)
+    value = torch.tensor([[0.75], [-0.75], [2.0]], requires_grad=True)
+
+    encoder.reconstruct(value).sum().backward()
+
+    torch.testing.assert_close(value.grad, torch.tensor([[1.0], [1.0], [0.0]]))
+
+
 def test_signed_qcfs_bfloat16_replays_large_time_step_counts_exactly():
     scale = torch.exp(torch.linspace(-8, 4, 17)).to(torch.bfloat16)
     counts = torch.arange(17, dtype=torch.bfloat16).reshape(1, 17) * 10
@@ -122,15 +131,6 @@ def test_signed_qcfs_bfloat16_replays_large_time_step_counts_exactly():
 
     expected = torch.round(value / scale).clamp(-160, 160) * scale
     torch.testing.assert_close(sequence.sum(0), expected, atol=0.0, rtol=0.0)
-
-
-def test_qwen2_snn_forward_rejects_autograd_before_computation():
-    model = Qwen2SNNModel.__new__(Qwen2SNNModel)
-    nn.Module.__init__(model)
-    model.eval()
-
-    with pytest.raises(RuntimeError, match="does not support autograd"):
-        model(torch.ones(1, 2, dtype=torch.long))
 
 
 def test_qwen2_snn_generate_owns_inference_mode():

--- a/test/activation_based/test_ann2snn_qwen2.py
+++ b/test/activation_based/test_ann2snn_qwen2.py
@@ -69,7 +69,7 @@ def test_qwen2_calibration_round_trip_and_conversion_preserve_contract():
         torch.equal(restored.layer_scales[0][name], calibration.layer_scales[0][name])
         for name in restored.layer_scales[0]
     )
-    assert not any(parameter.requires_grad for parameter in converted.parameters())
+    assert any(parameter.requires_grad for parameter in converted.parameters())
     assert converted.lm_head.weight is converted.embed_tokens.weight
     assert converted.device == converted.embed_tokens.weight.device
     assert converted.get_input_embeddings() is converted.embed_tokens
@@ -198,6 +198,23 @@ def test_qwen2_signed_if_replays_after_reset():
 
     assert torch.isfinite(first).all()
     assert torch.equal(first, second)
+
+
+def test_qwen2_qcfs_sg_allows_autograd():
+    _, converted = _convert(_tiny_qwen2())
+    inputs = _inputs()
+
+    output = converted(**inputs, encoding_mode="qcfs_sg")
+    loss = output.logits.float().sum()
+    loss.backward()
+
+    gradients = [
+        parameter.grad
+        for parameter in converted.parameters()
+        if parameter.requires_grad and parameter.grad is not None
+    ]
+    assert gradients
+    assert all(torch.isfinite(gradient).all() for gradient in gradients)
 
 
 def test_qwen2_calibration_failure_does_not_leave_hooks_installed():

--- a/test/activation_based/test_ilif_node.py
+++ b/test/activation_based/test_ilif_node.py
@@ -1,0 +1,93 @@
+import torch
+
+from spikingjelly.activation_based import neuron, surrogate
+
+
+def test_ilif_training_outputs_integer_counts_and_updates_voltage():
+    node = neuron.ILIFNode(v_threshold=1.0, max_spike_count=4, decay=0.25)
+    x = torch.tensor([[3.2, 0.4, 5.8]])
+
+    y = node(x)
+
+    expected = torch.tensor([[3.0, 0.0, 4.0]])
+    assert torch.equal(y, expected)
+    torch.testing.assert_close(node.v, x - expected)
+
+
+def test_ilif_uses_spike_count_surrogate():
+    node = neuron.ILIFNode(max_spike_count=4)
+
+    assert isinstance(node.surrogate_function, surrogate.MultiLevelSpikeCount)
+    assert node.surrogate_function.max_spike_count == 4
+
+
+def test_ilif_decay_is_applied_during_charge():
+    node = neuron.ILIFNode(v_threshold=1.0, max_spike_count=4, decay=0.25)
+
+    node(torch.tensor([[3.2]]))
+    y = node(torch.tensor([[0.0]]))
+
+    assert torch.equal(y, torch.tensor([[0.0]]))
+    torch.testing.assert_close(node.v, torch.tensor([[0.05]]))
+
+
+def test_ilif_eval_releases_only_binary_spikes_over_user_virtual_steps():
+    node = neuron.ILIFNode(v_threshold=1.0, max_spike_count=4, decay=1.0).eval()
+    x_seq = torch.tensor([[[1.2]], [[1.2]], [[1.2]], [[0.0]]])
+
+    y = torch.stack([node(x) for x in x_seq])
+
+    assert torch.equal(y.flatten(), torch.tensor([1.0, 1.0, 1.0, 0.0]))
+    assert set(y.unique().tolist()) <= {0.0, 1.0}
+    torch.testing.assert_close(node.v, torch.tensor([[0.6]]))
+
+
+def test_ilif_eval_does_not_return_integer_counts():
+    node = neuron.ILIFNode(v_threshold=1.0, max_spike_count=4, decay=0.25).eval()
+
+    y = node(torch.tensor([[3.2, 5.8]]))
+
+    assert torch.equal(y, torch.ones_like(y))
+    assert set(y.unique().tolist()) <= {0.0, 1.0}
+
+
+def test_ilif_multistep_uses_user_provided_virtual_length_without_expansion():
+    node = neuron.ILIFNode(
+        v_threshold=1.0,
+        max_spike_count=4,
+        decay=0.25,
+        step_mode="m",
+        store_v_seq=True,
+    ).eval()
+    x_seq = torch.tensor([[[1.2]], [[1.2]], [[1.2]], [[0.0]]])
+
+    y = node(x_seq)
+
+    assert y.shape == x_seq.shape
+    assert node.v_seq.shape == x_seq.shape
+    assert set(y.unique().tolist()) <= {0.0, 1.0}
+
+
+def test_ilif_training_straight_through_gradient_is_windowed():
+    node = neuron.ILIFNode(v_threshold=1.0, max_spike_count=4, decay=0.0)
+    x = torch.tensor([[-0.5, 0.5, 4.5]], requires_grad=True)
+
+    y = node(x)
+    y.sum().backward()
+
+    assert torch.equal(y.detach(), torch.tensor([[0.0, 0.0, 4.0]]))
+    torch.testing.assert_close(x.grad, torch.tensor([[0.0, 1.0, 0.0]]))
+
+
+def test_multi_level_spike_count_supports_custom_gradient_window():
+    spike_count = surrogate.MultiLevelSpikeCount(
+        max_spike_count=4,
+        grad_window=(-0.5, 4.5),
+    )
+    x = torch.tensor([[-0.25, 4.25, 4.75]], requires_grad=True)
+
+    y = spike_count(x)
+    y.sum().backward()
+
+    assert torch.equal(y.detach(), torch.tensor([[0.0, 4.0, 4.0]]))
+    torch.testing.assert_close(x.grad, torch.tensor([[1.0, 1.0, 0.0]]))

--- a/test/activation_based/test_ilif_node.py
+++ b/test/activation_based/test_ilif_node.py
@@ -1,6 +1,16 @@
+import pytest
 import torch
 
 from spikingjelly.activation_based import neuron, surrogate
+
+
+def test_ilif_rejects_invalid_max_spike_count():
+    for value in (0, -1):
+        with pytest.raises(ValueError):
+            neuron.ILIFNode(max_spike_count=value)
+    for value in (1.5, True):
+        with pytest.raises(TypeError):
+            neuron.ILIFNode(max_spike_count=value)
 
 
 def test_ilif_training_outputs_integer_counts_and_updates_voltage():
@@ -91,3 +101,14 @@ def test_multi_level_spike_count_supports_custom_gradient_window():
 
     assert torch.equal(y.detach(), torch.tensor([[0.0, 4.0, 4.0]]))
     torch.testing.assert_close(x.grad, torch.tensor([[1.0, 1.0, 0.0]]))
+
+
+def test_multi_level_spike_count_rejects_invalid_parameters():
+    for value in (0, -1):
+        with pytest.raises(ValueError):
+            surrogate.MultiLevelSpikeCount(value)
+    for value in (1.5, False):
+        with pytest.raises(TypeError):
+            surrogate.MultiLevelSpikeCount(value)
+    with pytest.raises(ValueError):
+        surrogate.MultiLevelSpikeCount(4, grad_window=(1.0, 0.0))

--- a/test/activation_based/test_noisy_and_misc.py
+++ b/test/activation_based/test_noisy_and_misc.py
@@ -185,6 +185,26 @@ def test_quantizers_keep_their_straight_through_gradients():
     torch.testing.assert_close(x.grad, torch.tensor([1.0, 2.0, 2.0, 1.0]))
 
 
+def test_multi_level_spike_count_quantizer_uses_windowed_gradient():
+    x = torch.tensor([[-0.25, 0.5, 4.25]], requires_grad=True)
+
+    y = quantize.multi_level_spike_count(x, max_spike_count=4)
+    y.sum().backward()
+
+    assert torch.equal(y.detach(), torch.tensor([[0.0, 0.0, 4.0]]))
+    torch.testing.assert_close(x.grad, torch.tensor([[0.0, 1.0, 0.0]]))
+
+    x.grad = None
+    y = quantize.multi_level_spike_count(
+        x,
+        max_spike_count=4,
+        grad_window=(-0.5, 4.5),
+    )
+    y.sum().backward()
+
+    torch.testing.assert_close(x.grad, torch.tensor([[1.0, 1.0, 1.0]]))
+
+
 def test_cubalif_inherited_multi_step_matches_repeated_single_steps():
     multi_step_node = CUBALIFNode()
     single_step_node = CUBALIFNode()


### PR DESCRIPTION
## Summary
- Add `ILIFNode` with integer-valued training and strictly binary spike inference.
- Add `MultiLevelSpikeCount` and `quantize.multi_level_spike_count` for multi-level spike-count STE.
- Reuse the spike-count operator in QCFS reconstruction and Qwen2 `qcfs_sg` mode.
- Keep model-layer autograd/freezing policy outside Qwen2 conversion internals.
- Document ILIF and the surrogate in the public API docs.

## Testing
- `uv run python -m py_compile spikingjelly/activation_based/quantize.py spikingjelly/activation_based/surrogate.py spikingjelly/activation_based/neuron/ilif.py spikingjelly/activation_based/ann2snn/qcfs.py spikingjelly/activation_based/ann2snn/recipes/qwen2.py`
- `uv run python -m pytest -q test/activation_based/test_ilif_node.py test/activation_based/test_noisy_and_misc.py test/activation_based/test_ann2snn_qcfs.py test/activation_based/test_ann2snn_qwen2.py` — 36 passed, 9 skipped
- `uv run sphinx-build -b html -W --keep-going docs/source /tmp/spikingjelly-docs-check`
- CUDA 12.8 / RTX 4090: `PYTHONPATH=/workspace/spikingjelly-ilif python -m pytest -q -rs test/activation_based` — 1807 passed, 82 skipped, 126 warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ILIFNode` for integer-valued training with strictly binary spike inference.
  * Introduced multi-level spike-count quantization with surrogate-gradient support.
  * Added a new Qwen2-to-SNN `qcfs_sg` encoding mode supporting autograd-enabled training.
* **Documentation**
  * Updated API docs for the new integer-valued training neurons and related quantization/surrogate behavior.
  * Refined benchmark/offline guidance wording around inference vs training scope.
* **Tests**
  * Added validation tests for neuron and quantization parameter correctness.
  * Added/updated coverage for `qcfs_sg` autograd and reconstruction gradient behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->