### PR TITLE
feat(layer): add ILIF binary spike conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,14 @@ Module: `spikingjelly.activation_based.triton_kernel.neuron_kernel`.
 - Added an inference-only single-step Triton kernel for the SpikeZIP STBIF
   neuron, exposed through functional and neuron interfaces.
 
+#### Integer-Valued Spike Conversion
+
+Module: `spikingjelly.activation_based.layer`.
+
+- Added `SpikeCountToBinary` and `TemporalBinSum` for multi-step I-LIF networks,
+  enabling integer-valued training and binary-event evaluation around bias-free
+  weight layers.
+
 ### Bug Fixes
 
 #### ANN-to-SNN Conversion

--- a/docs/source/APIs/spikingjelly.activation_based.layer.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.layer.rst
@@ -348,12 +348,15 @@ and performs binary conversion in evaluation mode.
 .. warning::
 
    ``SpikeCountToBinary`` 与 ``TemporalBinSum`` 必须使用相同的 ``num_slots``
-   和 ``conversion_mode``。两者之间的权重层必须禁用 bias；bias、归一化和
-   非线性应在 ``TemporalBinSum`` 之后执行一次。
+   和 ``always_convert``。连接 ``ILIFNode`` 时，``num_slots`` 不得小于
+   ``surrogate_function.max_spike_count``。两者之间的权重层必须禁用 bias；
+   bias、归一化和非线性应在 ``TemporalBinSum`` 之后执行一次。
 
-   Both modules must use the same ``num_slots`` and ``conversion_mode``. The
-   intervening weight layer must disable bias; apply bias, normalization, and
-   nonlinear operations once after ``TemporalBinSum``.
+   Both modules must use the same ``num_slots`` and ``always_convert``. When
+   connected to ``ILIFNode``, ``num_slots`` must be no smaller than
+   ``surrogate_function.max_spike_count``. The intervening weight layer must
+   disable bias; apply bias, normalization, and nonlinear operations once after
+   ``TemporalBinSum``.
 
    这些层提供二值事件语义和对应的运算计数，不会把稠密 PyTorch 权重算子替换为
    稀疏硬件 kernel，也不单独构成延迟或能耗提升的证据。

--- a/docs/source/APIs/spikingjelly.activation_based.layer.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.layer.rst
@@ -311,6 +311,57 @@ SpikingJelly's **online learning modules** provide auxiliary classes and operati
 
    online_learning <spikingjelly.activation_based.layer.online_learning>
 
+Integer-Valued Spike Conversion
+++++++++++++++++++++++++++++++++
+
+以下多步层将 I-LIF 的整数脉冲计数展开为二值事件槽，并在无 bias 权重运算后
+恢复逻辑时间维。默认配置在训练模式保持整数路径，在 eval 模式执行二值转换。
+
+----
+
+The following multi-step layers expand integer I-LIF spike counts into binary
+event slots and restore the logical time dimension after a bias-free weight
+operation. Their default configuration keeps the integer path during training
+and performs binary conversion in evaluation mode.
+
+.. list-table::
+
+   * - :class:`SpikeCountToBinary <spikingjelly.activation_based.layer.misc.SpikeCountToBinary>`
+     - Expand each integer spike count into consecutive binary event slots.
+   * - :class:`TemporalBinSum <spikingjelly.activation_based.layer.misc.TemporalBinSum>`
+     - Sum consecutive physical event slots back into logical timesteps.
+
+.. code-block:: python
+
+   import torch.nn as nn
+
+   from spikingjelly.activation_based import layer, neuron
+
+   num_slots = 4
+   block = nn.Sequential(
+       neuron.ILIFNode(step_mode="m"),
+       layer.SpikeCountToBinary(num_slots),
+       layer.Linear(16, 32, bias=False, step_mode="m"),
+       layer.TemporalBinSum(num_slots),
+   )
+
+.. warning::
+
+   ``SpikeCountToBinary`` 与 ``TemporalBinSum`` 必须使用相同的 ``num_slots``
+   和 ``conversion_mode``。两者之间的权重层必须禁用 bias；bias、归一化和
+   非线性应在 ``TemporalBinSum`` 之后执行一次。
+
+   Both modules must use the same ``num_slots`` and ``conversion_mode``. The
+   intervening weight layer must disable bias; apply bias, normalization, and
+   nonlinear operations once after ``TemporalBinSum``.
+
+   这些层提供二值事件语义和对应的运算计数，不会把稠密 PyTorch 权重算子替换为
+   稀疏硬件 kernel，也不单独构成延迟或能耗提升的证据。
+
+   These layers provide binary-event semantics and corresponding operation
+   accounting. They do not replace dense PyTorch weight operations with sparse
+   hardware kernels and do not by themselves demonstrate latency or energy gains.
+
 Miscellaneous
 +++++++++++++
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -77,6 +77,15 @@ Module: ``spikingjelly.activation_based.triton_kernel.neuron_kernel``.
 - Added an inference-only single-step Triton kernel for the SpikeZIP STBIF
   neuron, exposed through functional and neuron interfaces.
 
+Integer-Valued Spike Conversion
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Module: ``spikingjelly.activation_based.layer``.
+
+- Added ``SpikeCountToBinary`` and ``TemporalBinSum`` for multi-step I-LIF networks,
+  enabling integer-valued training and binary-event evaluation around bias-free
+  weight layers.
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/spikingjelly/activation_based/layer/misc.py
+++ b/spikingjelly/activation_based/layer/misc.py
@@ -1,6 +1,4 @@
 import math
-import numbers
-from typing import Literal
 
 import torch
 import torch.nn as nn
@@ -18,30 +16,6 @@ __all__ = [
     "SpikeCountToBinary",
     "TemporalBinSum",
 ]
-
-
-def _validate_temporal_conversion_config(
-    num_slots: int,
-    conversion_mode: Literal["eval", "always"],
-) -> None:
-    if not isinstance(num_slots, numbers.Integral) or isinstance(num_slots, bool):
-        raise TypeError("num_slots must be an integer.")
-    if num_slots < 1:
-        raise ValueError("num_slots must be >= 1.")
-    if conversion_mode not in ("eval", "always"):
-        raise ValueError(
-            'conversion_mode must be either "eval" or "always", '
-            f'but got "{conversion_mode}".'
-        )
-
-
-def _validate_temporal_input(x_seq: torch.Tensor) -> None:
-    if not x_seq.is_floating_point():
-        raise TypeError("x_seq must be a floating-point tensor.")
-    if x_seq.ndim < 2:
-        raise ValueError(f"expected x_seq with shape [T, N, *], but got {x_seq.shape}.")
-    if x_seq.shape[0] == 0:
-        raise ValueError("x_seq must have a non-empty time dimension.")
 
 
 class SynapseFilter(base.MemoryModule):
@@ -388,7 +362,7 @@ class SpikeCountToBinary(nn.Module, base.MultiStepModule):
     def __init__(
         self,
         num_slots: int,
-        conversion_mode: Literal["eval", "always"] = "eval",
+        always_convert: bool = False,
     ) -> None:
         r"""
         **API Language** - :ref:`中文 <SpikeCountToBinary.__init__-cn>` | :ref:`English <SpikeCountToBinary.__init__-en>`
@@ -400,8 +374,8 @@ class SpikeCountToBinary(nn.Module, base.MultiStepModule):
         * **中文**
 
         将每个非负整数脉冲计数展开为 ``num_slots`` 个二值事件槽。该模块仅支持
-        多步模式，时间维固定为第 0 维。当 ``conversion_mode="eval"`` 时，训练
-        模式返回原输入，推理模式执行展开；``"always"`` 表示始终展开。
+        多步模式，时间维固定为第 0 维。默认训练模式返回原输入、推理模式执行
+        展开；设置 ``always_convert=True`` 后始终展开。
 
         展开激活时使用硬二值前向和直通估计。每个事件槽对输入计数的代理导数为
         ``1 / num_slots``，因此反向传播会把同一 bin 的槽梯度取平均。若展开后
@@ -411,11 +385,9 @@ class SpikeCountToBinary(nn.Module, base.MultiStepModule):
 
         :param num_slots: 每个逻辑时间步包含的二值事件槽数量
         :type num_slots: int
-        :param conversion_mode: ``"eval"`` 表示仅在推理模式展开，``"always"``
-            表示始终展开
-        :type conversion_mode: Literal["eval", "always"]
-        :raises TypeError: 当 ``num_slots`` 不是整数或为 ``bool`` 时抛出
-        :raises ValueError: 当 ``num_slots < 1`` 或 ``conversion_mode`` 非法时抛出
+        :param always_convert: 为 ``True`` 时始终展开；为 ``False`` 时仅在推理
+            模式展开，默认为 ``False``
+        :type always_convert: bool
 
         ----
 
@@ -425,9 +397,9 @@ class SpikeCountToBinary(nn.Module, base.MultiStepModule):
 
         Expand each non-negative integer spike count into ``num_slots`` binary
         event slots. This module only supports multi-step mode and fixes the time
-        dimension at dimension 0. With ``conversion_mode="eval"``, training mode
-        returns the input unchanged and evaluation mode performs the expansion;
-        ``"always"`` always performs the expansion.
+        dimension at dimension 0. By default, training mode returns the input
+        unchanged and evaluation mode performs the expansion. Set
+        ``always_convert=True`` to always expand.
 
         Active expansion uses hard binary values in forward and a straight-through
         estimator whose surrogate derivative is ``1 / num_slots`` for each event
@@ -440,16 +412,13 @@ class SpikeCountToBinary(nn.Module, base.MultiStepModule):
 
         :param num_slots: Number of binary event slots per logical timestep
         :type num_slots: int
-        :param conversion_mode: ``"eval"`` to expand only in evaluation mode, or
-            ``"always"`` to always expand
-        :type conversion_mode: Literal["eval", "always"]
-        :raises TypeError: If ``num_slots`` is not an integer or is ``bool``
-        :raises ValueError: If ``num_slots < 1`` or ``conversion_mode`` is invalid
+        :param always_convert: ``True`` to always expand, or ``False`` to expand
+            only in evaluation mode; defaults to ``False``
+        :type always_convert: bool
         """
         super().__init__()
-        _validate_temporal_conversion_config(num_slots, conversion_mode)
-        self.num_slots = int(num_slots)
-        self.conversion_mode = conversion_mode
+        self.num_slots = num_slots
+        self.always_convert = always_convert
         self.step_mode = "m"
 
     def forward(self, x_seq: torch.Tensor) -> torch.Tensor:
@@ -462,15 +431,12 @@ class SpikeCountToBinary(nn.Module, base.MultiStepModule):
 
         * **中文**
 
-        :param x_seq: 整数值脉冲计数，形状为 ``[T, N, *]``。转换激活时必须为
-            非空浮点张量，所有值必须有限且位于 ``[0, num_slots]``
+        :param x_seq: 形状为 ``[T, N, *]``、取值位于 ``[0, num_slots]`` 的
+            浮点整数值脉冲计数
         :type x_seq: torch.Tensor
         :return: 转换激活时返回形状为 ``[T * num_slots, N, *]`` 的二值脉冲；
             否则原样返回 ``x_seq``。输出保持输入的 dtype 和 device
         :rtype: torch.Tensor
-        :raises TypeError: 转换激活且 ``x_seq`` 不是浮点张量时抛出
-        :raises ValueError: 转换激活且 ``x_seq`` 形状非法或时间维为空时抛出
-        :raises RuntimeError: 转换激活且计数包含非有限值、非整数值或越界值时抛出
 
         ----
 
@@ -478,36 +444,16 @@ class SpikeCountToBinary(nn.Module, base.MultiStepModule):
 
         * **English**
 
-        :param x_seq: Integer-valued spike counts with shape ``[T, N, *]``. When
-            conversion is active, it must be a non-empty floating-point tensor with
-            finite values in ``[0, num_slots]``
+        :param x_seq: Floating-point integer-valued spike counts in
+            ``[0, num_slots]`` with shape ``[T, N, *]``
         :type x_seq: torch.Tensor
         :return: Binary spikes with shape ``[T * num_slots, N, *]`` when
             conversion is active; otherwise ``x_seq`` unchanged. The output keeps
             the input dtype and device
         :rtype: torch.Tensor
-        :raises TypeError: If active conversion receives a non-floating-point tensor
-        :raises ValueError: If active conversion receives an invalid shape or an
-            empty time dimension
-        :raises RuntimeError: If active conversion receives non-finite,
-            non-integer-valued, or out-of-range counts
         """
-        if self.conversion_mode == "eval" and self.training:
+        if not self.always_convert and self.training:
             return x_seq
-
-        _validate_temporal_input(x_seq)
-        torch._assert_async(
-            torch.isfinite(x_seq).all(),
-            "x_seq must contain only finite values.",
-        )
-        torch._assert_async(
-            x_seq.eq(x_seq.round()).all(),
-            "x_seq must contain only integer-valued spike counts.",
-        )
-        torch._assert_async(
-            x_seq.ge(0).logical_and(x_seq.le(self.num_slots)).all(),
-            "x_seq spike counts must be in [0, num_slots].",
-        )
 
         counts = x_seq.unsqueeze(1)
         slots = torch.arange(self.num_slots, device=x_seq.device).view(
@@ -522,7 +468,7 @@ class TemporalBinSum(nn.Module, base.MultiStepModule):
     def __init__(
         self,
         num_slots: int,
-        conversion_mode: Literal["eval", "always"] = "eval",
+        always_convert: bool = False,
     ) -> None:
         r"""
         **API Language** - :ref:`中文 <TemporalBinSum.__init__-cn>` | :ref:`English <TemporalBinSum.__init__-en>`
@@ -534,21 +480,18 @@ class TemporalBinSum(nn.Module, base.MultiStepModule):
         * **中文**
 
         沿第 0 维将每 ``num_slots`` 个连续时间步求和。最后一个 bin 不完整时
-        在时间维末尾补零。该模块仅支持多步模式。当
-        ``conversion_mode="eval"`` 时，训练模式返回原输入，推理模式执行求和；
-        ``"always"`` 表示始终求和。
+        在时间维末尾补零。该模块仅支持多步模式。默认训练模式返回原输入、
+        推理模式执行求和；设置 ``always_convert=True`` 后始终求和。
 
         与 :class:`SpikeCountToBinary` 配对时，两者必须使用相同的
-        ``num_slots`` 和 ``conversion_mode``。展开与求和之间的权重层必须禁用
+        ``num_slots`` 和 ``always_convert``。展开与求和之间的权重层必须禁用
         bias；归一化和非线性应在求和后执行一次。
 
         :param num_slots: 每个输出逻辑时间步聚合的物理事件槽数量
         :type num_slots: int
-        :param conversion_mode: ``"eval"`` 表示仅在推理模式聚合，``"always"``
-            表示始终聚合
-        :type conversion_mode: Literal["eval", "always"]
-        :raises TypeError: 当 ``num_slots`` 不是整数或为 ``bool`` 时抛出
-        :raises ValueError: 当 ``num_slots < 1`` 或 ``conversion_mode`` 非法时抛出
+        :param always_convert: 为 ``True`` 时始终聚合；为 ``False`` 时仅在推理
+            模式聚合，默认为 ``False``
+        :type always_convert: bool
 
         ----
 
@@ -558,29 +501,25 @@ class TemporalBinSum(nn.Module, base.MultiStepModule):
 
         Sum each ``num_slots`` consecutive timesteps along dimension 0. An
         incomplete final bin is zero-padded at the end of the time dimension.
-        This module only supports multi-step mode. With
-        ``conversion_mode="eval"``, training mode returns the input unchanged
-        and evaluation mode performs the reduction; ``"always"`` always
-        performs the reduction.
+        This module only supports multi-step mode. By default, training mode
+        returns the input unchanged and evaluation mode performs the reduction.
+        Set ``always_convert=True`` to always reduce.
 
         When paired with :class:`SpikeCountToBinary`, both modules must use the
-        same ``num_slots`` and ``conversion_mode``. The weight layer between
+        same ``num_slots`` and ``always_convert``. The weight layer between
         expansion and reduction must disable bias; normalization and nonlinear
         operations must run once after the reduction.
 
         :param num_slots: Number of physical event slots aggregated into each
             output logical timestep
         :type num_slots: int
-        :param conversion_mode: ``"eval"`` to aggregate only in evaluation
-            mode, or ``"always"`` to always aggregate
-        :type conversion_mode: Literal["eval", "always"]
-        :raises TypeError: If ``num_slots`` is not an integer or is ``bool``
-        :raises ValueError: If ``num_slots < 1`` or ``conversion_mode`` is invalid
+        :param always_convert: ``True`` to always reduce, or ``False`` to reduce
+            only in evaluation mode; defaults to ``False``
+        :type always_convert: bool
         """
         super().__init__()
-        _validate_temporal_conversion_config(num_slots, conversion_mode)
-        self.num_slots = int(num_slots)
-        self.conversion_mode = conversion_mode
+        self.num_slots = num_slots
+        self.always_convert = always_convert
         self.step_mode = "m"
 
     def forward(self, x_seq: torch.Tensor) -> torch.Tensor:
@@ -599,8 +538,6 @@ class TemporalBinSum(nn.Module, base.MultiStepModule):
             ``[ceil(T / num_slots), N, *]`` 的序列；否则原样返回 ``x_seq``。
             输出保持输入的 dtype 和 device
         :rtype: torch.Tensor
-        :raises TypeError: 聚合激活且 ``x_seq`` 不是浮点张量时抛出
-        :raises ValueError: 聚合激活且 ``x_seq`` 形状非法或时间维为空时抛出
 
         ----
 
@@ -615,14 +552,9 @@ class TemporalBinSum(nn.Module, base.MultiStepModule):
             aggregation is active; otherwise ``x_seq`` unchanged. The output keeps
             the input dtype and device
         :rtype: torch.Tensor
-        :raises TypeError: If active aggregation receives a non-floating-point tensor
-        :raises ValueError: If active aggregation receives an invalid shape or an
-            empty time dimension
         """
-        if self.conversion_mode == "eval" and self.training:
+        if not self.always_convert and self.training:
             return x_seq
-
-        _validate_temporal_input(x_seq)
 
         remainder = x_seq.shape[0] % self.num_slots
         if remainder:

--- a/spikingjelly/activation_based/layer/misc.py
+++ b/spikingjelly/activation_based/layer/misc.py
@@ -388,6 +388,7 @@ class SpikeCountToBinary(nn.Module, base.MultiStepModule):
         :param always_convert: 为 ``True`` 时始终展开；为 ``False`` 时仅在推理
             模式展开，默认为 ``False``
         :type always_convert: bool
+        :raises ValueError: 当 ``num_slots < 1`` 时抛出
 
         ----
 
@@ -415,8 +416,11 @@ class SpikeCountToBinary(nn.Module, base.MultiStepModule):
         :param always_convert: ``True`` to always expand, or ``False`` to expand
             only in evaluation mode; defaults to ``False``
         :type always_convert: bool
+        :raises ValueError: If ``num_slots < 1``
         """
         super().__init__()
+        if num_slots < 1:
+            raise ValueError("num_slots must be >= 1.")
         self.num_slots = num_slots
         self.always_convert = always_convert
         self.step_mode = "m"
@@ -437,6 +441,7 @@ class SpikeCountToBinary(nn.Module, base.MultiStepModule):
         :return: 转换激活时返回形状为 ``[T * num_slots, N, *]`` 的二值脉冲；
             否则原样返回 ``x_seq``。输出保持输入的 dtype 和 device
         :rtype: torch.Tensor
+        :raises ValueError: 转换激活且计数包含非有限值、非整数值或越界值时抛出
 
         ----
 
@@ -451,9 +456,23 @@ class SpikeCountToBinary(nn.Module, base.MultiStepModule):
             conversion is active; otherwise ``x_seq`` unchanged. The output keeps
             the input dtype and device
         :rtype: torch.Tensor
+        :raises ValueError: If active conversion receives non-finite,
+            non-integer-valued, or out-of-range counts
         """
         if not self.always_convert and self.training:
             return x_seq
+
+        valid_counts = (
+            torch.isfinite(x_seq)
+            .logical_and(x_seq.eq(x_seq.round()))
+            .logical_and(x_seq.ge(0))
+            .logical_and(x_seq.le(self.num_slots))
+        )
+        if not valid_counts.all().item():
+            raise ValueError(
+                "x_seq must contain finite integer-valued spike counts in "
+                "[0, num_slots]."
+            )
 
         counts = x_seq.unsqueeze(1)
         slots = torch.arange(self.num_slots, device=x_seq.device).view(
@@ -492,6 +511,7 @@ class TemporalBinSum(nn.Module, base.MultiStepModule):
         :param always_convert: 为 ``True`` 时始终聚合；为 ``False`` 时仅在推理
             模式聚合，默认为 ``False``
         :type always_convert: bool
+        :raises ValueError: 当 ``num_slots < 1`` 时抛出
 
         ----
 
@@ -516,8 +536,11 @@ class TemporalBinSum(nn.Module, base.MultiStepModule):
         :param always_convert: ``True`` to always reduce, or ``False`` to reduce
             only in evaluation mode; defaults to ``False``
         :type always_convert: bool
+        :raises ValueError: If ``num_slots < 1``
         """
         super().__init__()
+        if num_slots < 1:
+            raise ValueError("num_slots must be >= 1.")
         self.num_slots = num_slots
         self.always_convert = always_convert
         self.step_mode = "m"

--- a/spikingjelly/activation_based/layer/misc.py
+++ b/spikingjelly/activation_based/layer/misc.py
@@ -435,13 +435,14 @@ class SpikeCountToBinary(nn.Module, base.MultiStepModule):
 
         * **中文**
 
-        :param x_seq: 形状为 ``[T, N, *]``、取值位于 ``[0, num_slots]`` 的
-            浮点整数值脉冲计数
+        :param x_seq: 形状为 ``[T, N, *]``、``T > 0`` 且取值位于
+            ``[0, num_slots]`` 的浮点整数值脉冲计数
         :type x_seq: torch.Tensor
         :return: 转换激活时返回形状为 ``[T * num_slots, N, *]`` 的二值脉冲；
             否则原样返回 ``x_seq``。输出保持输入的 dtype 和 device
         :rtype: torch.Tensor
-        :raises ValueError: 转换激活且计数包含非有限值、非整数值或越界值时抛出
+        :raises ValueError: 转换激活且 ``x_seq`` 不满足 ``[T, N, *]``、
+            ``T > 0`` 时抛出
 
         ----
 
@@ -450,29 +451,20 @@ class SpikeCountToBinary(nn.Module, base.MultiStepModule):
         * **English**
 
         :param x_seq: Floating-point integer-valued spike counts in
-            ``[0, num_slots]`` with shape ``[T, N, *]``
+            ``[0, num_slots]`` with shape ``[T, N, *]`` and ``T > 0``
         :type x_seq: torch.Tensor
         :return: Binary spikes with shape ``[T * num_slots, N, *]`` when
             conversion is active; otherwise ``x_seq`` unchanged. The output keeps
             the input dtype and device
         :rtype: torch.Tensor
-        :raises ValueError: If active conversion receives non-finite,
-            non-integer-valued, or out-of-range counts
+        :raises ValueError: If active conversion receives an input that does not
+            satisfy shape ``[T, N, *]`` and ``T > 0``
         """
         if not self.always_convert and self.training:
             return x_seq
 
-        valid_counts = (
-            torch.isfinite(x_seq)
-            .logical_and(x_seq.eq(x_seq.round()))
-            .logical_and(x_seq.ge(0))
-            .logical_and(x_seq.le(self.num_slots))
-        )
-        if not valid_counts.all().item():
-            raise ValueError(
-                "x_seq must contain finite integer-valued spike counts in "
-                "[0, num_slots]."
-            )
+        if x_seq.ndim < 2 or x_seq.shape[0] == 0:
+            raise ValueError("x_seq must have shape [T, N, *] with T > 0.")
 
         counts = x_seq.unsqueeze(1)
         slots = torch.arange(self.num_slots, device=x_seq.device).view(
@@ -555,12 +547,14 @@ class TemporalBinSum(nn.Module, base.MultiStepModule):
 
         * **中文**
 
-        :param x_seq: 形状为 ``[T, N, *]`` 的非空浮点物理事件槽序列
+        :param x_seq: 形状为 ``[T, N, *]``、``T > 0`` 的浮点物理事件槽序列
         :type x_seq: torch.Tensor
         :return: 聚合激活时返回形状为
             ``[ceil(T / num_slots), N, *]`` 的序列；否则原样返回 ``x_seq``。
             输出保持输入的 dtype 和 device
         :rtype: torch.Tensor
+        :raises ValueError: 聚合激活且 ``x_seq`` 不满足 ``[T, N, *]``、
+            ``T > 0`` 时抛出
 
         ----
 
@@ -568,16 +562,21 @@ class TemporalBinSum(nn.Module, base.MultiStepModule):
 
         * **English**
 
-        :param x_seq: Non-empty floating-point physical event-slot sequence with
-            shape ``[T, N, *]``
+        :param x_seq: Floating-point physical event-slot sequence with shape
+            ``[T, N, *]`` and ``T > 0``
         :type x_seq: torch.Tensor
         :return: A sequence with shape ``[ceil(T / num_slots), N, *]`` when
             aggregation is active; otherwise ``x_seq`` unchanged. The output keeps
             the input dtype and device
         :rtype: torch.Tensor
+        :raises ValueError: If active aggregation receives an input that does not
+            satisfy shape ``[T, N, *]`` and ``T > 0``
         """
         if not self.always_convert and self.training:
             return x_seq
+
+        if x_seq.ndim < 2 or x_seq.shape[0] == 0:
+            raise ValueError("x_seq must have shape [T, N, *] with T > 0.")
 
         remainder = x_seq.shape[0] % self.num_slots
         if remainder:

--- a/spikingjelly/activation_based/layer/misc.py
+++ b/spikingjelly/activation_based/layer/misc.py
@@ -1,4 +1,6 @@
 import math
+import numbers
+from typing import Literal
 
 import torch
 import torch.nn as nn
@@ -13,7 +15,33 @@ __all__ = [
     "PrintShapeModule",
     "VotingLayer",
     "Delay",
+    "SpikeCountToBinary",
+    "TemporalBinSum",
 ]
+
+
+def _validate_temporal_conversion_config(
+    num_slots: int,
+    conversion_mode: Literal["eval", "always"],
+) -> None:
+    if not isinstance(num_slots, numbers.Integral) or isinstance(num_slots, bool):
+        raise TypeError("num_slots must be an integer.")
+    if num_slots < 1:
+        raise ValueError("num_slots must be >= 1.")
+    if conversion_mode not in ("eval", "always"):
+        raise ValueError(
+            'conversion_mode must be either "eval" or "always", '
+            f'but got "{conversion_mode}".'
+        )
+
+
+def _validate_temporal_input(x_seq: torch.Tensor) -> None:
+    if not x_seq.is_floating_point():
+        raise TypeError("x_seq must be a floating-point tensor.")
+    if x_seq.ndim < 2:
+        raise ValueError(f"expected x_seq with shape [T, N, *], but got {x_seq.shape}.")
+    if x_seq.shape[0] == 0:
+        raise ValueError("x_seq must have a non-empty time dimension.")
 
 
 class SynapseFilter(base.MemoryModule):
@@ -348,11 +376,256 @@ class Delay(base.MemoryModule):
         return self._delay_steps
 
     def single_step_forward(self, x: torch.Tensor):
-        y, queue_next = functional.delay_step(
-            x, tuple(self.queue), self.delay_steps
-        )
+        y, queue_next = functional.delay_step(x, tuple(self.queue), self.delay_steps)
         self.queue[:] = queue_next
         return y
 
     def multi_step_forward(self, x_seq: torch.Tensor):
         return functional.delay(x_seq, self.delay_steps)
+
+
+class SpikeCountToBinary(nn.Module, base.MultiStepModule):
+    def __init__(
+        self,
+        num_slots: int,
+        conversion_mode: Literal["eval", "always"] = "eval",
+    ) -> None:
+        r"""
+        **API Language** - :ref:`中文 <SpikeCountToBinary.__init__-cn>` | :ref:`English <SpikeCountToBinary.__init__-en>`
+
+        ----
+
+        .. _SpikeCountToBinary.__init__-cn:
+
+        * **中文**
+
+        将每个非负整数脉冲计数展开为 ``num_slots`` 个二值事件槽。该模块仅支持
+        多步模式，时间维固定为第 0 维。当 ``conversion_mode="eval"`` 时，训练
+        模式返回原输入，推理模式执行展开；``"always"`` 表示始终展开。
+
+        展开激活时使用硬二值前向和直通估计。每个事件槽对输入计数的代理导数为
+        ``1 / num_slots``，因此反向传播会把同一 bin 的槽梯度取平均。若展开后
+        使用同一个无偏置权重层并由 :class:`TemporalBinSum` 求和，则前向、输入
+        梯度和权重梯度均与直接对整数计数执行权重运算等价。偏置、归一化和
+        非线性应放在 :class:`TemporalBinSum` 之后。
+
+        :param num_slots: 每个逻辑时间步包含的二值事件槽数量
+        :type num_slots: int
+        :param conversion_mode: ``"eval"`` 表示仅在推理模式展开，``"always"``
+            表示始终展开
+        :type conversion_mode: Literal["eval", "always"]
+        :raises TypeError: 当 ``num_slots`` 不是整数或为 ``bool`` 时抛出
+        :raises ValueError: 当 ``num_slots < 1`` 或 ``conversion_mode`` 非法时抛出
+
+        ----
+
+        .. _SpikeCountToBinary.__init__-en:
+
+        * **English**
+
+        Expand each non-negative integer spike count into ``num_slots`` binary
+        event slots. This module only supports multi-step mode and fixes the time
+        dimension at dimension 0. With ``conversion_mode="eval"``, training mode
+        returns the input unchanged and evaluation mode performs the expansion;
+        ``"always"`` always performs the expansion.
+
+        Active expansion uses hard binary values in forward and a straight-through
+        estimator whose surrogate derivative is ``1 / num_slots`` for each event
+        slot. Backward therefore averages the slot gradients in each bin. When the
+        same bias-free weight layer processes every slot and
+        :class:`TemporalBinSum` sums the results, the forward values, input
+        gradients, and weight gradients match a direct weight operation on the
+        integer counts. Bias, normalization, and nonlinear operations must follow
+        :class:`TemporalBinSum`.
+
+        :param num_slots: Number of binary event slots per logical timestep
+        :type num_slots: int
+        :param conversion_mode: ``"eval"`` to expand only in evaluation mode, or
+            ``"always"`` to always expand
+        :type conversion_mode: Literal["eval", "always"]
+        :raises TypeError: If ``num_slots`` is not an integer or is ``bool``
+        :raises ValueError: If ``num_slots < 1`` or ``conversion_mode`` is invalid
+        """
+        super().__init__()
+        _validate_temporal_conversion_config(num_slots, conversion_mode)
+        self.num_slots = int(num_slots)
+        self.conversion_mode = conversion_mode
+        self.step_mode = "m"
+
+    def forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+        r"""
+        **API Language** - :ref:`中文 <SpikeCountToBinary.forward-cn>` | :ref:`English <SpikeCountToBinary.forward-en>`
+
+        ----
+
+        .. _SpikeCountToBinary.forward-cn:
+
+        * **中文**
+
+        :param x_seq: 整数值脉冲计数，形状为 ``[T, N, *]``。转换激活时必须为
+            非空浮点张量，所有值必须有限且位于 ``[0, num_slots]``
+        :type x_seq: torch.Tensor
+        :return: 转换激活时返回形状为 ``[T * num_slots, N, *]`` 的二值脉冲；
+            否则原样返回 ``x_seq``。输出保持输入的 dtype 和 device
+        :rtype: torch.Tensor
+        :raises TypeError: 转换激活且 ``x_seq`` 不是浮点张量时抛出
+        :raises ValueError: 转换激活且 ``x_seq`` 形状非法或时间维为空时抛出
+        :raises RuntimeError: 转换激活且计数包含非有限值、非整数值或越界值时抛出
+
+        ----
+
+        .. _SpikeCountToBinary.forward-en:
+
+        * **English**
+
+        :param x_seq: Integer-valued spike counts with shape ``[T, N, *]``. When
+            conversion is active, it must be a non-empty floating-point tensor with
+            finite values in ``[0, num_slots]``
+        :type x_seq: torch.Tensor
+        :return: Binary spikes with shape ``[T * num_slots, N, *]`` when
+            conversion is active; otherwise ``x_seq`` unchanged. The output keeps
+            the input dtype and device
+        :rtype: torch.Tensor
+        :raises TypeError: If active conversion receives a non-floating-point tensor
+        :raises ValueError: If active conversion receives an invalid shape or an
+            empty time dimension
+        :raises RuntimeError: If active conversion receives non-finite,
+            non-integer-valued, or out-of-range counts
+        """
+        if self.conversion_mode == "eval" and self.training:
+            return x_seq
+
+        _validate_temporal_input(x_seq)
+        torch._assert_async(
+            torch.isfinite(x_seq).all(),
+            "x_seq must contain only finite values.",
+        )
+        torch._assert_async(
+            x_seq.eq(x_seq.round()).all(),
+            "x_seq must contain only integer-valued spike counts.",
+        )
+        torch._assert_async(
+            x_seq.ge(0).logical_and(x_seq.le(self.num_slots)).all(),
+            "x_seq spike counts must be in [0, num_slots].",
+        )
+
+        counts = x_seq.unsqueeze(1)
+        slots = torch.arange(self.num_slots, device=x_seq.device).view(
+            1, self.num_slots, *((1,) * (x_seq.ndim - 1))
+        )
+        hard_spikes = (slots < counts).to(x_seq.dtype)
+        proxy = counts / self.num_slots
+        return (hard_spikes + (proxy - proxy.detach())).flatten(0, 1)
+
+
+class TemporalBinSum(nn.Module, base.MultiStepModule):
+    def __init__(
+        self,
+        num_slots: int,
+        conversion_mode: Literal["eval", "always"] = "eval",
+    ) -> None:
+        r"""
+        **API Language** - :ref:`中文 <TemporalBinSum.__init__-cn>` | :ref:`English <TemporalBinSum.__init__-en>`
+
+        ----
+
+        .. _TemporalBinSum.__init__-cn:
+
+        * **中文**
+
+        沿第 0 维将每 ``num_slots`` 个连续时间步求和。最后一个 bin 不完整时
+        在时间维末尾补零。该模块仅支持多步模式。当
+        ``conversion_mode="eval"`` 时，训练模式返回原输入，推理模式执行求和；
+        ``"always"`` 表示始终求和。
+
+        与 :class:`SpikeCountToBinary` 配对时，两者必须使用相同的
+        ``num_slots`` 和 ``conversion_mode``。展开与求和之间的权重层必须禁用
+        bias；归一化和非线性应在求和后执行一次。
+
+        :param num_slots: 每个输出逻辑时间步聚合的物理事件槽数量
+        :type num_slots: int
+        :param conversion_mode: ``"eval"`` 表示仅在推理模式聚合，``"always"``
+            表示始终聚合
+        :type conversion_mode: Literal["eval", "always"]
+        :raises TypeError: 当 ``num_slots`` 不是整数或为 ``bool`` 时抛出
+        :raises ValueError: 当 ``num_slots < 1`` 或 ``conversion_mode`` 非法时抛出
+
+        ----
+
+        .. _TemporalBinSum.__init__-en:
+
+        * **English**
+
+        Sum each ``num_slots`` consecutive timesteps along dimension 0. An
+        incomplete final bin is zero-padded at the end of the time dimension.
+        This module only supports multi-step mode. With
+        ``conversion_mode="eval"``, training mode returns the input unchanged
+        and evaluation mode performs the reduction; ``"always"`` always
+        performs the reduction.
+
+        When paired with :class:`SpikeCountToBinary`, both modules must use the
+        same ``num_slots`` and ``conversion_mode``. The weight layer between
+        expansion and reduction must disable bias; normalization and nonlinear
+        operations must run once after the reduction.
+
+        :param num_slots: Number of physical event slots aggregated into each
+            output logical timestep
+        :type num_slots: int
+        :param conversion_mode: ``"eval"`` to aggregate only in evaluation
+            mode, or ``"always"`` to always aggregate
+        :type conversion_mode: Literal["eval", "always"]
+        :raises TypeError: If ``num_slots`` is not an integer or is ``bool``
+        :raises ValueError: If ``num_slots < 1`` or ``conversion_mode`` is invalid
+        """
+        super().__init__()
+        _validate_temporal_conversion_config(num_slots, conversion_mode)
+        self.num_slots = int(num_slots)
+        self.conversion_mode = conversion_mode
+        self.step_mode = "m"
+
+    def forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+        r"""
+        **API Language** - :ref:`中文 <TemporalBinSum.forward-cn>` | :ref:`English <TemporalBinSum.forward-en>`
+
+        ----
+
+        .. _TemporalBinSum.forward-cn:
+
+        * **中文**
+
+        :param x_seq: 形状为 ``[T, N, *]`` 的非空浮点物理事件槽序列
+        :type x_seq: torch.Tensor
+        :return: 聚合激活时返回形状为
+            ``[ceil(T / num_slots), N, *]`` 的序列；否则原样返回 ``x_seq``。
+            输出保持输入的 dtype 和 device
+        :rtype: torch.Tensor
+        :raises TypeError: 聚合激活且 ``x_seq`` 不是浮点张量时抛出
+        :raises ValueError: 聚合激活且 ``x_seq`` 形状非法或时间维为空时抛出
+
+        ----
+
+        .. _TemporalBinSum.forward-en:
+
+        * **English**
+
+        :param x_seq: Non-empty floating-point physical event-slot sequence with
+            shape ``[T, N, *]``
+        :type x_seq: torch.Tensor
+        :return: A sequence with shape ``[ceil(T / num_slots), N, *]`` when
+            aggregation is active; otherwise ``x_seq`` unchanged. The output keeps
+            the input dtype and device
+        :rtype: torch.Tensor
+        :raises TypeError: If active aggregation receives a non-floating-point tensor
+        :raises ValueError: If active aggregation receives an invalid shape or an
+            empty time dimension
+        """
+        if self.conversion_mode == "eval" and self.training:
+            return x_seq
+
+        _validate_temporal_input(x_seq)
+
+        remainder = x_seq.shape[0] % self.num_slots
+        if remainder:
+            padding = x_seq.new_zeros((self.num_slots - remainder, *x_seq.shape[1:]))
+            x_seq = torch.cat((x_seq, padding))
+        return x_seq.reshape(-1, self.num_slots, *x_seq.shape[1:]).sum(dim=1)

--- a/spikingjelly/activation_based/neuron/ilif.py
+++ b/spikingjelly/activation_based/neuron/ilif.py
@@ -86,6 +86,12 @@ class ILIFNode(LIFNode):
         unary/thermometer 事件槽，不参与神经元状态更新。:class:`ILIFNode`
         只输出整数计数，不负责二值脉冲展开和累加。
 
+        :class:`~spikingjelly.activation_based.layer.misc.SpikeCountToBinary`
+        可以将整数计数展开到时间维，随后由无 bias 权重层处理二值事件；
+        :class:`~spikingjelly.activation_based.layer.misc.TemporalBinSum`
+        将权重层输出还原到逻辑时间维。两者默认在训练模式保持恒等映射、在
+        eval 模式执行转换，从而支持整数训练和二值脉冲推理。
+
         .. warning::
 
             I-LIF 不是传统的二值脉冲神经元。从数值上看，其发放函数是带 LIF
@@ -114,7 +120,11 @@ class ILIFNode(LIFNode):
             每个事件会使 bias 项随事件数变化。对上面的标量计数，结果是
             :math:`W C[t] + C[t] b / D`。这时应先做无 bias 的事件累加，再在
             逻辑时间步结束时加入一次 :math:`b`；归一化和非线性也应在累加完成后
-            执行一次。换言之，I-LIF 使用的标准流程是 ``I-LIF - weight - bin_sum`` 。
+            执行一次。使用 SpikingJelly 提供的转换层时，中间权重层必须设置
+            ``bias=False``；若需要 bias，应在
+            :class:`~spikingjelly.activation_based.layer.misc.TemporalBinSum`
+            之后单独加入。标准流程是
+            ``I-LIF - SpikeCountToBinary - bias-free weight - TemporalBinSum``。
 
             同一逻辑时间步下，I-LIF 每个位置携带 :math:`D+1` 个幅值等级，并可
             触发最多 :math:`D` 个事件；它与每步最多一个事件的二值 IF/LIF
@@ -212,6 +222,14 @@ class ILIFNode(LIFNode):
         :class:`ILIFNode` returns integer counts; it does not expand binary spikes
         or accumulate across them.
 
+        :class:`~spikingjelly.activation_based.layer.misc.SpikeCountToBinary`
+        expands the integer counts along the time dimension so that a bias-free
+        weight layer processes binary events. Then
+        :class:`~spikingjelly.activation_based.layer.misc.TemporalBinSum`
+        restores the logical time dimension. By default, both modules are identity
+        mappings in training mode and perform their conversions in evaluation mode,
+        enabling integer-valued training and binary-spike inference.
+
         .. warning::
 
             I-LIF is not a conventional binary spiking neuron. Numerically, its
@@ -245,9 +263,12 @@ class ILIFNode(LIFNode):
             :math:`W C[t] + C[t] b / D`. In that case, events should first be
             accumulated with a bias-free weight operation, and :math:`b` should be
             added once at the end of the logical timestep. Normalization and
-            nonlinear operations should likewise run once after accumulation.
-            In other words, the standard I-LIF flow is
-            ``I-LIF - weight - bin_sum``.
+            nonlinear operations should likewise run once after accumulation. When
+            using the SpikingJelly conversion layers, the intervening weight layer
+            must set ``bias=False``; add any required bias once after
+            :class:`~spikingjelly.activation_based.layer.misc.TemporalBinSum`. The
+            standard flow is
+            ``I-LIF - SpikeCountToBinary - bias-free weight - TemporalBinSum``.
 
             At the same logical timestep count, I-LIF carries :math:`D+1`
             amplitude levels per position and may trigger up to :math:`D` events.

--- a/test/activation_based/test_ilif_node.py
+++ b/test/activation_based/test_ilif_node.py
@@ -1,7 +1,13 @@
 import pytest
 import torch
 
-from spikingjelly.activation_based import neuron, surrogate
+from spikingjelly.activation_based import (
+    functional,
+    layer,
+    neuron,
+    op_counter,
+    surrogate,
+)
 
 
 def _assert_close(actual: torch.Tensor, expected: torch.Tensor):
@@ -9,6 +15,301 @@ def _assert_close(actual: torch.Tensor, expected: torch.Tensor):
         torch.testing.assert_close(actual, expected)
     else:
         torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+
+
+def test_spike_count_to_binary_expands_only_in_eval_by_default():
+    converter = layer.SpikeCountToBinary(num_slots=4)
+    counts = torch.tensor(
+        [
+            [[0.0, 2.0, 4.0]],
+            [[3.0, 1.0, 0.0]],
+        ]
+    )
+
+    assert converter.step_mode == "m"
+    assert converter.supported_step_mode() == ("m",)
+    assert converter(counts) is counts
+
+    converter.eval()
+    spikes = converter(counts)
+    expected = torch.tensor(
+        [
+            [[0.0, 1.0, 1.0]],
+            [[0.0, 1.0, 1.0]],
+            [[0.0, 0.0, 1.0]],
+            [[0.0, 0.0, 1.0]],
+            [[1.0, 1.0, 0.0]],
+            [[1.0, 0.0, 0.0]],
+            [[1.0, 0.0, 0.0]],
+            [[0.0, 0.0, 0.0]],
+        ]
+    )
+
+    assert torch.equal(spikes, expected)
+    functional.set_step_mode(converter, "m")
+    with pytest.raises(ValueError, match="step_mode can only be"):
+        functional.set_step_mode(converter, "s")
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float16, torch.bfloat16, torch.float32, torch.float64],
+)
+@pytest.mark.parametrize(
+    "device",
+    ["cpu"] + (["cuda"] if torch.cuda.is_available() else []),
+)
+def test_spike_count_to_binary_preserves_dtype_device_and_counts(dtype, device):
+    counts = torch.tensor([[[0.0, 1.0, 2.0, 3.0]]], dtype=dtype, device=device)
+    spikes = layer.SpikeCountToBinary(3, conversion_mode="always")(counts)
+
+    assert spikes.dtype == counts.dtype
+    assert spikes.device == counts.device
+    assert torch.all(spikes.eq(0).logical_or(spikes.eq(1)))
+    assert torch.equal(spikes.reshape(1, 3, 1, 4).sum(dim=1), counts)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float16, torch.bfloat16, torch.float32, torch.float64],
+)
+@pytest.mark.parametrize(
+    "device",
+    ["cpu"] + (["cuda"] if torch.cuda.is_available() else []),
+)
+def test_temporal_bin_sum_pads_the_final_bin_only_in_eval_by_default(dtype, device):
+    reducer = layer.TemporalBinSum(num_slots=4)
+    x_seq = torch.arange(10, dtype=dtype, device=device).reshape(5, 2).requires_grad_()
+
+    assert reducer.step_mode == "m"
+    assert reducer.supported_step_mode() == ("m",)
+    assert reducer(x_seq) is x_seq
+
+    reducer.eval()
+    output = reducer(x_seq)
+
+    assert output.dtype == x_seq.dtype
+    assert output.device == x_seq.device
+    torch.testing.assert_close(
+        output,
+        torch.tensor(
+            [
+                [12.0, 16.0],
+                [8.0, 9.0],
+            ],
+            dtype=dtype,
+            device=device,
+        ),
+    )
+    output.sum().backward()
+    torch.testing.assert_close(x_seq.grad, torch.ones_like(x_seq))
+
+    functional.set_step_mode(reducer, "m")
+    with pytest.raises(ValueError, match="step_mode can only be"):
+        functional.set_step_mode(reducer, "s")
+
+
+@pytest.mark.parametrize(
+    "module_type",
+    [layer.SpikeCountToBinary, layer.TemporalBinSum],
+)
+def test_ilif_temporal_conversion_modules_validate_their_configuration(module_type):
+    for num_slots in (1.5, False):
+        with pytest.raises(TypeError, match="num_slots must be an integer"):
+            module_type(num_slots=num_slots)
+    for num_slots in (0, -1):
+        with pytest.raises(ValueError, match="num_slots must be >= 1"):
+            module_type(num_slots=num_slots)
+    with pytest.raises(ValueError, match="conversion_mode"):
+        module_type(num_slots=4, conversion_mode="invalid")
+
+    module = module_type(num_slots=2, conversion_mode="always")
+    x_seq = torch.ones(2, 1)
+    assert module(x_seq) is not x_seq
+
+
+def test_spike_count_to_binary_rejects_invalid_active_inputs():
+    converter = layer.SpikeCountToBinary(num_slots=4, conversion_mode="always")
+
+    with pytest.raises(TypeError, match="floating-point"):
+        converter(torch.ones(2, 1, dtype=torch.int64))
+    for shape in ((), (2,)):
+        with pytest.raises(ValueError, match=r"\[T, N, \*\]"):
+            converter(torch.ones(shape))
+    with pytest.raises(ValueError, match="non-empty time dimension"):
+        converter(torch.empty(0, 1))
+
+    invalid_counts = [
+        (float("nan"), "finite"),
+        (float("inf"), "finite"),
+        (1.5, "integer-valued"),
+        (-1.0, r"\[0, num_slots\]"),
+        (5.0, r"\[0, num_slots\]"),
+    ]
+    for value, message in invalid_counts:
+        with pytest.raises(RuntimeError, match=message):
+            converter(torch.tensor([[value]]))
+
+
+def test_temporal_bin_sum_rejects_invalid_active_inputs():
+    reducer = layer.TemporalBinSum(num_slots=4, conversion_mode="always")
+
+    with pytest.raises(TypeError, match="floating-point"):
+        reducer(torch.ones(2, 1, dtype=torch.int64))
+    for shape in ((), (2,)):
+        with pytest.raises(ValueError, match=r"\[T, N, \*\]"):
+            reducer(torch.ones(shape))
+    with pytest.raises(ValueError, match="non-empty time dimension"):
+        reducer(torch.empty(0, 1))
+
+
+def test_binary_slot_linear_path_matches_integer_forward_and_backward():
+    torch.manual_seed(7)
+    num_slots = 4
+    integer_counts = torch.tensor(
+        [
+            [[0.0, 1.0, 2.0], [3.0, 4.0, 1.0]],
+            [[4.0, 2.0, 0.0], [1.0, 3.0, 2.0]],
+        ],
+        requires_grad=True,
+    )
+    spike_counts = integer_counts.detach().clone().requires_grad_()
+    integer_weight = layer.Linear(3, 5, bias=False, step_mode="m")
+    spike_weight = layer.Linear(3, 5, bias=False, step_mode="m")
+    spike_weight.load_state_dict(integer_weight.state_dict())
+    converter = layer.SpikeCountToBinary(num_slots, conversion_mode="always")
+    reducer = layer.TemporalBinSum(num_slots, conversion_mode="always")
+    upstream = torch.randn(2, 2, 5)
+
+    integer_output = integer_weight(integer_counts)
+    spike_output = reducer(spike_weight(converter(spike_counts)))
+
+    torch.testing.assert_close(spike_output, integer_output)
+    (integer_output * upstream).sum().backward()
+    (spike_output * upstream).sum().backward()
+    torch.testing.assert_close(spike_counts.grad, integer_counts.grad)
+    torch.testing.assert_close(spike_weight.weight.grad, integer_weight.weight.grad)
+
+
+def test_binary_slot_conv_path_matches_integer_forward_and_backward():
+    torch.manual_seed(11)
+    num_slots = 4
+    integer_counts = (
+        torch.randint(0, num_slots + 1, (3, 2, 2, 4, 4)).float().requires_grad_()
+    )
+    spike_counts = integer_counts.detach().clone().requires_grad_()
+    integer_weight = layer.Conv2d(
+        2,
+        3,
+        kernel_size=3,
+        padding=1,
+        bias=False,
+        step_mode="m",
+    )
+    spike_weight = layer.Conv2d(
+        2,
+        3,
+        kernel_size=3,
+        padding=1,
+        bias=False,
+        step_mode="m",
+    )
+    spike_weight.load_state_dict(integer_weight.state_dict())
+    converter = layer.SpikeCountToBinary(num_slots, conversion_mode="always")
+    reducer = layer.TemporalBinSum(num_slots, conversion_mode="always")
+    upstream = torch.randn(3, 2, 3, 4, 4)
+
+    integer_output = integer_weight(integer_counts)
+    spike_output = reducer(spike_weight(converter(spike_counts)))
+
+    torch.testing.assert_close(spike_output, integer_output)
+    (integer_output * upstream).sum().backward()
+    (spike_output * upstream).sum().backward()
+    torch.testing.assert_close(spike_counts.grad, integer_counts.grad)
+    torch.testing.assert_close(spike_weight.weight.grad, integer_weight.weight.grad)
+
+
+def test_binary_slot_path_preserves_ilif_bptt_gradients():
+    torch.manual_seed(13)
+    num_slots = 4
+    integer_node = neuron.ILIFNode(step_mode="m")
+    spike_node = neuron.ILIFNode(step_mode="m")
+    integer_weight = layer.Linear(3, 2, bias=False, step_mode="m")
+    spike_weight = layer.Linear(3, 2, bias=False, step_mode="m")
+    spike_weight.load_state_dict(integer_weight.state_dict())
+    converter = layer.SpikeCountToBinary(num_slots, conversion_mode="always")
+    reducer = layer.TemporalBinSum(num_slots, conversion_mode="always")
+    integer_input = torch.tensor(
+        [
+            [[0.2, 1.2, 2.2]],
+            [[1.1, 0.3, 3.2]],
+            [[0.4, 2.1, 0.2]],
+        ],
+        requires_grad=True,
+    )
+    spike_input = integer_input.detach().clone().requires_grad_()
+    upstream = torch.randn(3, 1, 2)
+
+    integer_output = integer_weight(integer_node(integer_input))
+    spike_output = reducer(spike_weight(converter(spike_node(spike_input))))
+
+    torch.testing.assert_close(spike_output, integer_output)
+    (integer_output * upstream).sum().backward()
+    (spike_output * upstream).sum().backward()
+    torch.testing.assert_close(spike_input.grad, integer_input.grad)
+    torch.testing.assert_close(spike_weight.weight.grad, integer_weight.weight.grad)
+
+
+def test_default_conversion_modules_enable_integer_training_and_binary_eval():
+    num_slots = 4
+    training_model = torch.nn.Sequential(
+        neuron.ILIFNode(step_mode="m"),
+        layer.SpikeCountToBinary(num_slots),
+        layer.Linear(3, 2, bias=False, step_mode="m"),
+        layer.TemporalBinSum(num_slots),
+    )
+    evaluation_model = torch.nn.Sequential(
+        neuron.ILIFNode(step_mode="m"),
+        layer.SpikeCountToBinary(num_slots),
+        layer.Linear(3, 2, bias=False, step_mode="m"),
+        layer.TemporalBinSum(num_slots),
+    ).eval()
+    evaluation_model.load_state_dict(training_model.state_dict())
+    x_seq = torch.tensor(
+        [
+            [[0.2, 1.2, 2.2]],
+            [[1.1, 0.3, 3.2]],
+            [[0.4, 2.1, 0.2]],
+        ]
+    )
+
+    training_output = training_model(x_seq)
+    evaluation_output = evaluation_model(x_seq)
+
+    assert training_output.shape == evaluation_output.shape == (3, 1, 2)
+    torch.testing.assert_close(evaluation_output, training_output)
+
+
+def test_binary_slot_weight_path_is_counted_as_synaptic_accumulation():
+    counts = torch.tensor(
+        [
+            [[0.0, 1.0, 2.0], [3.0, 4.0, 1.0]],
+            [[4.0, 2.0, 0.0], [1.0, 3.0, 2.0]],
+        ]
+    )
+    spikes = layer.SpikeCountToBinary(4, conversion_mode="always")(counts)
+    weight = layer.Linear(3, 5, bias=False, step_mode="m")
+    mac_counter = op_counter.MACCounter()
+    ac_counter = op_counter.ACCounter()
+    synop_counter = op_counter.SynOpCounter()
+
+    with op_counter.DispatchCounterMode([mac_counter, ac_counter, synop_counter]):
+        weight(spikes)
+
+    expected_synops = int(spikes.count_nonzero()) * weight.out_features
+    assert mac_counter.get_total() == 0
+    assert ac_counter.get_total() == expected_synops
+    assert synop_counter.get_total() == expected_synops
 
 
 def _safe_ilif_sequence(tau: float, dtype: torch.dtype):

--- a/test/activation_based/test_ilif_node.py
+++ b/test/activation_based/test_ilif_node.py
@@ -109,6 +109,30 @@ def test_temporal_bin_sum_pads_the_final_bin_only_in_eval_by_default(dtype, devi
         functional.set_step_mode(reducer, "s")
 
 
+@pytest.mark.parametrize(
+    "module_type",
+    [layer.SpikeCountToBinary, layer.TemporalBinSum],
+)
+def test_ilif_temporal_conversion_modules_require_nonzero_slots(module_type):
+    with pytest.raises(ValueError, match="num_slots must be >= 1"):
+        module_type(num_slots=0)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [float("nan"), float("inf"), 1.5, -1.0, 5.0],
+)
+@pytest.mark.parametrize(
+    "device",
+    ["cpu"] + (["cuda"] if torch.cuda.is_available() else []),
+)
+def test_spike_count_to_binary_rejects_silently_invalid_counts(value, device):
+    converter = layer.SpikeCountToBinary(num_slots=4, always_convert=True)
+
+    with pytest.raises(ValueError, match="finite integer-valued spike counts"):
+        converter(torch.tensor([[value]], device=device))
+
+
 def test_binary_slot_linear_path_matches_integer_forward_and_backward():
     torch.manual_seed(7)
     num_slots = 4

--- a/test/activation_based/test_ilif_node.py
+++ b/test/activation_based/test_ilif_node.py
@@ -61,7 +61,7 @@ def test_spike_count_to_binary_expands_only_in_eval_by_default():
 )
 def test_spike_count_to_binary_preserves_dtype_device_and_counts(dtype, device):
     counts = torch.tensor([[[0.0, 1.0, 2.0, 3.0]]], dtype=dtype, device=device)
-    spikes = layer.SpikeCountToBinary(3, conversion_mode="always")(counts)
+    spikes = layer.SpikeCountToBinary(3, always_convert=True)(counts)
 
     assert spikes.dtype == counts.dtype
     assert spikes.device == counts.device
@@ -109,60 +109,6 @@ def test_temporal_bin_sum_pads_the_final_bin_only_in_eval_by_default(dtype, devi
         functional.set_step_mode(reducer, "s")
 
 
-@pytest.mark.parametrize(
-    "module_type",
-    [layer.SpikeCountToBinary, layer.TemporalBinSum],
-)
-def test_ilif_temporal_conversion_modules_validate_their_configuration(module_type):
-    for num_slots in (1.5, False):
-        with pytest.raises(TypeError, match="num_slots must be an integer"):
-            module_type(num_slots=num_slots)
-    for num_slots in (0, -1):
-        with pytest.raises(ValueError, match="num_slots must be >= 1"):
-            module_type(num_slots=num_slots)
-    with pytest.raises(ValueError, match="conversion_mode"):
-        module_type(num_slots=4, conversion_mode="invalid")
-
-    module = module_type(num_slots=2, conversion_mode="always")
-    x_seq = torch.ones(2, 1)
-    assert module(x_seq) is not x_seq
-
-
-def test_spike_count_to_binary_rejects_invalid_active_inputs():
-    converter = layer.SpikeCountToBinary(num_slots=4, conversion_mode="always")
-
-    with pytest.raises(TypeError, match="floating-point"):
-        converter(torch.ones(2, 1, dtype=torch.int64))
-    for shape in ((), (2,)):
-        with pytest.raises(ValueError, match=r"\[T, N, \*\]"):
-            converter(torch.ones(shape))
-    with pytest.raises(ValueError, match="non-empty time dimension"):
-        converter(torch.empty(0, 1))
-
-    invalid_counts = [
-        (float("nan"), "finite"),
-        (float("inf"), "finite"),
-        (1.5, "integer-valued"),
-        (-1.0, r"\[0, num_slots\]"),
-        (5.0, r"\[0, num_slots\]"),
-    ]
-    for value, message in invalid_counts:
-        with pytest.raises(RuntimeError, match=message):
-            converter(torch.tensor([[value]]))
-
-
-def test_temporal_bin_sum_rejects_invalid_active_inputs():
-    reducer = layer.TemporalBinSum(num_slots=4, conversion_mode="always")
-
-    with pytest.raises(TypeError, match="floating-point"):
-        reducer(torch.ones(2, 1, dtype=torch.int64))
-    for shape in ((), (2,)):
-        with pytest.raises(ValueError, match=r"\[T, N, \*\]"):
-            reducer(torch.ones(shape))
-    with pytest.raises(ValueError, match="non-empty time dimension"):
-        reducer(torch.empty(0, 1))
-
-
 def test_binary_slot_linear_path_matches_integer_forward_and_backward():
     torch.manual_seed(7)
     num_slots = 4
@@ -177,8 +123,8 @@ def test_binary_slot_linear_path_matches_integer_forward_and_backward():
     integer_weight = layer.Linear(3, 5, bias=False, step_mode="m")
     spike_weight = layer.Linear(3, 5, bias=False, step_mode="m")
     spike_weight.load_state_dict(integer_weight.state_dict())
-    converter = layer.SpikeCountToBinary(num_slots, conversion_mode="always")
-    reducer = layer.TemporalBinSum(num_slots, conversion_mode="always")
+    converter = layer.SpikeCountToBinary(num_slots, always_convert=True)
+    reducer = layer.TemporalBinSum(num_slots, always_convert=True)
     upstream = torch.randn(2, 2, 5)
 
     integer_output = integer_weight(integer_counts)
@@ -215,8 +161,8 @@ def test_binary_slot_conv_path_matches_integer_forward_and_backward():
         step_mode="m",
     )
     spike_weight.load_state_dict(integer_weight.state_dict())
-    converter = layer.SpikeCountToBinary(num_slots, conversion_mode="always")
-    reducer = layer.TemporalBinSum(num_slots, conversion_mode="always")
+    converter = layer.SpikeCountToBinary(num_slots, always_convert=True)
+    reducer = layer.TemporalBinSum(num_slots, always_convert=True)
     upstream = torch.randn(3, 2, 3, 4, 4)
 
     integer_output = integer_weight(integer_counts)
@@ -237,8 +183,8 @@ def test_binary_slot_path_preserves_ilif_bptt_gradients():
     integer_weight = layer.Linear(3, 2, bias=False, step_mode="m")
     spike_weight = layer.Linear(3, 2, bias=False, step_mode="m")
     spike_weight.load_state_dict(integer_weight.state_dict())
-    converter = layer.SpikeCountToBinary(num_slots, conversion_mode="always")
-    reducer = layer.TemporalBinSum(num_slots, conversion_mode="always")
+    converter = layer.SpikeCountToBinary(num_slots, always_convert=True)
+    reducer = layer.TemporalBinSum(num_slots, always_convert=True)
     integer_input = torch.tensor(
         [
             [[0.2, 1.2, 2.2]],
@@ -297,7 +243,7 @@ def test_binary_slot_weight_path_is_counted_as_synaptic_accumulation():
             [[4.0, 2.0, 0.0], [1.0, 3.0, 2.0]],
         ]
     )
-    spikes = layer.SpikeCountToBinary(4, conversion_mode="always")(counts)
+    spikes = layer.SpikeCountToBinary(4, always_convert=True)(counts)
     weight = layer.Linear(3, 5, bias=False, step_mode="m")
     mac_counter = op_counter.MACCounter()
     ac_counter = op_counter.ACCounter()

--- a/test/activation_based/test_ilif_node.py
+++ b/test/activation_based/test_ilif_node.py
@@ -119,18 +119,15 @@ def test_ilif_temporal_conversion_modules_require_nonzero_slots(module_type):
 
 
 @pytest.mark.parametrize(
-    "value",
-    [float("nan"), float("inf"), 1.5, -1.0, 5.0],
+    "module_type",
+    [layer.SpikeCountToBinary, layer.TemporalBinSum],
 )
-@pytest.mark.parametrize(
-    "device",
-    ["cpu"] + (["cuda"] if torch.cuda.is_available() else []),
-)
-def test_spike_count_to_binary_rejects_silently_invalid_counts(value, device):
-    converter = layer.SpikeCountToBinary(num_slots=4, always_convert=True)
+def test_ilif_temporal_conversion_modules_reject_silent_shape_errors(module_type):
+    module = module_type(num_slots=4, always_convert=True)
 
-    with pytest.raises(ValueError, match="finite integer-valued spike counts"):
-        converter(torch.tensor([[value]], device=device))
+    for x_seq in (torch.ones(2), torch.empty(0, 1)):
+        with pytest.raises(ValueError, match=r"shape \[T, N, \*\] with T > 0"):
+            module(x_seq)
 
 
 def test_binary_slot_linear_path_matches_integer_forward_and_backward():


### PR DESCRIPTION
## Summary

- add multi-step SpikeCountToBinary and TemporalBinSum layers in the existing layer.misc module
- preserve integer training by default while enabling binary-event evaluation around bias-free weight layers
- document the STE/bin-sum gradient contract, topology constraints, and operation-counting semantics
- add forward/backward equivalence tests for Linear, Conv2d, and ILIF BPTT, plus dtype, device, validation, step-mode, and MAC/AC/SynOp coverage

## Validation

- 58 passed, 56 skipped: ILIF, misc, MAC, AC, and SynOp test suites
- changed-file format check and git diff check
- changelog generator check
- full Sphinx HTML build
- two-axis standards/spec review: no open findings

CUDA/Triton-only cases are conditionally skipped on this CPU-only host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added integer-valued spike conversion for multi-step I-LIF networks.
  * Added conversion of spike counts into binary event slots and temporal bin aggregation, including zero-padding for incomplete bins.
  * Supports configurable training and evaluation behavior while preserving gradients.

* **Documentation**
  * Added usage guidance, constraints, examples, and I-LIF integration details.

* **Tests**
  * Expanded coverage for validation, device and data type handling, gradients, model integration, and operation counting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->