### PR TITLE
refactor(activation_based): make memory modules functional-backed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,31 +30,12 @@ Module: `spikingjelly`.
 Modules: `spikingjelly.activation_based.functional` and
 `spikingjelly.activation_based.base`.
 
-- Added explicit tensor-state APIs for modules with state-update semantics,
-  including LIAF, I-LIF, MaskedPSN, NeuNorm, delay and synaptic filters,
-  learning traces, and SpikeZIP STBIF updates. Reusable LIF charging and
-  voltage-reset primitives are also available for neuron variants that insert
-  operations between charge, fire, and reset. Existing modules retain their
-  public state, lifecycle, backend selection, and output behavior.
-- State-update APIs use `*_step` for one complete update and `*_multi_step` only for
-  independently implemented sequence paths. Supported CuPy, Triton, and
-  Inductor paths identify their backend in the function name.
-- Fixed MaskedPSN single-step execution for inputs with more than one dimension.
-- The Inductor neuron multi-step implementation is the single source of its state-update equation
-  and shares a bounded process-local compiled-graph cache.
-- Hookable Node classes retain their existing execution paths; their standard
-  transitions are also available as independent functional APIs.
-- Added FlexSN custom-op registry diagnostics for entry, owner-reference, and
-  active-reference counts.
-- Added grouped `MemoryModule.functional_forward` interfaces and changed
-  `to_functional_forward` to return
-  `(inputs, states) -> (outputs, updated_states)`. Regular forward paths for the
-  framework's stateful modules now use native functional transitions. Multi-step
-  execution loops the single-step transition by default; sequence kernels may
-  override it. Sequential modules compose child transitions directly, while other
-  composite modules use the state-substitution fallback.
-- Added `MemoryModule.materialize_states(inputs, states, step_mode)` for converting
-  input-dependent states before functional execution.
+- Added explicit-state functional execution across the framework's stateful
+  modules while preserving regular stateful forward behavior.
+- Regular and functional forward paths now share state transitions, with optimized
+  multi-step implementations retained where needed.
+- Functional conversion now covers native, composite, and user-defined modules,
+  while optional execution traces remain separate from recurrent state.
 
 #### ANN-to-SNN Conversion
 
@@ -228,10 +209,10 @@ Module: `spikingjelly.activation_based.base`.
 
 Module: `spikingjelly.activation_based.neuron`.
 
-- **Breaking change:** `BaseNode` now defines production neurons solely through
-  functional state transitions and no longer provides `neuronal_charge()`,
-  `neuronal_fire()`, or `neuronal_reset()`. Existing custom neurons that inherit
-  `BaseNode` and override these hooks must use `SimpleBaseNode` or implement
+- **Breaking change:** production neuron classes now define their dynamics solely
+  through functional state transitions and no longer provide
+  `neuronal_charge()`, `neuronal_fire()`, or `neuronal_reset()`. Custom neurons
+  that override these hooks must use `SimpleBaseNode` or implement
   `single_step_functional_forward()`.
 - **Breaking change:** removed `BaseNode.v_float_to_tensor()`. Custom functional
   modules that require input-dependent state initialization should override

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,14 +31,15 @@ Modules: `spikingjelly.activation_based.functional` and
 `spikingjelly.activation_based.base`.
 
 - Added explicit tensor-state APIs for modules with state-update semantics,
-  including neurons, delay and synaptic filters, learning traces, and SpikeZIP
-  STBIF updates. Reusable LIF charging and voltage-reset primitives are also
-  available for neuron variants that insert operations between charge, fire,
-  and reset. Existing modules retain their public state, lifecycle, backend
-  selection, and output behavior.
+  including LIAF, I-LIF, MaskedPSN, NeuNorm, delay and synaptic filters,
+  learning traces, and SpikeZIP STBIF updates. Reusable LIF charging and
+  voltage-reset primitives are also available for neuron variants that insert
+  operations between charge, fire, and reset. Existing modules retain their
+  public state, lifecycle, backend selection, and output behavior.
 - State-update APIs use `*_step` for one complete update and `*_multi_step` only for
   independently implemented sequence paths. Supported CuPy, Triton, and
   Inductor paths identify their backend in the function name.
+- Fixed MaskedPSN single-step execution for inputs with more than one dimension.
 - The Inductor neuron multi-step implementation is the single source of its state-update equation
   and shares a bounded process-local compiled-graph cache.
 - Hookable Node classes retain their existing execution paths; their standard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ Modules: `spikingjelly.activation_based.functional` and
 
 - Added explicit tensor-state APIs for modules with state-update semantics,
   including neurons, delay and synaptic filters, learning traces, and SpikeZIP
-  STBIF updates. Existing modules retain their public state, lifecycle, backend
+  STBIF updates. Reusable LIF charging and voltage-reset primitives are also
+  available for neuron variants that insert operations between charge, fire,
+  and reset. Existing modules retain their public state, lifecycle, backend
   selection, and output behavior.
 - State-update APIs use `*_step` for one complete update and `*_multi_step` only for
   independently implemented sequence paths. Supported CuPy, Triton, and
@@ -46,21 +48,12 @@ Modules: `spikingjelly.activation_based.functional` and
 - Added grouped `MemoryModule.functional_forward` interfaces and changed
   `to_functional_forward` to return
   `(inputs, states) -> (outputs, updated_states)`. Regular forward paths for the
-  framework's stateful neurons, layers, encoders, recurrent containers, temporal
-  ANN-to-SNN operators, and transformer conversion modules are now backed by
-  their native functional transition. The default multi-step implementation
-  rolls the single-step transition over time, while sequence kernels override it.
-  Sequential modules compose child transitions directly and arbitrary composite
-  modules use a dictionary-swap fallback. Custom production `MemoryModule` and
-  `BaseNode` subclasses should implement `single_step_functional_forward` and
-  override `multi_step_functional_forward` only when they provide a specialized
-  sequence implementation. `SimpleBaseNode`, `SimpleIFNode`, and `SimpleLIFNode`
-  retain the charge-fire-reset forward model for equation experiments and use the
-  general state-substitution path when converted.
-- Added `MemoryModule.materialize_states(inputs, states, step_mode)` as the
-  single hook for converting registered scalar or empty states into
-  input-dependent states before functional execution. Its default implementation
-  returns states unchanged.
+  framework's stateful modules now use native functional transitions. Multi-step
+  execution loops the single-step transition by default; sequence kernels may
+  override it. Sequential modules compose child transitions directly, while other
+  composite modules use the state-substitution fallback.
+- Added `MemoryModule.materialize_states(inputs, states, step_mode)` for converting
+  input-dependent states before functional execution.
 
 #### ANN-to-SNN Conversion
 
@@ -237,17 +230,14 @@ Module: `spikingjelly.activation_based.neuron`.
 - **Breaking change:** `BaseNode` now defines production neurons solely through
   functional state transitions and no longer provides `neuronal_charge()`,
   `neuronal_fire()`, or `neuronal_reset()`. Existing custom neurons that inherit
-  `BaseNode` and override these hooks must either change their base class to
-  `SimpleBaseNode` to retain the charge-fire-reset extension model, or implement
-  `single_step_functional_forward()` for a native-functional production neuron.
-  `to_functional_forward()` converts `SimpleBaseNode` through the general
-  state-substitution path. Built-in production neurons such as `IFNode` and
-  `LIFNode` use native functional transitions and their specialized sequence
-  kernels.
+  `BaseNode` and override these hooks must use `SimpleBaseNode` or implement
+  `single_step_functional_forward()`.
 - **Breaking change:** removed `BaseNode.v_float_to_tensor()`. Custom functional
   modules that require input-dependent state initialization should override
-  `materialize_states(inputs, states, step_mode)` and return a new state tuple
-  without mutating module memory.
+  `materialize_states(inputs, states, step_mode)`.
+- **Breaking change:** sequence caches such as `v_seq`, `i_seq`, and `state_seqs`
+  are no longer functional states. Functional forward returns only recurrent
+  states; regular multi-step forward stores the requested sequences on the module.
 - **Breaking change:** `MemoryModule` subclasses without functional or regular
   forward semantics now raise `NotImplementedError` when called. Stateful
   learners such as `STDPLearner`, `MSTDPLearner`, and `MSTDPETLearner` continue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ Module: `spikingjelly`.
 
 #### Functional State Transitions
 
-Module: `spikingjelly.activation_based.functional`.
+Modules: `spikingjelly.activation_based.functional` and
+`spikingjelly.activation_based.base`.
 
 - Added explicit tensor-state APIs for modules with state-update semantics,
   including neurons, delay and synaptic filters, learning traces, and SpikeZIP
@@ -42,6 +43,24 @@ Module: `spikingjelly.activation_based.functional`.
   transitions are also available as independent functional APIs.
 - Added FlexSN custom-op registry diagnostics for entry, owner-reference, and
   active-reference counts.
+- Added grouped `MemoryModule.functional_forward` interfaces and changed
+  `to_functional_forward` to return
+  `(inputs, states) -> (outputs, updated_states)`. Regular forward paths for the
+  framework's stateful neurons, layers, encoders, recurrent containers, temporal
+  ANN-to-SNN operators, and transformer conversion modules are now backed by
+  their native functional transition. The default multi-step implementation
+  rolls the single-step transition over time, while sequence kernels override it.
+  Sequential modules compose child transitions directly and arbitrary composite
+  modules use a dictionary-swap fallback. Custom production `MemoryModule` and
+  `BaseNode` subclasses should implement `single_step_functional_forward` and
+  override `multi_step_functional_forward` only when they provide a specialized
+  sequence implementation. `SimpleBaseNode`, `SimpleIFNode`, and `SimpleLIFNode`
+  retain the charge-fire-reset forward model for equation experiments and use the
+  general state-substitution path when converted.
+- Added `MemoryModule.materialize_states(inputs, states, step_mode)` as the
+  single hook for converting registered scalar or empty states into
+  input-dependent states before functional execution. Its default implementation
+  returns states unchanged.
 
 #### ANN-to-SNN Conversion
 
@@ -198,6 +217,41 @@ Module: `spikingjelly.activation_based.triton_kernel.neuron_kernel`.
   membrane potential.
 
 ### Breaking Changes and Notices
+
+#### Functional Forward API Changes
+
+Module: `spikingjelly.activation_based.base`.
+
+- **Breaking change:** `to_functional_forward()` now returns a function with the
+  grouped interface
+  `(inputs, states, **kwargs) -> (outputs, updated_states)`. Both `inputs` and
+  `outputs` remain tuples when they contain one tensor. Replace calls such as
+  `output, state = forward(x, state)` with
+  `outputs, states = forward((x,), (state,))` and read the single output from
+  `outputs[0]`.
+
+#### Neuron Extension API Changes
+
+Module: `spikingjelly.activation_based.neuron`.
+
+- **Breaking change:** `BaseNode` now defines production neurons solely through
+  functional state transitions and no longer provides `neuronal_charge()`,
+  `neuronal_fire()`, or `neuronal_reset()`. Existing custom neurons that inherit
+  `BaseNode` and override these hooks must either change their base class to
+  `SimpleBaseNode` to retain the charge-fire-reset extension model, or implement
+  `single_step_functional_forward()` for a native-functional production neuron.
+  `to_functional_forward()` converts `SimpleBaseNode` through the general
+  state-substitution path. Built-in production neurons such as `IFNode` and
+  `LIFNode` use native functional transitions and their specialized sequence
+  kernels.
+- **Breaking change:** removed `BaseNode.v_float_to_tensor()`. Custom functional
+  modules that require input-dependent state initialization should override
+  `materialize_states(inputs, states, step_mode)` and return a new state tuple
+  without mutating module memory.
+- **Breaking change:** `MemoryModule` subclasses without functional or regular
+  forward semantics now raise `NotImplementedError` when called. Stateful
+  learners such as `STDPLearner`, `MSTDPLearner`, and `MSTDPETLearner` continue
+  to expose their computation through `step()`.
 
 #### Logging-Controlled Diagnostics
 

--- a/docs/source/APIs/spikingjelly.activation_based.examples.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.examples.rst
@@ -111,6 +111,7 @@ DQN\_state
    :members:
    :undoc-members:
    :show-inheritance:
+   :exclude-members: NonSpikingLIFNode
 
 PPO
 --------------------------------------------------

--- a/docs/source/APIs/spikingjelly.activation_based.neuron.core.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.neuron.core.rst
@@ -40,7 +40,7 @@ Integrate-and-fire (IF) Neurons
    :members:
    :undoc-members:
    :show-inheritance:
-   :exclude-members: supported_backends, jit_eval_single_step_forward_hard_reset, jit_eval_single_step_forward_soft_reset, jit_eval_multi_step_forward_hard_reset, jit_eval_multi_step_forward_hard_reset_with_v_seq, jit_eval_multi_step_forward_soft_reset, jit_eval_multi_step_forward_soft_reset_with_v_seq
+   :exclude-members: supported_backends
 
 Leaky Integrate-and-fire (LIF) Neurons
 ------------------------------------------------
@@ -49,7 +49,7 @@ Leaky Integrate-and-fire (LIF) Neurons
    :members:
    :undoc-members:
    :show-inheritance:
-   :exclude-members: supported_backends, neuronal_charge_decay_input_reset0, neuronal_charge_decay_input, neuronal_charge_no_decay_input_reset0, neuronal_charge_no_decay_input, jit_eval_single_step_forward_hard_reset_decay_input, jit_eval_single_step_forward_hard_reset_no_decay_input, jit_eval_single_step_forward_soft_reset_decay_input, jit_eval_single_step_forward_soft_reset_no_decay_input, jit_eval_multi_step_forward_hard_reset_decay_input, jit_eval_multi_step_forward_hard_reset_decay_input_with_v_seq, jit_eval_multi_step_forward_hard_reset_no_decay_input, jit_eval_multi_step_forward_hard_reset_no_decay_input_with_v_seq, jit_eval_multi_step_forward_soft_reset_decay_input, jit_eval_multi_step_forward_soft_reset_decay_input_with_v_seq, jit_eval_multi_step_forward_soft_reset_no_decay_input, jit_eval_multi_step_forward_soft_reset_no_decay_input_with_v_seq,
+   :exclude-members: supported_backends
 
 Parametric Leaky Integrate-and-fire (PLIF) Neurons
 ----------------------------------------------------------

--- a/docs/source/APIs/spikingjelly.activation_based.neuron.core.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.neuron.core.rst
@@ -31,7 +31,7 @@ Base Classes
    :members:
    :undoc-members:
    :show-inheritance:
-   :exclude-members: store_v_seq, extra_repr, v_float_to_tensor, apply_hard_reset, apply_soft_reset, jit_neuronal_adaptation
+   :exclude-members: store_v_seq, extra_repr, apply_hard_reset, apply_soft_reset, jit_neuronal_adaptation
 
 Integrate-and-fire (IF) Neurons
 ------------------------------------

--- a/docs/source/APIs/spikingjelly.activation_based.neuron.research.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.neuron.research.rst
@@ -32,7 +32,7 @@ Adaptive Neurons
    :members:
    :undoc-members:
    :show-inheritance:
-   :exclude-members: supported_backends, extra_repr, w_float_to_tensor
+   :exclude-members: supported_backends, extra_repr
 
 Nonlinear Integrate-and-fire Neurons
 --------------------------------------------------

--- a/docs/source/APIs/spikingjelly.activation_based.neuron.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.neuron.rst
@@ -48,7 +48,7 @@ Base Classes
 .. list-table::
 
    * - :class:`SimpleBaseNode <spikingjelly.activation_based.neuron.base_node.SimpleBaseNode>`
-     - Simplified base class for neurons.
+     - Pure-PyTorch interface for understanding and customizing neuron dynamics.
    * - :class:`BaseNode <spikingjelly.activation_based.neuron.base_node.BaseNode>`
      - Base class for neurons.
    * - :class:`NonSpikingBaseNode <spikingjelly.activation_based.neuron.base_node.NonSpikingBaseNode>`
@@ -60,7 +60,7 @@ Integrate-and-fire (IF) Neurons
 .. list-table::
 
    * - :class:`SimpleIFNode <spikingjelly.activation_based.neuron.integrate_and_fire.SimpleIFNode>`
-     - Simplified IF neuron.
+     - IF implementation using the readable charge-fire-reset interface.
    * - :class:`IFNode <spikingjelly.activation_based.neuron.integrate_and_fire.IFNode>`
      - IF neuron.
    * - :class:`ActivationAwareIFNode <spikingjelly.activation_based.neuron.integrate_and_fire.ActivationAwareIFNode>`
@@ -74,7 +74,7 @@ Leaky Integrate-and-fire (LIF) Neurons
 .. list-table::
 
    * - :class:`SimpleLIFNode <spikingjelly.activation_based.neuron.lif.SimpleLIFNode>`
-     - Simplified LIF neuon.
+     - LIF implementation using the readable charge-fire-reset interface.
    * - :class:`LIFNode <spikingjelly.activation_based.neuron.lif.LIFNode>`
      - LIF neuron.
    * - :class:`NonSpikingLIFNode <spikingjelly.activation_based.neuron.lif.NonSpikingLIFNode>`

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -40,14 +40,15 @@ Modules: ``spikingjelly.activation_based.functional`` and
 ``spikingjelly.activation_based.base``.
 
 - Added explicit tensor-state APIs for modules with state-update semantics,
-  including neurons, delay and synaptic filters, learning traces, and SpikeZIP
-  STBIF updates. Reusable LIF charging and voltage-reset primitives are also
-  available for neuron variants that insert operations between charge, fire,
-  and reset. Existing modules retain their public state, lifecycle, backend
-  selection, and output behavior.
+  including LIAF, I-LIF, MaskedPSN, NeuNorm, delay and synaptic filters,
+  learning traces, and SpikeZIP STBIF updates. Reusable LIF charging and
+  voltage-reset primitives are also available for neuron variants that insert
+  operations between charge, fire, and reset. Existing modules retain their
+  public state, lifecycle, backend selection, and output behavior.
 - State-update APIs use ``*_step`` for one complete update and ``*_multi_step`` only for
   independently implemented sequence paths. Supported CuPy, Triton, and
   Inductor paths identify their backend in the function name.
+- Fixed MaskedPSN single-step execution for inputs with more than one dimension.
 - The Inductor neuron multi-step implementation is the single source of its state-update equation
   and shares a bounded process-local compiled-graph cache.
 - Hookable Node classes retain their existing execution paths; their standard

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -36,7 +36,8 @@ Module: ``spikingjelly``.
 Functional State Transitions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Module: ``spikingjelly.activation_based.functional``.
+Modules: ``spikingjelly.activation_based.functional`` and
+``spikingjelly.activation_based.base``.
 
 - Added explicit tensor-state APIs for modules with state-update semantics,
   including neurons, delay and synaptic filters, learning traces, and SpikeZIP
@@ -51,6 +52,24 @@ Module: ``spikingjelly.activation_based.functional``.
   transitions are also available as independent functional APIs.
 - Added FlexSN custom-op registry diagnostics for entry, owner-reference, and
   active-reference counts.
+- Added grouped ``MemoryModule.functional_forward`` interfaces and changed
+  ``to_functional_forward`` to return
+  ``(inputs, states) -> (outputs, updated_states)``. Regular forward paths for the
+  framework's stateful neurons, layers, encoders, recurrent containers, temporal
+  ANN-to-SNN operators, and transformer conversion modules are now backed by
+  their native functional transition. The default multi-step implementation
+  rolls the single-step transition over time, while sequence kernels override it.
+  Sequential modules compose child transitions directly and arbitrary composite
+  modules use a dictionary-swap fallback. Custom production ``MemoryModule`` and
+  ``BaseNode`` subclasses should implement ``single_step_functional_forward`` and
+  override ``multi_step_functional_forward`` only when they provide a specialized
+  sequence implementation. ``SimpleBaseNode``, ``SimpleIFNode``, and ``SimpleLIFNode``
+  retain the charge-fire-reset forward model for equation experiments and use the
+  general state-substitution path when converted.
+- Added ``MemoryModule.materialize_states(inputs, states, step_mode)`` as the
+  single hook for converting registered scalar or empty states into
+  input-dependent states before functional execution. Its default implementation
+  returns states unchanged.
 
 ANN-to-SNN Conversion
 ^^^^^^^^^^^^^^^^^^^^^
@@ -226,6 +245,43 @@ Module: ``spikingjelly.activation_based.triton_kernel.neuron_kernel``.
 
 Breaking Changes and Notices
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Functional Forward API Changes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Module: ``spikingjelly.activation_based.base``.
+
+- **Breaking change:** ``to_functional_forward()`` now returns a function with the
+  grouped interface
+  ``(inputs, states, **kwargs) -> (outputs, updated_states)``. Both ``inputs`` and
+  ``outputs`` remain tuples when they contain one tensor. Replace calls such as
+  ``output, state = forward(x, state)`` with
+  ``outputs, states = forward((x,), (state,))`` and read the single output from
+  ``outputs[0]``.
+
+Neuron Extension API Changes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Module: ``spikingjelly.activation_based.neuron``.
+
+- **Breaking change:** ``BaseNode`` now defines production neurons solely through
+  functional state transitions and no longer provides ``neuronal_charge()``,
+  ``neuronal_fire()``, or ``neuronal_reset()``. Existing custom neurons that inherit
+  ``BaseNode`` and override these hooks must either change their base class to
+  ``SimpleBaseNode`` to retain the charge-fire-reset extension model, or implement
+  ``single_step_functional_forward()`` for a native-functional production neuron.
+  ``to_functional_forward()`` converts ``SimpleBaseNode`` through the general
+  state-substitution path. Built-in production neurons such as ``IFNode`` and
+  ``LIFNode`` use native functional transitions and their specialized sequence
+  kernels.
+- **Breaking change:** removed ``BaseNode.v_float_to_tensor()``. Custom functional
+  modules that require input-dependent state initialization should override
+  ``materialize_states(inputs, states, step_mode)`` and return a new state tuple
+  without mutating module memory.
+- **Breaking change:** ``MemoryModule`` subclasses without functional or regular
+  forward semantics now raise ``NotImplementedError`` when called. Stateful
+  learners such as ``STDPLearner``, ``MSTDPLearner``, and ``MSTDPETLearner`` continue
+  to expose their computation through ``step()``.
 
 Logging-Controlled Diagnostics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -41,7 +41,9 @@ Modules: ``spikingjelly.activation_based.functional`` and
 
 - Added explicit tensor-state APIs for modules with state-update semantics,
   including neurons, delay and synaptic filters, learning traces, and SpikeZIP
-  STBIF updates. Existing modules retain their public state, lifecycle, backend
+  STBIF updates. Reusable LIF charging and voltage-reset primitives are also
+  available for neuron variants that insert operations between charge, fire,
+  and reset. Existing modules retain their public state, lifecycle, backend
   selection, and output behavior.
 - State-update APIs use ``*_step`` for one complete update and ``*_multi_step`` only for
   independently implemented sequence paths. Supported CuPy, Triton, and
@@ -55,21 +57,12 @@ Modules: ``spikingjelly.activation_based.functional`` and
 - Added grouped ``MemoryModule.functional_forward`` interfaces and changed
   ``to_functional_forward`` to return
   ``(inputs, states) -> (outputs, updated_states)``. Regular forward paths for the
-  framework's stateful neurons, layers, encoders, recurrent containers, temporal
-  ANN-to-SNN operators, and transformer conversion modules are now backed by
-  their native functional transition. The default multi-step implementation
-  rolls the single-step transition over time, while sequence kernels override it.
-  Sequential modules compose child transitions directly and arbitrary composite
-  modules use a dictionary-swap fallback. Custom production ``MemoryModule`` and
-  ``BaseNode`` subclasses should implement ``single_step_functional_forward`` and
-  override ``multi_step_functional_forward`` only when they provide a specialized
-  sequence implementation. ``SimpleBaseNode``, ``SimpleIFNode``, and ``SimpleLIFNode``
-  retain the charge-fire-reset forward model for equation experiments and use the
-  general state-substitution path when converted.
-- Added ``MemoryModule.materialize_states(inputs, states, step_mode)`` as the
-  single hook for converting registered scalar or empty states into
-  input-dependent states before functional execution. Its default implementation
-  returns states unchanged.
+  framework's stateful modules now use native functional transitions. Multi-step
+  execution loops the single-step transition by default; sequence kernels may
+  override it. Sequential modules compose child transitions directly, while other
+  composite modules use the state-substitution fallback.
+- Added ``MemoryModule.materialize_states(inputs, states, step_mode)`` for converting
+  input-dependent states before functional execution.
 
 ANN-to-SNN Conversion
 ^^^^^^^^^^^^^^^^^^^^^
@@ -267,17 +260,14 @@ Module: ``spikingjelly.activation_based.neuron``.
 - **Breaking change:** ``BaseNode`` now defines production neurons solely through
   functional state transitions and no longer provides ``neuronal_charge()``,
   ``neuronal_fire()``, or ``neuronal_reset()``. Existing custom neurons that inherit
-  ``BaseNode`` and override these hooks must either change their base class to
-  ``SimpleBaseNode`` to retain the charge-fire-reset extension model, or implement
-  ``single_step_functional_forward()`` for a native-functional production neuron.
-  ``to_functional_forward()`` converts ``SimpleBaseNode`` through the general
-  state-substitution path. Built-in production neurons such as ``IFNode`` and
-  ``LIFNode`` use native functional transitions and their specialized sequence
-  kernels.
+  ``BaseNode`` and override these hooks must use ``SimpleBaseNode`` or implement
+  ``single_step_functional_forward()``.
 - **Breaking change:** removed ``BaseNode.v_float_to_tensor()``. Custom functional
   modules that require input-dependent state initialization should override
-  ``materialize_states(inputs, states, step_mode)`` and return a new state tuple
-  without mutating module memory.
+  ``materialize_states(inputs, states, step_mode)``.
+- **Breaking change:** sequence caches such as ``v_seq``, ``i_seq``, and ``state_seqs``
+  are no longer functional states. Functional forward returns only recurrent
+  states; regular multi-step forward stores the requested sequences on the module.
 - **Breaking change:** ``MemoryModule`` subclasses without functional or regular
   forward semantics now raise ``NotImplementedError`` when called. Stateful
   learners such as ``STDPLearner``, ``MSTDPLearner``, and ``MSTDPETLearner`` continue

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -39,31 +39,12 @@ Functional State Transitions
 Modules: ``spikingjelly.activation_based.functional`` and
 ``spikingjelly.activation_based.base``.
 
-- Added explicit tensor-state APIs for modules with state-update semantics,
-  including LIAF, I-LIF, MaskedPSN, NeuNorm, delay and synaptic filters,
-  learning traces, and SpikeZIP STBIF updates. Reusable LIF charging and
-  voltage-reset primitives are also available for neuron variants that insert
-  operations between charge, fire, and reset. Existing modules retain their
-  public state, lifecycle, backend selection, and output behavior.
-- State-update APIs use ``*_step`` for one complete update and ``*_multi_step`` only for
-  independently implemented sequence paths. Supported CuPy, Triton, and
-  Inductor paths identify their backend in the function name.
-- Fixed MaskedPSN single-step execution for inputs with more than one dimension.
-- The Inductor neuron multi-step implementation is the single source of its state-update equation
-  and shares a bounded process-local compiled-graph cache.
-- Hookable Node classes retain their existing execution paths; their standard
-  transitions are also available as independent functional APIs.
-- Added FlexSN custom-op registry diagnostics for entry, owner-reference, and
-  active-reference counts.
-- Added grouped ``MemoryModule.functional_forward`` interfaces and changed
-  ``to_functional_forward`` to return
-  ``(inputs, states) -> (outputs, updated_states)``. Regular forward paths for the
-  framework's stateful modules now use native functional transitions. Multi-step
-  execution loops the single-step transition by default; sequence kernels may
-  override it. Sequential modules compose child transitions directly, while other
-  composite modules use the state-substitution fallback.
-- Added ``MemoryModule.materialize_states(inputs, states, step_mode)`` for converting
-  input-dependent states before functional execution.
+- Added explicit-state functional execution across the framework's stateful
+  modules while preserving regular stateful forward behavior.
+- Regular and functional forward paths now share state transitions, with optimized
+  multi-step implementations retained where needed.
+- Functional conversion now covers native, composite, and user-defined modules,
+  while optional execution traces remain separate from recurrent state.
 
 ANN-to-SNN Conversion
 ^^^^^^^^^^^^^^^^^^^^^
@@ -258,10 +239,10 @@ Neuron Extension API Changes
 
 Module: ``spikingjelly.activation_based.neuron``.
 
-- **Breaking change:** ``BaseNode`` now defines production neurons solely through
-  functional state transitions and no longer provides ``neuronal_charge()``,
-  ``neuronal_fire()``, or ``neuronal_reset()``. Existing custom neurons that inherit
-  ``BaseNode`` and override these hooks must use ``SimpleBaseNode`` or implement
+- **Breaking change:** production neuron classes now define their dynamics solely
+  through functional state transitions and no longer provide
+  ``neuronal_charge()``, ``neuronal_fire()``, or ``neuronal_reset()``. Custom neurons
+  that override these hooks must use ``SimpleBaseNode`` or implement
   ``single_step_functional_forward()``.
 - **Breaking change:** removed ``BaseNode.v_float_to_tensor()``. Custom functional
   modules that require input-dependent state initialization should override

--- a/docs/source/legacy_tutorials/cn/0_neuron.rst
+++ b/docs/source/legacy_tutorials/cn/0_neuron.rst
@@ -98,8 +98,9 @@ LIF神经元层有一些构造参数，在API文档中对这些参数有详细�
             else:
                 self.v += (x - (self.v - self.v_reset)) / self.tau
 
-不同的神经元具有不同的充电方程。可扩展的 Simple 神经元继承自
-:class:`spikingjelly.activation_based.neuron.SimpleBaseNode`，共享放电和重置方程。
+不同的神经元具有不同的充电方程。:class:`spikingjelly.activation_based.neuron.SimpleBaseNode`
+是为了教学和动力学自定义而提供的纯 PyTorch 接口，并不是一种神经元数学模型。它直接
+展示神经元的充电、放电和重置职责；继承该接口的实现共享放电和重置方程。
 可以在 :meth:`spikingjelly.activation_based.neuron.SimpleBaseNode.neuronal_fire`
 中找到释放脉冲的代码：
 

--- a/docs/source/legacy_tutorials/cn/0_neuron.rst
+++ b/docs/source/legacy_tutorials/cn/0_neuron.rst
@@ -98,7 +98,10 @@ LIF神经元层有一些构造参数，在API文档中对这些参数有详细�
             else:
                 self.v += (x - (self.v - self.v_reset)) / self.tau
 
-不同的神经元，充电方程不尽相同。但膜电位超过阈值电压后，释放脉冲，以及释放脉冲后，膜电位的重置都是相同的。因此它们全部继承自 :class:`spikingjelly.activation_based.neuron.BaseNode`，共享相同的放电、重置方程。可以在 :class:`spikingjelly.activation_based.neuron.BaseNode.neuronal_fire` 中找到释放脉冲的代码：
+不同的神经元具有不同的充电方程。可扩展的 Simple 神经元继承自
+:class:`spikingjelly.activation_based.neuron.SimpleBaseNode`，共享放电和重置方程。
+可以在 :meth:`spikingjelly.activation_based.neuron.SimpleBaseNode.neuronal_fire`
+中找到释放脉冲的代码：
 
 .. code-block:: python
 
@@ -113,7 +116,9 @@ LIF神经元层有一些构造参数，在API文档中对这些参数有详细�
 
 #. Soft方式：释放脉冲后，膜电位减去阈值电压：:math:`V[t] = V[t] - V_{threshold}`
 
-可以发现，对于使用Soft方式的神经元，并不需要重置电压 :math:`V_{reset}` 这个变量。:class:`spikingjelly.activation_based.neuron` 中的神经元，在构造函数的参数之一 ``v_reset``，默认为 ``1.0`` ，表示神经元使用Hard方式；若设置为 ``None``，则会使用Soft方式。在 :class:`spikingjelly.activation_based.neuron.BaseNode.neuronal_fire.neuronal_reset` 中可以找到膜电位重置的代码：
+可以发现，对于使用Soft方式的神经元，并不需要重置电压 :math:`V_{reset}` 这个变量。:class:`spikingjelly.activation_based.neuron` 中的神经元，在构造函数的参数之一 ``v_reset``，默认为 ``1.0`` ，表示神经元使用Hard方式；若设置为 ``None``，则会使用Soft方式。在
+:meth:`spikingjelly.activation_based.neuron.SimpleBaseNode.neuronal_reset`
+中可以找到膜电位重置的代码：
 
 .. code-block:: python
 

--- a/docs/source/legacy_tutorials/cn/0_neuron.rst
+++ b/docs/source/legacy_tutorials/cn/0_neuron.rst
@@ -98,11 +98,10 @@ LIF神经元层有一些构造参数，在API文档中对这些参数有详细�
             else:
                 self.v += (x - (self.v - self.v_reset)) / self.tau
 
-不同的神经元具有不同的充电方程。:class:`spikingjelly.activation_based.neuron.SimpleBaseNode`
-是为了教学和动力学自定义而提供的纯 PyTorch 接口，并不是一种神经元数学模型。它直接
-展示神经元的充电、放电和重置职责；继承该接口的实现共享放电和重置方程。
-可以在 :meth:`spikingjelly.activation_based.neuron.SimpleBaseNode.neuronal_fire`
-中找到释放脉冲的代码：
+不同的神经元可以使用不同的充电、放电和重置方程。
+:class:`spikingjelly.activation_based.neuron.SimpleBaseNode` 将这三个过程分别暴露为
+可重写方法。释放脉冲的默认实现位于
+:meth:`spikingjelly.activation_based.neuron.SimpleBaseNode.neuronal_fire`：
 
 .. code-block:: python
 
@@ -117,7 +116,7 @@ LIF神经元层有一些构造参数，在API文档中对这些参数有详细�
 
 #. Soft方式：释放脉冲后，膜电位减去阈值电压：:math:`V[t] = V[t] - V_{threshold}`
 
-可以发现，对于使用Soft方式的神经元，并不需要重置电压 :math:`V_{reset}` 这个变量。:class:`spikingjelly.activation_based.neuron` 中的神经元，在构造函数的参数之一 ``v_reset``，默认为 ``1.0`` ，表示神经元使用Hard方式；若设置为 ``None``，则会使用Soft方式。在
+可以发现，对于使用Soft方式的神经元，并不需要重置电压 :math:`V_{reset}` 这个变量。:class:`spikingjelly.activation_based.neuron` 中的神经元，在构造函数的参数之一 ``v_reset``，默认为 ``0.0`` ，表示神经元使用Hard方式；若设置为 ``None``，则会使用Soft方式。在
 :meth:`spikingjelly.activation_based.neuron.SimpleBaseNode.neuronal_reset`
 中可以找到膜电位重置的代码：
 

--- a/docs/source/legacy_tutorials/cn/0_neuron.rst
+++ b/docs/source/legacy_tutorials/cn/0_neuron.rst
@@ -84,19 +84,15 @@ LIF神经元层有一些构造参数，在API文档中对这些参数有详细�
 .. math::
     V[t] = f(V[t-1], X[t]) = V[t-1] + \frac{1}{\tau_{m}}(-(V[t - 1] - V_{reset}) + X[t])
 
-可以在 :class:`spikingjelly.activation_based.neuron.LIFNode.neuronal_charge` 中找到如下所示的代码：
+可以在 :meth:`spikingjelly.activation_based.neuron.SimpleLIFNode.neuronal_charge` 中找到如下所示的代码：
 
 .. code-block:: python
 
     def neuronal_charge(self, x: torch.Tensor):
-        if self.v_reset is None:
-            self.v += (x - self.v) / self.tau
-
+        if self.decay_input:
+            self.v = self.v + (self.v_reset - self.v + x) / self.tau
         else:
-            if isinstance(self.v_reset, float) and self.v_reset == 0.:
-                self.v += (x - self.v) / self.tau
-            else:
-                self.v += (x - (self.v - self.v_reset)) / self.tau
+            self.v = self.v + (self.v_reset - self.v) / self.tau + x
 
 不同的神经元可以使用不同的充电、放电和重置方程。
 :class:`spikingjelly.activation_based.neuron.SimpleBaseNode` 将这三个过程分别暴露为

--- a/docs/source/legacy_tutorials/en/0_neuron.rst
+++ b/docs/source/legacy_tutorials/en/0_neuron.rst
@@ -114,12 +114,10 @@ The corresponding code can be found in :class:`spikingjelly.activation_based.neu
             else:
                 self.v += (x - (self.v - self.v_reset)) / self.tau
 
-Different neurons have different charging equations.
-:class:`spikingjelly.activation_based.neuron.SimpleBaseNode` is a pure-PyTorch
-interface for teaching and dynamics customization, not a neuron mathematical
-model. It exposes the charge, fire, and reset responsibilities directly;
-implementations derived from it share the firing and reset equations. The firing implementation is
-available at :meth:`spikingjelly.activation_based.neuron.SimpleBaseNode.neuronal_fire`:
+Different neurons can use different charge, fire, and reset equations.
+:class:`spikingjelly.activation_based.neuron.SimpleBaseNode` exposes these three
+processes as independently overridable methods. The default firing implementation
+is available at :meth:`spikingjelly.activation_based.neuron.SimpleBaseNode.neuronal_fire`:
 
 .. code-block:: python
 
@@ -138,7 +136,7 @@ two ways to realize neuronal reset:
 #. Soft method: After releasing a spike, the membrane potential subtracts the threshold voltage :math:`V = V - V_{threshold}`
 
 It can be found that for neurons using the soft method, there is no need to reset the voltage :math:`V_{reset}`.
-For the neurons in :class:`spikingjelly.activation_based.neuron`, when ``v_reset`` is set to the a float value (e.g., the default value is ``1.0``), the neuron uses the hard reset; if ``v_reset`` is set to ``None``, the soft reset will be used.
+For the neurons in :class:`spikingjelly.activation_based.neuron`, when ``v_reset`` is set to a float value (the default is ``0.0``), the neuron uses the hard reset; if ``v_reset`` is set to ``None``, the soft reset will be used.
 We can find the corresponding code in
 :meth:`spikingjelly.activation_based.neuron.SimpleBaseNode.neuronal_reset`:
 

--- a/docs/source/legacy_tutorials/en/0_neuron.rst
+++ b/docs/source/legacy_tutorials/en/0_neuron.rst
@@ -114,9 +114,10 @@ The corresponding code can be found in :class:`spikingjelly.activation_based.neu
             else:
                 self.v += (x - (self.v - self.v_reset)) / self.tau
 
-Different neurons have different charging equations. However, when the membrane potential exceeds the threshold potential,
-the release of spike and the reset of the membrane potential are the same for all kinds of neurons. Therefore,
-they all inherit from :class:`spikingjelly.activation_based.neuron.BaseNode` and share the same discharge and reset equations. The codes of neuronal fire can be found at :class:`spikingjelly.activation_based.neuron.BaseNode.neuronal_fire`:
+Different neurons have different charging equations. The extensible Simple
+neurons inherit from :class:`spikingjelly.activation_based.neuron.SimpleBaseNode`
+and share its discharge and reset equations. The neuronal fire implementation is
+available at :meth:`spikingjelly.activation_based.neuron.SimpleBaseNode.neuronal_fire`:
 
 .. code-block:: python
 
@@ -136,7 +137,8 @@ two ways to realize neuronal reset:
 
 It can be found that for neurons using the soft method, there is no need to reset the voltage :math:`V_{reset}`.
 For the neurons in :class:`spikingjelly.activation_based.neuron`, when ``v_reset`` is set to the a float value (e.g., the default value is ``1.0``), the neuron uses the hard reset; if ``v_reset`` is set to ``None``, the soft reset will be used.
-We can find the corresponding codes in :class:`spikingjelly.activation_based.neuron.BaseNode.neuronal_fire.neuronal_reset`:
+We can find the corresponding code in
+:meth:`spikingjelly.activation_based.neuron.SimpleBaseNode.neuronal_reset`:
 
 .. code-block:: python
 

--- a/docs/source/legacy_tutorials/en/0_neuron.rst
+++ b/docs/source/legacy_tutorials/en/0_neuron.rst
@@ -100,19 +100,15 @@ The expression of :math:`V_{t}` can be obtained as
 .. math::
     V_{t} = f(V_{t-1}, X_{t}) = V_{t-1} + \frac{1}{\tau_{m}}(-(V_{t - 1} - V_{reset}) + X_{t})
 
-The corresponding code can be found in :class:`spikingjelly.activation_based.neuron.LIFNode.neuronal_charge`:
+The corresponding code can be found in :meth:`spikingjelly.activation_based.neuron.SimpleLIFNode.neuronal_charge`:
 
 .. code-block:: python
 
-    def neuronal_charge(self, dv: torch.Tensor):
-        if self.v_reset is None:
-            self.v += (x - self.v) / self.tau
-
+    def neuronal_charge(self, x: torch.Tensor):
+        if self.decay_input:
+            self.v = self.v + (self.v_reset - self.v + x) / self.tau
         else:
-            if isinstance(self.v_reset, float) and self.v_reset == 0.:
-                self.v += (x - self.v) / self.tau
-            else:
-                self.v += (x - (self.v - self.v_reset)) / self.tau
+            self.v = self.v + (self.v_reset - self.v) / self.tau + x
 
 Different neurons can use different charge, fire, and reset equations.
 :class:`spikingjelly.activation_based.neuron.SimpleBaseNode` exposes these three

--- a/docs/source/legacy_tutorials/en/0_neuron.rst
+++ b/docs/source/legacy_tutorials/en/0_neuron.rst
@@ -114,9 +114,11 @@ The corresponding code can be found in :class:`spikingjelly.activation_based.neu
             else:
                 self.v += (x - (self.v - self.v_reset)) / self.tau
 
-Different neurons have different charging equations. The extensible Simple
-neurons inherit from :class:`spikingjelly.activation_based.neuron.SimpleBaseNode`
-and share its discharge and reset equations. The neuronal fire implementation is
+Different neurons have different charging equations.
+:class:`spikingjelly.activation_based.neuron.SimpleBaseNode` is a pure-PyTorch
+interface for teaching and dynamics customization, not a neuron mathematical
+model. It exposes the charge, fire, and reset responsibilities directly;
+implementations derived from it share the firing and reset equations. The firing implementation is
 available at :meth:`spikingjelly.activation_based.neuron.SimpleBaseNode.neuronal_fire`:
 
 .. code-block:: python

--- a/docs/source/tutorials/cn/cupy_neuron.rst
+++ b/docs/source/tutorials/cn/cupy_neuron.rst
@@ -742,7 +742,8 @@ autograd Function时进行使用。建议首先阅读 :class:`NeuronATGFBase <sp
 
 实现CUPY后端
 -------------------------------------
-利用之前我们已经定义好的 ``IFNodeFPTTKernel, IFNodeBPTTKernel, IFNodeATGF``，我们实现一个简化的IF神经元，并添加CUPY后端。
+利用之前已经定义好的 ``IFNodeFPTTKernel, IFNodeBPTTKernel, IFNodeATGF``，
+我们实现一个用于演示后端接入的 IFNode，并为其添加 CUPY 后端。
 
 完整的代码如下：
 

--- a/docs/source/tutorials/cn/cupy_neuron.rst
+++ b/docs/source/tutorials/cn/cupy_neuron.rst
@@ -742,8 +742,7 @@ autograd Function时进行使用。建议首先阅读 :class:`NeuronATGFBase <sp
 
 实现CUPY后端
 -------------------------------------
-利用之前已经定义好的 ``IFNodeFPTTKernel, IFNodeBPTTKernel, IFNodeATGF``，
-我们实现一个用于演示后端接入的 IFNode，并为其添加 CUPY 后端。
+利用之前我们已经定义好的 ``IFNodeFPTTKernel, IFNodeBPTTKernel, IFNodeATGF``，我们实现一个简化的IF神经元，并添加CUPY后端。
 
 完整的代码如下：
 
@@ -772,11 +771,16 @@ autograd Function时进行使用。建议首先阅读 :class:`NeuronATGFBase <sp
             else:
                 self.register_memory('v', 0.)
 
-        def multi_step_forward(self, x_seq: torch.Tensor):
+        def materialize_states(self, inputs, states, step_mode):
+            x = inputs[0][0]
+            v = states[0]
+            if not isinstance(v, torch.Tensor) or v.shape != x.shape:
+                v = torch.full_like(x, self.v_reset or 0.)
+            return (v,)
 
-            if isinstance(self.v, float):
-                self.v = torch.zeros_like(x_seq[0])
-
+        def multi_step_functional_forward(self, inputs, states, **kwargs):
+            x_seq = inputs[0]
+            v = states[0]
             hard_reset = self.v_reset is not None
             if x_seq.dtype == torch.float:
                 dtype = 'float'
@@ -788,12 +792,11 @@ autograd Function时进行使用。建议首先阅读 :class:`NeuronATGFBase <sp
             backward_kernel = IFNodeBPTTKernel(surrogate_function=self.surrogate_function.cuda_codes, hard_reset=hard_reset, detach_reset=self.detach_reset, dtype=dtype)
 
             # All tensors wil be regard as 2D or 1D. Thus, we use flatten
-            spike_seq, v_seq = IFNodeATGF.apply(x_seq.flatten(1), self.v.flatten(), self.v_threshold, self.v_reset, forward_kernel, backward_kernel)
+            spike_seq, v_seq = IFNodeATGF.apply(x_seq.flatten(1), v.flatten(), self.v_threshold, self.v_reset, forward_kernel, backward_kernel)
 
             spike_seq = spike_seq.view(x_seq.shape)
-            self.v = v_seq[-1].view(x_seq.shape[1:])
-
-            return spike_seq
+            v = v_seq[-1].view(x_seq.shape[1:])
+            return (spike_seq,), (v,)
 
 接下来，让我们与纯pytorch实现对比输出误差：
 

--- a/docs/source/tutorials/cn/memopt.rst
+++ b/docs/source/tutorials/cn/memopt.rst
@@ -280,7 +280,7 @@ English version: :doc:`../en/memopt`
 
     import torch
     import torch.nn as nn
-    from spikingjelly.activation_based import layer, neuron, surrogate, functional
+    from spikingjelly.activation_based import base, functional, layer, neuron, surrogate
 
 
     class VGGBlock(nn.Module):
@@ -381,13 +381,8 @@ Step 1. 定义分割规则
     outputs, updated_states = f_forward((x,), (v,))
 
 已实现 functional forward 的 MemoryModule 会直接执行显式状态转移；
-``nn.Sequential`` 会递归组合子模块；其他复合模块由通用路径处理。
-``SimpleBaseNode``、``SimpleIFNode`` 和 ``SimpleLIFNode`` 的名称表示其纯 PyTorch、
-便于理解和自定义动力学的接口定位，并不表示一种神经元数学模型。它们为保留可修改的
-``charge → fire → reset`` 方程接口，也使用通用路径：转换函数会临时换入显式状态，
-执行原有前向后恢复模块状态。该路径保持数值与状态语义，但包含状态替换开销。
-频繁进行时间维梯度检查点或其他 functional 调用时，应优先使用具有原生 functional
-状态转移的 ``IFNode``、``LIFNode`` 等生产级神经元。
+``nn.Sequential`` 会递归组合子模块；其他复合模块由通用路径处理。通用路径会临时
+换入显式状态，执行原有前向后再恢复模块状态，因此包含额外的状态替换开销。
 
 Step 2. 显式声明压缩器（可选）
 ################################

--- a/docs/source/tutorials/cn/memopt.rst
+++ b/docs/source/tutorials/cn/memopt.rst
@@ -371,6 +371,23 @@ Step 1. 定义分割规则
 
 :func:`memory_optimization <spikingjelly.activation_based.memopt.pipeline.memory_optimization>` 的时间分割将自动借助 :func:`to_functional_forward <spikingjelly.activation_based.base.to_functional_forward>` 实现，无需手动定义规则。
 
+``to_functional_forward`` 返回的函数使用分组接口
+``(inputs, states) -> (outputs, updated_states)``。``inputs`` 和 ``outputs``
+即使只有一个张量也使用 tuple。例如：
+
+.. code:: python
+
+    f_forward = base.to_functional_forward(neuron.LIFNode())
+    outputs, updated_states = f_forward((x,), (v,))
+
+已实现 functional forward 的 MemoryModule 会直接执行显式状态转移；
+``nn.Sequential`` 会递归组合子模块；其他复合模块由通用路径处理。
+``SimpleBaseNode``、``SimpleIFNode`` 和 ``SimpleLIFNode`` 为保留可修改的
+``charge → fire → reset`` 方程接口，也使用通用路径：转换函数会临时换入显式状态，
+执行原有前向后恢复模块状态。该路径保持数值与状态语义，但包含状态替换开销。
+频繁进行时间维梯度检查点或其他 functional 调用时，应优先使用具有原生 functional
+状态转移的 ``IFNode``、``LIFNode`` 等生产级神经元。
+
 Step 2. 显式声明压缩器（可选）
 ################################
 

--- a/docs/source/tutorials/cn/memopt.rst
+++ b/docs/source/tutorials/cn/memopt.rst
@@ -382,7 +382,8 @@ Step 1. 定义分割规则
 
 已实现 functional forward 的 MemoryModule 会直接执行显式状态转移；
 ``nn.Sequential`` 会递归组合子模块；其他复合模块由通用路径处理。
-``SimpleBaseNode``、``SimpleIFNode`` 和 ``SimpleLIFNode`` 为保留可修改的
+``SimpleBaseNode``、``SimpleIFNode`` 和 ``SimpleLIFNode`` 的名称表示其纯 PyTorch、
+便于理解和自定义动力学的接口定位，并不表示一种神经元数学模型。它们为保留可修改的
 ``charge → fire → reset`` 方程接口，也使用通用路径：转换函数会临时换入显式状态，
 执行原有前向后恢复模块状态。该路径保持数值与状态语义，但包含状态替换开销。
 频繁进行时间维梯度检查点或其他 functional 调用时，应优先使用具有原生 functional

--- a/docs/source/tutorials/cn/neuron.rst
+++ b/docs/source/tutorials/cn/neuron.rst
@@ -81,16 +81,18 @@ IF神经元层有一些构造参数，在API文档中对这些参数有详细的
 .. math::
     V[t] = f(V[t-1], X[t]) = V[t-1] + X[t]
 
-在用于动力学实验的 :class:`spikingjelly.activation_based.neuron.SimpleIFNode`
-中，充电方程直接写为：
+``SimpleBaseNode`` 中的 ``Simple`` 描述的是接口目标，并不是一种神经元数学模型。
+该接口使用纯 PyTorch 直接展开 SNN 神经元的充电、放电和重置职责，便于使用者理解
+神经元在 SNN 中承担的工作，也便于修改动力学方程。在基于该接口实现的
+:class:`spikingjelly.activation_based.neuron.SimpleIFNode` 中，充电方程直接写为：
 
 .. code-block:: python
 
     def neuronal_charge(self, x: torch.Tensor):
         self.v = self.v + x
 
-不同的神经元具有不同的充电方程，但通常共享放电和重置方程。``Simple`` 神经元通过
-:class:`spikingjelly.activation_based.neuron.SimpleBaseNode` 的
+不同的神经元具有不同的充电方程，但通常共享放电和重置方程。
+:class:`spikingjelly.activation_based.neuron.SimpleBaseNode` 通过
 ``neuronal_charge → neuronal_fire → neuronal_reset`` 路径直接表达这三个阶段；
 生产级神经元则在 functional 状态转移或专用 kernel 中实现等价计算。下面是
 ``SimpleBaseNode.neuronal_fire`` 的核心计算：
@@ -280,7 +282,9 @@ Soft方式重置方程为：
 
 自定义神经元
 -------------------------------------------
-SpikingJelly 为修改神经元动力学和高性能执行提供了两类接口：
+SpikingJelly 为修改神经元动力学和高性能执行提供了两类接口。``SimpleBaseNode`` 是
+纯 PyTorch 的教学与自定义接口，而不是新的神经元数学模型；它优先保证职责和方程清晰，
+使使用者能直接修改动力学。
 
 .. list-table:: 神经元扩展接口
     :header-rows: 1

--- a/docs/source/tutorials/cn/neuron.rst
+++ b/docs/source/tutorials/cn/neuron.rst
@@ -81,14 +81,19 @@ IF神经元层有一些构造参数，在API文档中对这些参数有详细的
 .. math::
     V[t] = f(V[t-1], X[t]) = V[t-1] + X[t]
 
-可以在 :class:`spikingjelly.activation_based.neuron.IFNode.neuronal_charge` 中找到如下所示的代码：
+在用于动力学实验的 :class:`spikingjelly.activation_based.neuron.SimpleIFNode`
+中，充电方程直接写为：
 
 .. code-block:: python
 
     def neuronal_charge(self, x: torch.Tensor):
         self.v = self.v + x
 
-不同的神经元，充电方程不尽相同。但膜电位超过阈值电压后，释放脉冲，以及释放脉冲后，膜电位的重置都是相同的。因此它们全部继承自 :class:`spikingjelly.activation_based.neuron.BaseNode`，共享相同的放电、重置方程。可以在 :class:`spikingjelly.activation_based.neuron.BaseNode.neuronal_fire` 中找到释放脉冲的代码：
+不同的神经元具有不同的充电方程，但通常共享放电和重置方程。``Simple`` 神经元通过
+:class:`spikingjelly.activation_based.neuron.SimpleBaseNode` 的
+``neuronal_charge → neuronal_fire → neuronal_reset`` 路径直接表达这三个阶段；
+生产级神经元则在 functional 状态转移或专用 kernel 中实现等价计算。下面是
+``SimpleBaseNode.neuronal_fire`` 的核心计算：
 
 .. code-block:: python
 
@@ -103,7 +108,7 @@ IF神经元层有一些构造参数，在API文档中对这些参数有详细的
 
 #. Soft方式：释放脉冲后，膜电位减去阈值电压：:math:`V[t] = V[t] - V_{threshold}`
 
-可以发现，对于使用Soft方式的神经元，并不需要重置电压 :math:`V_{reset}` 这个变量。在当前实现中， :class:`spikingjelly.activation_based.neuron` 中的大多数神经元构造函数中的 ``v_reset`` 默认值均为 ``0.0`` ，表示神经元默认使用Hard方式；若设置为 ``None``，则会使用Soft方式。在 :class:`spikingjelly.activation_based.neuron.BaseNode.neuronal_reset` 中可以找到膜电位重置的代码：
+可以发现，对于使用Soft方式的神经元，并不需要重置电压 :math:`V_{reset}` 这个变量。在当前实现中， :class:`spikingjelly.activation_based.neuron` 中的大多数神经元构造函数中的 ``v_reset`` 默认值均为 ``0.0`` ，表示神经元默认使用Hard方式；若设置为 ``None``，则会使用Soft方式。``SimpleBaseNode.neuronal_reset`` 使用如下等价逻辑：
 
 .. code-block:: python
 
@@ -275,20 +280,42 @@ Soft方式重置方程为：
 
 自定义神经元
 -------------------------------------------
-如前所述，SpikingJelly使用充电、放电、重置三个方程来描述脉冲神经元，在 :class:`BaseNode <spikingjelly.activation_based.neuron.BaseNode>` \
-中可以找到对应的代码，单步模式下的前向传播 ``single_step_forward`` 函数即是由这3个过程组成：
+SpikingJelly 为修改神经元动力学和高性能执行提供了两类接口：
 
-.. code-block:: python
+.. list-table:: 神经元扩展接口
+    :header-rows: 1
+    :widths: 20 30 25 25
 
-    # spikingjelly.activation_based.neuron.BaseNode
-    def single_step_forward(self, x: torch.Tensor):
-        self.neuronal_charge(x)
-        spike = self.neuronal_fire()
-        self.neuronal_reset(spike)
-        return spike
+    * - 基类
+      - 前向模型
+      - ``to_functional_forward``
+      - 适用场景
+    * - :class:`SimpleBaseNode <spikingjelly.activation_based.neuron.SimpleBaseNode>`
+      - ``neuronal_charge`` → ``neuronal_fire`` → ``neuronal_reset``
+      - 通用状态替换路径
+      - 教学、动力学实验和快速原型
+    * - :class:`BaseNode <spikingjelly.activation_based.neuron.BaseNode>`
+      - 原生 functional 状态转移，可使用专用多步 kernel
+      - 直接调用 functional forward
+      - 生产级神经元和后端实现
 
-其中 ``neuronal_fire`` 和 ``neuronal_reset`` 对绝大多数神经元都是相同的，因而在 ``BaseNode`` 中就已经定义了。不同的神经元主要是\
-构造函数和充电方程 ``neuronal_charge`` 不同。因此，若想实现新的神经元，则只需要更改构造函数和充电方程即可。
+若只需要修改神经元方程，应继承 ``SimpleBaseNode``。其单步前向固定按照充电、放电、
+重置的顺序执行，多步前向则逐时间步调用完整的单步前向。因而通常只需要实现
+``neuronal_charge``。``SimpleIFNode`` 和 ``SimpleLIFNode`` 也是基于这一接口实现的。
+
+``SimpleBaseNode`` 没有原生 functional 状态转移。直接调用 ``functional_forward`` 会报错。
+对其实例调用
+:func:`to_functional_forward <spikingjelly.activation_based.base.to_functional_forward>`
+时，会通过通用 fallback 临时换入显式状态、执行原有前向并恢复模块状态。这能保持方程扩展
+接口，但效率低于
+``LIFNode`` 等原生 functional 神经元，因此不适合作为依赖频繁 functional 转换的高性能实现。
+
+生产级 ``MemoryModule`` 在 functional forward 前会调用
+``materialize_states(inputs, states, step_mode)``。
+默认实现原样返回状态；只有当标量或空状态需要依据当前输入转换成张量时才需要重写。
+``inputs`` 是当前前向传播的完整输入；实现可依据 ``step_mode`` 在多步模式下选取第一个
+时间步作为形状和设备参照，不能假定所有输入都具有时间维。该方法返回新的状态元组，不应
+修改模块 memory。旧的 ``BaseNode.v_float_to_tensor`` 已删除。
 
 
 假设我们构造一种平方积分发放神经元，其充电方程为：
@@ -303,13 +330,9 @@ Soft方式重置方程为：
     import torch
     from spikingjelly.activation_based import neuron
 
-    class SquareIFNode(neuron.BaseNode):
+    class SquareIFNode(neuron.SimpleBaseNode):
         def neuronal_charge(self, x: torch.Tensor):
-            self.v = self.v + x ** 2
-
-
-:class:`BaseNode <spikingjelly.activation_based.neuron.BaseNode>` 继承自 :class:`MemoryModule <spikingjelly.activation_based.base.MemoryModule>`。:class:`MemoryModule <spikingjelly.activation_based.base.MemoryModule>` \
-默认的多步传播，是使用 ``for t in range(T)`` 来循环调用单步传播实现的。因此我们定义 ``neuronal_charge`` 后， ``single_step_forward`` 就已经是完整的了，进而 ``multi_step_forward`` 也可以被使用。
+            self.v = self.v + x.square()
 
 使用平方积分发放神经元进行单步或多步传播：
 
@@ -318,10 +341,9 @@ Soft方式重置方程为：
     import torch
     from spikingjelly.activation_based import neuron
 
-    class SquareIFNode(neuron.BaseNode):
-
+    class SquareIFNode(neuron.SimpleBaseNode):
         def neuronal_charge(self, x: torch.Tensor):
-            self.v = self.v + x ** 2
+            self.v = self.v + x.square()
 
     sif_layer = SquareIFNode()
 
@@ -357,3 +379,16 @@ Soft方式重置方程为：
             [1.],
             [0.],
             [0.]])
+
+若要实现与 ``LIFNode`` 一样可直接转换并可接入 CuPy、Triton 或 Inductor kernel 的生产级
+神经元，应继承 ``BaseNode`` 并实现 ``single_step_functional_forward``。该方法的接口为
+``(self, inputs, states, **kwargs) -> (outputs, updated_states)``，且不得修改模块中注册的
+memory 或传入的 ``states``。只有存在独立序列实现或专用 kernel 时，才需要重写
+``multi_step_functional_forward``。
+
+.. warning::
+
+    ``BaseNode`` 的常规前向已改为 functional-backed，并已移除 ``neuronal_charge``、
+    ``neuronal_fire`` 和 ``neuronal_reset``。旧代码若通过这些方法修改 Python 神经元方程，
+    请将基类改为 ``SimpleBaseNode``；原有方程无需重写。生产级神经元或自定义后端应迁移为
+    上述 functional 接口。

--- a/docs/source/tutorials/cn/neuron.rst
+++ b/docs/source/tutorials/cn/neuron.rst
@@ -81,10 +81,8 @@ IF神经元层有一些构造参数，在API文档中对这些参数有详细的
 .. math::
     V[t] = f(V[t-1], X[t]) = V[t-1] + X[t]
 
-``SimpleBaseNode`` 中的 ``Simple`` 描述的是接口目标，并不是一种神经元数学模型。
-该接口使用纯 PyTorch 直接展开 SNN 神经元的充电、放电和重置职责，便于使用者理解
-神经元在 SNN 中承担的工作，也便于修改动力学方程。在基于该接口实现的
-:class:`spikingjelly.activation_based.neuron.SimpleIFNode` 中，充电方程直接写为：
+在用于动力学实验的 :class:`spikingjelly.activation_based.neuron.SimpleIFNode`
+中，充电方程直接写为：
 
 .. code-block:: python
 
@@ -282,9 +280,9 @@ Soft方式重置方程为：
 
 自定义神经元
 -------------------------------------------
-SpikingJelly 为修改神经元动力学和高性能执行提供了两类接口。``SimpleBaseNode`` 是
-纯 PyTorch 的教学与自定义接口，而不是新的神经元数学模型；它优先保证职责和方程清晰，
-使使用者能直接修改动力学。
+SpikingJelly 为修改神经元动力学和高性能执行提供了两类接口。``SimpleBaseNode`` 中的
+``Simple`` 描述的是接口定位，而不是一种神经元数学模型。该接口使用纯 PyTorch 直接
+展示充电、放电和重置职责，便于理解神经元在 SNN 中承担的工作和自定义动力学。
 
 .. list-table:: 神经元扩展接口
     :header-rows: 1

--- a/docs/source/tutorials/cn/surrogate.rst
+++ b/docs/source/tutorials/cn/surrogate.rst
@@ -26,12 +26,14 @@ English version: :doc:`../en/surrogate`
 直接使用冲激函数进行梯度下降，显然会使得网络的训练及其不稳定。为了解决这一问题，各种梯度替代法(the surrogate gradient method)被相继提出，参见\
 此综述 `Surrogate Gradient Learning in Spiking Neural Networks <https://arxiv.org/abs/1901.09948>`_。
 
-替代函数在神经元中被用于生成脉冲，查看 :class:`BaseNode.neuronal_fire <spikingjelly.activation_based.neuron.BaseNode.neuronal_fire>` 的源代码可以发现：
+替代函数在神经元中被用于生成脉冲，查看
+:meth:`SimpleBaseNode.neuronal_fire <spikingjelly.activation_based.neuron.SimpleBaseNode.neuronal_fire>`
+的源代码可以发现：
 
 .. code-block:: python
 
     # spikingjelly.activation_based.neuron
-    class BaseNode(base.MemoryModule):
+    class SimpleBaseNode(base.MemoryModule):
         def __init__(..., surrogate_function: Callable = surrogate.Sigmoid(), ...)
         # ...
         self.surrogate_function = surrogate_function

--- a/docs/source/tutorials/en/cupy_neuron.rst
+++ b/docs/source/tutorials/en/cupy_neuron.rst
@@ -755,8 +755,7 @@ The full codes are:
 
 Implement the CUPY backend
 -------------------------------------
-We have implemented ``IFNodeFPTTKernel, IFNodeBPTTKernel, IFNodeATGF``. We can
-now use them to implement an IFNode example with a CUPY backend.
+We have implemented  ``IFNodeFPTTKernel, IFNodeBPTTKernel, IFNodeATGF``. Now we can use them to implement the simplified IF neuron with CUPY backend.
 
 
 Here are the codes:
@@ -786,11 +785,16 @@ Here are the codes:
             else:
                 self.register_memory('v', 0.)
 
-        def multi_step_forward(self, x_seq: torch.Tensor):
+        def materialize_states(self, inputs, states, step_mode):
+            x = inputs[0][0]
+            v = states[0]
+            if not isinstance(v, torch.Tensor) or v.shape != x.shape:
+                v = torch.full_like(x, self.v_reset or 0.)
+            return (v,)
 
-            if isinstance(self.v, float):
-                self.v = torch.zeros_like(x_seq[0])
-
+        def multi_step_functional_forward(self, inputs, states, **kwargs):
+            x_seq = inputs[0]
+            v = states[0]
             hard_reset = self.v_reset is not None
             if x_seq.dtype == torch.float:
                 dtype = 'float'
@@ -802,12 +806,11 @@ Here are the codes:
             backward_kernel = IFNodeBPTTKernel(surrogate_function=self.surrogate_function.cuda_codes, hard_reset=hard_reset, detach_reset=self.detach_reset, dtype=dtype)
 
             # All tensors wil be regard as 2D or 1D. Thus, we use flatten
-            spike_seq, v_seq = IFNodeATGF.apply(x_seq.flatten(1), self.v.flatten(), self.v_threshold, self.v_reset, forward_kernel, backward_kernel)
+            spike_seq, v_seq = IFNodeATGF.apply(x_seq.flatten(1), v.flatten(), self.v_threshold, self.v_reset, forward_kernel, backward_kernel)
 
             spike_seq = spike_seq.view(x_seq.shape)
-            self.v = v_seq[-1].view(x_seq.shape[1:])
-
-            return spike_seq
+            v = v_seq[-1].view(x_seq.shape[1:])
+            return (spike_seq,), (v,)
 
 Let us check the output error compared with the python neuron:
 

--- a/docs/source/tutorials/en/cupy_neuron.rst
+++ b/docs/source/tutorials/en/cupy_neuron.rst
@@ -755,7 +755,8 @@ The full codes are:
 
 Implement the CUPY backend
 -------------------------------------
-We have implemented  ``IFNodeFPTTKernel, IFNodeBPTTKernel, IFNodeATGF``. Now we can use them to implement the simplified IF neuron with CUPY backend. 
+We have implemented ``IFNodeFPTTKernel, IFNodeBPTTKernel, IFNodeATGF``. We can
+now use them to implement an IFNode example with a CUPY backend.
 
 
 Here are the codes:

--- a/docs/source/tutorials/en/memopt.rst
+++ b/docs/source/tutorials/en/memopt.rst
@@ -280,7 +280,7 @@ We use Spiking VGG training on CIFAR10-DVS to demonstrate the workflow. The mode
 
     import torch
     import torch.nn as nn
-    from spikingjelly.activation_based import layer, neuron, surrogate, functional
+    from spikingjelly.activation_based import base, functional, layer, neuron, surrogate
 
 
     class VGGBlock(nn.Module):
@@ -382,16 +382,9 @@ remain tuples even when they contain one tensor. For example:
 
 MemoryModule implementations with functional forward use their explicit state
 transition directly. ``nn.Sequential`` modules recursively compose their children,
-while other composite modules use the general fallback path.
-The names ``SimpleBaseNode``, ``SimpleIFNode``, and ``SimpleLIFNode`` describe a
-pure-PyTorch interface intended for understanding and customizing dynamics, not
-a neuron mathematical model. These classes also use the general path so that
-their configurable ``charge → fire → reset`` equation interface is
-preserved. The converted function temporarily substitutes explicit state, runs
-the regular forward, and then restores the module state. This path preserves
-numerical and state semantics but incurs state-substitution overhead. Prefer
-production neurons with native functional transitions, such as ``IFNode`` and
-``LIFNode``, for frequent temporal checkpointing or other functional calls.
+while other composite modules use the general fallback path. The fallback
+temporarily substitutes explicit state, runs the regular forward, and then restores
+the module state, so it has additional state-substitution overhead.
 
 Step 2. Explicitly declare compressors (optional)
 ###############################################################

--- a/docs/source/tutorials/en/memopt.rst
+++ b/docs/source/tutorials/en/memopt.rst
@@ -371,6 +371,26 @@ In other words, defining ``__spatial_split__`` and returning a tuple suffices. F
 
 Temporal splitting in :func:`memory_optimization <spikingjelly.activation_based.memopt.pipeline.memory_optimization>` is handled automatically via :func:`to_functional_forward <spikingjelly.activation_based.base.to_functional_forward>`, so no manually designed rules are required.
 
+``to_functional_forward`` returns a grouped interface with the form
+``(inputs, states) -> (outputs, updated_states)``. ``inputs`` and ``outputs``
+remain tuples even when they contain one tensor. For example:
+
+.. code:: python
+
+    f_forward = base.to_functional_forward(neuron.LIFNode())
+    outputs, updated_states = f_forward((x,), (v,))
+
+MemoryModule implementations with functional forward use their explicit state
+transition directly. ``nn.Sequential`` modules recursively compose their children,
+while other composite modules use the general fallback path.
+``SimpleBaseNode``, ``SimpleIFNode``, and ``SimpleLIFNode`` also use the general
+path so that their configurable ``charge → fire → reset`` equation interface is
+preserved. The converted function temporarily substitutes explicit state, runs
+the regular forward, and then restores the module state. This path preserves
+numerical and state semantics but incurs state-substitution overhead. Prefer
+production neurons with native functional transitions, such as ``IFNode`` and
+``LIFNode``, for frequent temporal checkpointing or other functional calls.
+
 Step 2. Explicitly declare compressors (optional)
 ###############################################################
 

--- a/docs/source/tutorials/en/memopt.rst
+++ b/docs/source/tutorials/en/memopt.rst
@@ -383,8 +383,10 @@ remain tuples even when they contain one tensor. For example:
 MemoryModule implementations with functional forward use their explicit state
 transition directly. ``nn.Sequential`` modules recursively compose their children,
 while other composite modules use the general fallback path.
-``SimpleBaseNode``, ``SimpleIFNode``, and ``SimpleLIFNode`` also use the general
-path so that their configurable ``charge → fire → reset`` equation interface is
+The names ``SimpleBaseNode``, ``SimpleIFNode``, and ``SimpleLIFNode`` describe a
+pure-PyTorch interface intended for understanding and customizing dynamics, not
+a neuron mathematical model. These classes also use the general path so that
+their configurable ``charge → fire → reset`` equation interface is
 preserved. The converted function temporarily substitutes explicit state, runs
 the regular forward, and then restores the module state. This path preserves
 numerical and state semantics but incurs state-substitution overhead. Prefer

--- a/docs/source/tutorials/en/neuron.rst
+++ b/docs/source/tutorials/en/neuron.rst
@@ -84,12 +84,9 @@ We use the sub-threshold neuronal dynamics :math:`\frac{\mathrm{d}V(t)}{\mathrm{
 .. math::
     V[t] = f(V[t-1], X[t]) = V[t-1] + X[t]
 
-``Simple`` in ``SimpleBaseNode`` describes the goal of the interface; it is not a
-neuron mathematical model. This pure-PyTorch interface exposes the charge, fire,
-and reset responsibilities of an SNN neuron directly, helping users understand
-the role of a neuron in an SNN and customize its dynamics. The charge equation is
-written directly in :class:`spikingjelly.activation_based.neuron.SimpleIFNode`,
-which is built on this interface:
+The equation is written directly in
+:class:`spikingjelly.activation_based.neuron.SimpleIFNode` for dynamics
+experiments:
 
 .. code-block:: python
 
@@ -291,9 +288,10 @@ Some neurons support the ``cupy`` backend in both single-step and multi-step mod
 Custom Spiking Neurons
 -------------------------------------------
 SpikingJelly provides separate interfaces for modifying neuron dynamics and for
-high-performance execution. ``SimpleBaseNode`` is a pure-PyTorch interface for
-teaching and customization, not a new neuron mathematical model. It prioritizes
-clear responsibilities and equations so that users can modify dynamics directly.
+high-performance execution. ``Simple`` in ``SimpleBaseNode`` describes the role
+of the interface, not a neuron mathematical model. This pure-PyTorch interface
+exposes charge, fire, and reset directly so that users can understand the role of
+a neuron in an SNN and customize its dynamics.
 
 .. list-table:: Neuron extension interfaces
     :header-rows: 1

--- a/docs/source/tutorials/en/neuron.rst
+++ b/docs/source/tutorials/en/neuron.rst
@@ -84,9 +84,12 @@ We use the sub-threshold neuronal dynamics :math:`\frac{\mathrm{d}V(t)}{\mathrm{
 .. math::
     V[t] = f(V[t-1], X[t]) = V[t-1] + X[t]
 
-The equation is written directly in
-:class:`spikingjelly.activation_based.neuron.SimpleIFNode` for dynamics
-experiments:
+``Simple`` in ``SimpleBaseNode`` describes the goal of the interface; it is not a
+neuron mathematical model. This pure-PyTorch interface exposes the charge, fire,
+and reset responsibilities of an SNN neuron directly, helping users understand
+the role of a neuron in an SNN and customize its dynamics. The charge equation is
+written directly in :class:`spikingjelly.activation_based.neuron.SimpleIFNode`,
+which is built on this interface:
 
 .. code-block:: python
 
@@ -94,9 +97,10 @@ experiments:
         self.v = self.v + x
 
 Different spiking neurons have different charging equations but usually share
-the firing and reset equations. ``Simple`` neurons express these stages directly
-through the ``neuronal_charge → neuronal_fire → neuronal_reset`` path in
-:class:`spikingjelly.activation_based.neuron.SimpleBaseNode`. Production neurons
+the firing and reset equations. The
+:class:`spikingjelly.activation_based.neuron.SimpleBaseNode` interface expresses
+these stages directly through the
+``neuronal_charge → neuronal_fire → neuronal_reset`` path. Production neurons
 perform the equivalent computation in functional transitions or specialized
 kernels. The core firing expression in ``SimpleBaseNode.neuronal_fire`` is:
 
@@ -287,7 +291,9 @@ Some neurons support the ``cupy`` backend in both single-step and multi-step mod
 Custom Spiking Neurons
 -------------------------------------------
 SpikingJelly provides separate interfaces for modifying neuron dynamics and for
-high-performance execution:
+high-performance execution. ``SimpleBaseNode`` is a pure-PyTorch interface for
+teaching and customization, not a new neuron mathematical model. It prioritizes
+clear responsibilities and equations so that users can modify dynamics directly.
 
 .. list-table:: Neuron extension interfaces
     :header-rows: 1
@@ -315,8 +321,9 @@ Therefore, users normally only implement ``neuronal_charge``. ``SimpleIFNode`` a
 ``SimpleBaseNode`` does not define a native functional transition. Calling
 ``functional_forward`` directly raises an error. Calling
 :func:`to_functional_forward <spikingjelly.activation_based.base.to_functional_forward>`
-on a simple node uses the general fallback, which temporarily substitutes explicit
-state, runs the regular forward, and restores the module state. This preserves the
+on a module derived from ``SimpleBaseNode`` uses the general fallback, which
+temporarily substitutes explicit state, runs the regular forward, and restores
+the module state. This preserves the
 equation extension interface but is less efficient than native-functional neurons
 such as ``LIFNode``; it is not intended for high-performance workloads that
 repeatedly require functional conversion.

--- a/docs/source/tutorials/en/neuron.rst
+++ b/docs/source/tutorials/en/neuron.rst
@@ -84,14 +84,21 @@ We use the sub-threshold neuronal dynamics :math:`\frac{\mathrm{d}V(t)}{\mathrm{
 .. math::
     V[t] = f(V[t-1], X[t]) = V[t-1] + X[t]
 
-We can find the following codes in :class:`spikingjelly.activation_based.neuron.IFNode.neuronal_charge`:
+The equation is written directly in
+:class:`spikingjelly.activation_based.neuron.SimpleIFNode` for dynamics
+experiments:
 
 .. code-block:: python
 
     def neuronal_charge(self, x: torch.Tensor):
         self.v = self.v + x
 
-Different spiking neurons have different charging equations. But after the membrane potential exceeds the threshold voltage, the firing and resetting equations are the same. Hence, these equations are inherited from :class:`spikingjelly.activation_based.neuron.BaseNode`. We can find the codes in :class:`spikingjelly.activation_based.neuron.BaseNode.neuronal_fire`:
+Different spiking neurons have different charging equations but usually share
+the firing and reset equations. ``Simple`` neurons express these stages directly
+through the ``neuronal_charge → neuronal_fire → neuronal_reset`` path in
+:class:`spikingjelly.activation_based.neuron.SimpleBaseNode`. Production neurons
+perform the equivalent computation in functional transitions or specialized
+kernels. The core firing expression in ``SimpleBaseNode.neuronal_fire`` is:
 
 .. code-block:: python
 
@@ -104,10 +111,11 @@ Firing spike will consume the accumulated potential, and make the potential decr
 
 #. Hard reset: the membrane potential will be set to the reset voltage after firing: :math:`V[t] = V_{reset}`
 
-#. #. Soft reset: the membrane potential will decrease the threshold potential after firing: :math:`V[t] = V[t] - V_{threshold}`
+#. Soft reset: the membrane potential will decrease the threshold potential after firing: :math:`V[t] = V[t] - V_{threshold}`
 
 We can find that the neuron that uses soft reset does not need the attribute :math:`V_{reset}`. In the current implementation of :class:`spikingjelly.activation_based.neuron`, the default value of ``v_reset`` is ``0.0``, which means the neuron will use hard reset by default.\
-If we set ``v_reset = None``, then the neuron will use the soft reset. We can find the codes for neuronal reset in :class:`spikingjelly.activation_based.neuron.BaseNode.neuronal_reset`:
+If we set ``v_reset = None``, then the neuron will use the soft reset.
+``SimpleBaseNode.neuronal_reset`` uses the following equivalent logic:
 
 .. code-block:: python
 
@@ -278,21 +286,50 @@ Some neurons support the ``cupy`` backend in both single-step and multi-step mod
 
 Custom Spiking Neurons
 -------------------------------------------
-As mentioned above, SpikingJelly uses three equations: neuronal change, neuronal fire, and neuronal reset, to describe all kinds of spiking neurons.\
-We can find the corresponding codes in :class:`BaseNode <spikingjelly.activation_based.neuron.BaseNode>`. The forward of single-step, which is the ``single_step_forward`` function, \
-is composed of the three equations:
+SpikingJelly provides separate interfaces for modifying neuron dynamics and for
+high-performance execution:
 
-.. code-block:: python
+.. list-table:: Neuron extension interfaces
+    :header-rows: 1
+    :widths: 20 30 25 25
 
-    # spikingjelly.activation_based.neuron.BaseNode
-    def single_step_forward(self, x: torch.Tensor):
-        self.neuronal_charge(x)
-        spike = self.neuronal_fire()
-        self.neuronal_reset(spike)
-        return spike
+    * - Base class
+      - Forward model
+      - ``to_functional_forward``
+      - Intended use
+    * - :class:`SimpleBaseNode <spikingjelly.activation_based.neuron.SimpleBaseNode>`
+      - ``neuronal_charge`` → ``neuronal_fire`` → ``neuronal_reset``
+      - General state-substitution path
+      - Teaching, dynamics experiments, and rapid prototypes
+    * - :class:`BaseNode <spikingjelly.activation_based.neuron.BaseNode>`
+      - Native functional transition with optional sequence kernels
+      - Direct functional-forward call
+      - Production neurons and backend implementations
 
-``neuronal_fire`` and ``neuronal_reset`` are same for most spiking neurons, and are defined by ``BaseNode``. The difference of neurons are ``__init__`` and ``neuronal_charge`` functions.\
-Hence, if we want to implement a new kind of spiking neuron, we only need to change the ``__init__`` and ``neuronal_charge`` functions.
+Inherit from ``SimpleBaseNode`` when only the neuron equation needs to change. Its
+single-step forward always applies charge, fire, and reset in order, and its
+multi-step forward invokes the complete single-step forward at every time step.
+Therefore, users normally only implement ``neuronal_charge``. ``SimpleIFNode`` and
+``SimpleLIFNode`` use the same interface.
+
+``SimpleBaseNode`` does not define a native functional transition. Calling
+``functional_forward`` directly raises an error. Calling
+:func:`to_functional_forward <spikingjelly.activation_based.base.to_functional_forward>`
+on a simple node uses the general fallback, which temporarily substitutes explicit
+state, runs the regular forward, and restores the module state. This preserves the
+equation extension interface but is less efficient than native-functional neurons
+such as ``LIFNode``; it is not intended for high-performance workloads that
+repeatedly require functional conversion.
+
+Production ``MemoryModule`` implementations call
+``materialize_states(inputs, states, step_mode)`` before functional forward. Its
+default implementation returns states unchanged; override it only when scalar
+or empty states must become tensors based on the current inputs. ``inputs``
+contains the complete inputs of the current forward pass. An implementation may
+use ``step_mode`` to select the first time step as its reference in multi-step
+mode; it must not assume that every input has a time dimension. The method
+returns a new state tuple and must not mutate module memory. The former
+``BaseNode.v_float_to_tensor`` hook has been removed.
 
 Suppose we want to build a Square-Integrated-and-Fire neuron, whose neuronal charge equation is:
 
@@ -306,12 +343,9 @@ We can implement this kind of neuron by the following codes:
     import torch
     from spikingjelly.activation_based import neuron
 
-    class SquareIFNode(neuron.BaseNode):
+    class SquareIFNode(neuron.SimpleBaseNode):
         def neuronal_charge(self, x: torch.Tensor):
-            self.v = self.v + x ** 2
-
-:class:`BaseNode <spikingjelly.activation_based.neuron.BaseNode>` is inherited from :class:`MemoryModule <spikingjelly.activation_based.base.MemoryModule>`, \
-which uses ``for t in range(T)`` to call single-step forward function to implement the multi-step forward by default. So, after we define the  ``neuronal_charge``, then ``single_step_forward`` is completed, and ``multi_step_forward`` is also completed.
+            self.v = self.v + x.square()
 
 Use our ``SquareIFNode`` to implement the single/multi-step forward:
 
@@ -320,10 +354,9 @@ Use our ``SquareIFNode`` to implement the single/multi-step forward:
     import torch
     from spikingjelly.activation_based import neuron
 
-    class SquareIFNode(neuron.BaseNode):
-
+    class SquareIFNode(neuron.SimpleBaseNode):
         def neuronal_charge(self, x: torch.Tensor):
-            self.v = self.v + x ** 2
+            self.v = self.v + x.square()
 
     sif_layer = SquareIFNode()
 
@@ -359,3 +392,20 @@ The outputs are:
             [1.],
             [0.],
             [0.]])
+
+To implement a production neuron that converts directly like ``LIFNode`` and can
+provide CuPy, Triton, or Inductor kernels, inherit from ``BaseNode`` and implement
+``single_step_functional_forward``. Its interface is
+``(self, inputs, states, **kwargs) -> (outputs, updated_states)``. The method must
+not mutate registered module memories or the supplied ``states``. Override
+``multi_step_functional_forward`` only when an independent sequence implementation
+or specialized kernel exists.
+
+.. warning::
+
+    Regular ``BaseNode`` forward is now functional-backed, and
+    ``neuronal_charge``, ``neuronal_fire``, and ``neuronal_reset`` have been
+    removed from it. Existing subclasses that customize Python neuron equations
+    through these methods should change their base class to ``SimpleBaseNode``;
+    their existing equations do not need to be rewritten. Production neurons and
+    custom backends should migrate to the functional interface described above.

--- a/docs/source/tutorials/en/surrogate.rst
+++ b/docs/source/tutorials/en/surrogate.rst
@@ -28,12 +28,13 @@ Its derivative is the unit impulse function, which is defined by:
 If we use the unit impulse function to calculate the gradient and apply the gradient descent, the training will be very unstable. To solve this problem, the surrogate gradient method \
 is proposed. Refer to `Surrogate Gradient Learning in Spiking Neural Networks <https://arxiv.org/abs/1901.09948>`_ for more details.
 
-The surrogate function is used to generate spikes, which can be found in the codes of :class:`BaseNode.neuronal_fire <spikingjelly.activation_based.neuron.BaseNode.neuronal_fire>`:
+The surrogate function is used to generate spikes, as shown by
+:meth:`SimpleBaseNode.neuronal_fire <spikingjelly.activation_based.neuron.SimpleBaseNode.neuronal_fire>`:
 
 .. code-block:: python
 
     # spikingjelly.activation_based.neuron
-    class BaseNode(base.MemoryModule):
+    class SimpleBaseNode(base.MemoryModule):
         def __init__(..., surrogate_function: Callable = surrogate.Sigmoid(), ...)
         # ...
         self.surrogate_function = surrogate_function

--- a/spikingjelly/activation_based/ann2snn/operators.py
+++ b/spikingjelly/activation_based/ann2snn/operators.py
@@ -1,5 +1,5 @@
 import math
-from typing import Literal, Optional, Sequence, Tuple, Union
+from typing import Callable, Literal, Optional, Sequence, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -66,8 +66,9 @@ class TDModule(base.MemoryModule):
         memory 并返回当前差分输出；``step_mode="m"`` 时，输入第 0 维被解释为
         时间维，模块返回完整差分序列并保留最终 memory。普通 ANN/PyTorch 数值
         路径由 :meth:`ann_forward` 提供，且不读写 memory。子类必须实现
-        :meth:`ann_forward` 和 :meth:`multi_step_forward`。子类 ``__init__``
-        应调用 ``super().__init__(step_mode)`` 初始化步进模式。
+        :meth:`ann_forward`；默认多步 functional 前传会循环单步状态转移，具有
+        向量化序列算法的子类可重写 :meth:`multi_step_functional_forward`。子类
+        ``__init__`` 应调用 ``super().__init__(step_mode)`` 初始化步进模式。
 
         :param step_mode: 步进模式，``"s"`` 或 ``"m"``。默认 ``"m"`` 保持既有
             TD operator 行为。
@@ -93,9 +94,11 @@ class TDModule(base.MemoryModule):
         dimension 0 is interpreted as the time dimension; the module returns a
         full differential sequence and keeps the final memory. The ordinary
         ANN/PyTorch numeric path is exposed by :meth:`ann_forward` and does not
-        read or write memory. Subclasses must implement :meth:`ann_forward` and
-        :meth:`multi_step_forward`. Subclass ``__init__`` methods should call
-        ``super().__init__(step_mode)`` to initialize the step mode.
+        read or write memory. Subclasses must implement :meth:`ann_forward`. The
+        default multi-step functional forward rolls the single-step transition;
+        subclasses with a vectorized sequence algorithm may override
+        :meth:`multi_step_functional_forward`. Subclass ``__init__`` methods
+        should call ``super().__init__(step_mode)`` to initialize the step mode.
 
         :param step_mode: Step mode, ``"s"`` or ``"m"``. The default ``"m"``
             preserves existing TD operator behavior.
@@ -113,97 +116,74 @@ class TDModule(base.MemoryModule):
     def ann_forward(self, *args, **kwargs):
         raise NotImplementedError
 
-    def multi_step_forward(self, *args, **kwargs):
-        raise NotImplementedError(
-            f"{type(self).__name__} must implement multi_step_forward."
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        accumulated_inputs, x_cum, y_cum = self._accumulate_inputs(
+            inputs, states[0], states[1]
         )
-
-    def single_step_forward(self, *args, **kwargs):
-        y_cum = self.ann_forward(*self._accumulate_inputs(*args), **kwargs)
-        return self._diff_output(y_cum)
+        output_cum = self.ann_forward(*accumulated_inputs, **kwargs)
+        output, y_cum = self._diff_output(output_cum, y_cum)
+        return (output,), (x_cum, y_cum)
 
     @staticmethod
     def _same_tensor_meta(a: torch.Tensor, b: torch.Tensor) -> bool:
         return a.shape == b.shape and a.device == b.device and a.dtype == b.dtype
 
-    def _accumulate_one_input(self, x: torch.Tensor, index: int = 0) -> torch.Tensor:
-        if self.x_cum is None:
-            self.y_cum = None
-            x_cum = x
-        elif isinstance(self.x_cum, tuple):
-            prev = self.x_cum[index]
-            if prev is None or not self._same_tensor_meta(prev, x):
-                self.y_cum = None
-                x_cum = x
-            else:
-                x_cum = prev + x
-        else:
-            if not self._same_tensor_meta(self.x_cum, x):
-                self.y_cum = None
-                x_cum = x
-            else:
-                x_cum = self.x_cum + x
-
-        if isinstance(self.x_cum, tuple):
-            x_cum_values = list(self.x_cum)
-            x_cum_values[index] = x_cum
-            self.x_cum = tuple(x_cum_values)
-        else:
-            self.x_cum = x_cum
-        return x_cum
-
-    def _accumulate_inputs(self, *xs: torch.Tensor) -> Tuple[torch.Tensor, ...]:
-        if len(xs) == 1:
-            if isinstance(self.x_cum, tuple):
-                self.x_cum = None
-                self.y_cum = None
-            return (self._accumulate_one_input(xs[0]),)
-        if self.x_cum is None:
-            self.x_cum = tuple(None for _ in xs)
-            self.y_cum = None
-        elif not isinstance(self.x_cum, tuple) or len(self.x_cum) != len(xs):
-            self.x_cum = tuple(None for _ in xs)
-            self.y_cum = None
-        elif not all(
-            prev is not None
-            and isinstance(prev, torch.Tensor)
-            and self._same_tensor_meta(prev, x)
-            for prev, x in zip(self.x_cum, xs)
+    def _accumulate_inputs(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        x_cum: object,
+        y_cum: object,
+    ) -> tuple[tuple[torch.Tensor, ...], object, object]:
+        previous_inputs = x_cum if isinstance(x_cum, tuple) else (x_cum,)
+        if len(previous_inputs) != len(inputs) or not all(
+            isinstance(previous, torch.Tensor)
+            and self._same_tensor_meta(previous, current)
+            for previous, current in zip(previous_inputs, inputs)
         ):
-            self.x_cum = tuple(None for _ in xs)
-            self.y_cum = None
-        return tuple(self._accumulate_one_input(x, i) for i, x in enumerate(xs))
+            previous_inputs = (None,) * len(inputs)
+            y_cum = None
+        accumulated = tuple(
+            current if previous is None else previous + current
+            for previous, current in zip(previous_inputs, inputs)
+        )
+        x_cum = accumulated[0] if len(accumulated) == 1 else accumulated
+        return accumulated, x_cum, y_cum
 
-    def _diff_output(self, y_cum: torch.Tensor) -> torch.Tensor:
-        if (
-            self.y_cum is None
-            or not isinstance(self.y_cum, torch.Tensor)
-            or not self._same_tensor_meta(self.y_cum, y_cum)
+    def _diff_output(
+        self, output_cum: torch.Tensor, previous_output: object
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if not isinstance(previous_output, torch.Tensor) or not self._same_tensor_meta(
+            previous_output, output_cum
         ):
-            y = y_cum
+            output = output_cum
         else:
-            y = y_cum - self.y_cum
-        self.y_cum = y_cum
-        return y
+            output = output_cum - previous_output
+        return output, output_cum
 
-    def _diff_sequence_output(self, y_cum_seq: torch.Tensor) -> torch.Tensor:
-        if y_cum_seq.shape[0] == 0:
-            self.y_cum = None
-            return y_cum_seq
-        if (
-            self.y_cum is None
-            or not isinstance(self.y_cum, torch.Tensor)
-            or not self._same_tensor_meta(self.y_cum, y_cum_seq[0])
+    def _diff_sequence_output(
+        self, output_cum_seq: torch.Tensor, previous_output: object
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if not isinstance(previous_output, torch.Tensor) or not self._same_tensor_meta(
+            previous_output, output_cum_seq[0]
         ):
-            y_seq = _temporal_difference(y_cum_seq)
+            output_seq = _temporal_difference(output_cum_seq)
         else:
-            y_seq = torch.empty_like(y_cum_seq)
-            y_seq[0] = y_cum_seq[0] - self.y_cum
-            y_seq[1:] = y_cum_seq[1:] - y_cum_seq[:-1]
-        self.y_cum = y_cum_seq[-1].clone()
-        return y_seq
+            output_seq = torch.empty_like(output_cum_seq)
+            output_seq[0] = output_cum_seq[0] - previous_output
+            output_seq[1:] = output_cum_seq[1:] - output_cum_seq[:-1]
+        return output_seq, output_cum_seq[-1].clone()
 
-    def _td_sequence_forward(self, input_seqs: Tuple[torch.Tensor, ...], ann_forward):
+    def _td_sequence_forward(
+        self,
+        input_seqs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        ann_forward: Callable,
+    ) -> tuple[torch.Tensor, tuple[object, ...]]:
         for x_seq in input_seqs:
             if x_seq.shape[0] == 0:
                 raise ValueError(
@@ -211,10 +191,8 @@ class TDModule(base.MemoryModule):
                     f"dimension, but got shape {tuple(x_seq.shape)}."
                 )
         cum_seqs = tuple(x_seq.cumsum(dim=0) for x_seq in input_seqs)
-        if len(cum_seqs) == 1:
-            prev_inputs = self.x_cum if isinstance(self.x_cum, tuple) else (self.x_cum,)
-        else:
-            prev_inputs = self.x_cum
+        x_cum, y_cum = states
+        prev_inputs = x_cum if isinstance(x_cum, tuple) else (x_cum,)
 
         should_continue = (
             isinstance(prev_inputs, tuple)
@@ -232,13 +210,13 @@ class TDModule(base.MemoryModule):
                 for prev, x_cum_seq in zip(prev_inputs, cum_seqs, strict=True)
             )
         else:
-            self.y_cum = None
+            y_cum = None
 
         y_cum_seq = ann_forward(*cum_seqs)
-        y_seq = self._diff_sequence_output(y_cum_seq)
+        y_seq, y_cum = self._diff_sequence_output(y_cum_seq, y_cum)
         final_inputs = tuple(x_cum_seq[-1].clone() for x_cum_seq in cum_seqs)
-        self.x_cum = final_inputs[0] if len(final_inputs) == 1 else final_inputs
-        return y_seq
+        x_cum = final_inputs[0] if len(final_inputs) == 1 else final_inputs
+        return (y_seq,), (x_cum, y_cum)
 
 
 def _check_time_sequence(x_seq: torch.Tensor, module_name: str) -> None:
@@ -389,7 +367,12 @@ class TDSoftmax(TDModule):
     def ann_forward(self, x: torch.Tensor) -> torch.Tensor:
         return torch.softmax(x, dim=self.dim)
 
-    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         r"""
         .. rubric:: API Language
 
@@ -465,6 +448,7 @@ class TDSoftmax(TDModule):
         :raises ValueError: If ``x_seq`` has fewer than 2 dimensions, the time
             dimension is empty, or ``dim`` refers to the time dimension.
         """
+        x_seq = inputs[0]
         _check_time_sequence(x_seq, "TDSoftmax")
 
         dim = _resolve_dim(self.dim, x_seq.dim())
@@ -475,7 +459,7 @@ class TDSoftmax(TDModule):
             )
 
         return self._td_sequence_forward(
-            (x_seq,), lambda x_cum: torch.softmax(x_cum, dim=dim)
+            (x_seq,), states, lambda x_cum: torch.softmax(x_cum, dim=dim)
         )
 
     def extra_repr(self) -> str:
@@ -653,7 +637,12 @@ class TDLayerNorm(TDModule):
             self.eps,
         )
 
-    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         r"""
         .. rubric:: API Language
 
@@ -732,6 +721,7 @@ class TDLayerNorm(TDModule):
         :raises ValueError: If ``x_seq`` has fewer than 2 dimensions, the time
             dimension is empty, or the trailing shape does not match.
         """
+        x_seq = inputs[0]
         _check_time_sequence(x_seq, "TDLayerNorm")
         if len(self.normalized_shape) > x_seq.dim() - 1:
             trailing_shape = tuple(x_seq.shape[1:])
@@ -746,6 +736,7 @@ class TDLayerNorm(TDModule):
 
         return self._td_sequence_forward(
             (x_seq,),
+            states,
             lambda x_cum: F.layer_norm(
                 x_cum,
                 self.normalized_shape,
@@ -887,23 +878,38 @@ class TDRMSNorm(TDModule):
         """
         return F.rms_norm(x, self.normalized_shape, self.weight, self.eps)
 
-    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         r"""
-        对完整时间序列执行 TD RMSNorm。
-        Apply TD RMSNorm to a complete time sequence.
+        **API Language** - 中文 | English
 
-        :param x_seq: 输入时间差分序列，形状为 ``[T, ...]``，``T > 0``，尾部
-            形状必须匹配 ``normalized_shape``。 / Input differential sequence
-            with shape ``[T, ...]`` and ``T > 0`` whose trailing shape matches
-            ``normalized_shape``.
-        :type x_seq: torch.Tensor
-        :return: 与输入形状相同的 TD RMSNorm 差分序列。 / TD RMSNorm
-            differential sequence with the same shape as the input.
-        :rtype: torch.Tensor
-        :raises ValueError: 若时间维为空、输入维数不足或尾部形状不匹配。 / If
-            the time dimension is empty, rank is insufficient, or the trailing
+        对 ``inputs[0]`` 中的完整时间序列执行 TD RMSNorm。``states`` 为
+        ``(x_cum, y_cum)``，本方法不修改模块 memory。
+
+        Apply TD RMSNorm to the complete sequence in ``inputs[0]``. ``states``
+        contains ``(x_cum, y_cum)`` and module memories are not mutated.
+
+        :param inputs: 仅包含输入差分序列的元组，序列形状为 ``[T, ...]`` 且
+            ``T > 0``，尾部形状匹配 ``normalized_shape``。 / Tuple containing
+            the differential input sequence with shape ``[T, ...]``, ``T > 0``,
+            and trailing shape matching ``normalized_shape``.
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: 显式累计输入和累计输出 ``(x_cum, y_cum)``。 / Explicit
+            cumulative input and output states ``(x_cum, y_cum)``.
+        :type states: tuple[object, ...]
+        :return: ``((output_seq,), updated_states)``，其中输出序列形状与输入
+            相同。 / ``((output_seq,), updated_states)`` with an output sequence
+            matching the input shape.
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple[object, ...]]
+        :raises ValueError: 时间维为空、输入维数不足或尾部形状不匹配时抛出。 /
+            If the time dimension is empty, rank is insufficient, or the trailing
             shape does not match.
         """
+        x_seq = inputs[0]
         _check_time_sequence(x_seq, "TDRMSNorm")
         if len(self.normalized_shape) > x_seq.dim() - 1:
             trailing_shape = tuple(x_seq.shape[1:])
@@ -917,6 +923,7 @@ class TDRMSNorm(TDModule):
             )
         return self._td_sequence_forward(
             (x_seq,),
+            states,
             lambda x_cum: F.rms_norm(
                 x_cum,
                 self.normalized_shape,
@@ -1005,7 +1012,12 @@ class TDSiLU(TDModule):
         """
         return F.silu(x)
 
-    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         r"""
         对完整时间序列执行 TD SiLU。 / Apply TD SiLU to a complete sequence.
 
@@ -1018,8 +1030,9 @@ class TDSiLU(TDModule):
         :raises ValueError: 若输入维数不足或时间维为空。 / If input rank is
             insufficient or the time dimension is empty.
         """
+        x_seq = inputs[0]
         _check_time_sequence(x_seq, "TDSiLU")
-        return self._td_sequence_forward((x_seq,), F.silu)
+        return self._td_sequence_forward((x_seq,), states, F.silu)
 
 
 class TDGELU(TDModule):
@@ -1137,7 +1150,12 @@ class TDGELU(TDModule):
     def ann_forward(self, x: torch.Tensor) -> torch.Tensor:
         return F.gelu(x, approximate=self.approximate)
 
-    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         r"""
         .. rubric:: API Language
 
@@ -1212,10 +1230,13 @@ class TDGELU(TDModule):
         :raises ValueError: If ``x_seq`` has fewer than 2 dimensions or the time
             dimension is empty.
         """
+        x_seq = inputs[0]
         _check_time_sequence(x_seq, "TDGELU")
 
         return self._td_sequence_forward(
-            (x_seq,), lambda x_cum: F.gelu(x_cum, approximate=self.approximate)
+            (x_seq,),
+            states,
+            lambda x_cum: F.gelu(x_cum, approximate=self.approximate),
         )
 
     def extra_repr(self) -> str:
@@ -1361,7 +1382,12 @@ class TDLinear(TDModule):
     def ann_forward(self, x: torch.Tensor) -> torch.Tensor:
         return F.linear(x, self.weight, self.bias)
 
-    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         r"""
         **API Language:**
         :ref:`中文 <TDLinear.forward-cn>` |
@@ -1442,9 +1468,10 @@ class TDLinear(TDModule):
         :raises ValueError: If ``x_seq`` has fewer than 2 dimensions or the
             time dimension is empty.
         """
+        x_seq = inputs[0]
         _check_time_sequence(x_seq, "TDLinear")
 
-        return self._td_sequence_forward((x_seq,), self.ann_forward)
+        return self._td_sequence_forward((x_seq,), states, self.ann_forward)
 
     def extra_repr(self) -> str:
         return (
@@ -1645,7 +1672,13 @@ class TDConv2d(TDModule):
     def ann_forward(self, x: torch.Tensor) -> torch.Tensor:
         return self._conv2d(x, self.bias)
 
-    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x_seq = inputs[0]
         _check_time_sequence(x_seq, "TDConv2d")
         if x_seq.dim() != 5:
             raise ValueError(
@@ -1659,7 +1692,7 @@ class TDConv2d(TDModule):
             y = self._conv2d(x_cum_seq.flatten(0, 1), self.bias)
             return y.reshape(t, n, *y.shape[1:])
 
-        return self._td_sequence_forward((x_seq,), ann_forward)
+        return self._td_sequence_forward((x_seq,), states, ann_forward)
 
     def extra_repr(self) -> str:
         s = (
@@ -1758,9 +1791,12 @@ class SNNMatrixOperator(TDModule):
     def ann_forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
         return torch.matmul(a, b)
 
-    def multi_step_forward(
-        self, a_seq: torch.Tensor, b_seq: torch.Tensor
-    ) -> torch.Tensor:
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         r"""
         .. rubric:: API Language
 
@@ -1837,6 +1873,7 @@ class SNNMatrixOperator(TDModule):
         :raises ValueError: If an input has fewer than 3 dimensions, the time
             dimension is empty, or the time lengths differ.
         """
+        a_seq, b_seq = inputs
         if a_seq.dim() < 3:
             raise ValueError(
                 "SNNMatrixOperator expects a_seq with shape [T, ..., M, N] "
@@ -1850,7 +1887,7 @@ class SNNMatrixOperator(TDModule):
         _check_pair_time_sequence(a_seq, b_seq, "a_seq", "b_seq", "SNNMatrixOperator")
 
         a_seq, b_seq = _align_sequence_ranks(a_seq, b_seq)
-        return self._td_sequence_forward((a_seq, b_seq), torch.matmul)
+        return self._td_sequence_forward((a_seq, b_seq), states, torch.matmul)
 
 
 class SNNElementWiseProduct(TDModule):
@@ -1927,9 +1964,12 @@ class SNNElementWiseProduct(TDModule):
     def ann_forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
         return a * b
 
-    def multi_step_forward(
-        self, a_seq: torch.Tensor, b_seq: torch.Tensor
-    ) -> torch.Tensor:
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         r"""
         .. rubric:: API Language
 
@@ -2007,12 +2047,13 @@ class SNNElementWiseProduct(TDModule):
         :raises ValueError: If an input has fewer than 2 dimensions, the time
             dimension is empty, or the time lengths differ.
         """
+        a_seq, b_seq = inputs
         _check_pair_time_sequence(
             a_seq, b_seq, "a_seq", "b_seq", "SNNElementWiseProduct"
         )
 
         a_seq, b_seq = _align_sequence_ranks(a_seq, b_seq)
-        return self._td_sequence_forward((a_seq, b_seq), torch.mul)
+        return self._td_sequence_forward((a_seq, b_seq), states, torch.mul)
 
 
 class TDScaledDotProductAttention(TDModule):
@@ -2167,20 +2208,24 @@ class TDScaledDotProductAttention(TDModule):
             scale=self.scale,
         )
 
-    def single_step_forward(
+    def single_step_functional_forward(
         self,
-        query: torch.Tensor,
-        key: torch.Tensor,
-        value: torch.Tensor,
-        attn_mask: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        query, key, value = inputs[:3]
+        attn_mask = inputs[3] if len(inputs) > 3 else kwargs.get("attn_mask")
         if self.is_causal and attn_mask is not None:
             raise ValueError(
                 "TDScaledDotProductAttention does not allow attn_mask when "
                 "is_causal=True; use one masking mode at a time."
             )
-        query_cum, key_cum, value_cum = self._accumulate_inputs(query, key, value)
-        y_cum = F.scaled_dot_product_attention(
+        accumulated, x_cum, y_cum = self._accumulate_inputs(
+            inputs[:3], states[0], states[1]
+        )
+        query_cum, key_cum, value_cum = accumulated
+        output_cum = F.scaled_dot_product_attention(
             query_cum,
             key_cum,
             value_cum,
@@ -2189,15 +2234,15 @@ class TDScaledDotProductAttention(TDModule):
             is_causal=self.is_causal,
             scale=self.scale,
         )
-        return self._diff_output(y_cum)
+        output, y_cum = self._diff_output(output_cum, states[1])
+        return (output,), (x_cum, y_cum)
 
-    def multi_step_forward(
+    def multi_step_functional_forward(
         self,
-        query_seq: torch.Tensor,
-        key_seq: torch.Tensor,
-        value_seq: torch.Tensor,
-        attn_mask: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         r"""
         .. rubric:: API Language
 
@@ -2303,6 +2348,8 @@ class TDScaledDotProductAttention(TDModule):
             dimension is empty, the time lengths differ, or ``attn_mask`` is
             passed when ``is_causal=True``.
         """
+        query_seq, key_seq, value_seq = inputs[:3]
+        attn_mask = inputs[3] if len(inputs) > 3 else kwargs.get("attn_mask")
         _check_attention_sequence(query_seq, "query_seq", "TDScaledDotProductAttention")
         _check_attention_sequence(key_seq, "key_seq", "TDScaledDotProductAttention")
         _check_attention_sequence(value_seq, "value_seq", "TDScaledDotProductAttention")
@@ -2323,6 +2370,7 @@ class TDScaledDotProductAttention(TDModule):
             )
         return self._td_sequence_forward(
             (query_seq, key_seq, value_seq),
+            states,
             lambda query_cum, key_cum, value_cum: F.scaled_dot_product_attention(
                 query_cum,
                 key_cum,
@@ -2658,17 +2706,18 @@ class TDMultiheadAttention(TDModule):
         out = self.out_proj.ann_forward(self._merge_heads_single(attn))
         return out, None
 
-    def single_step_forward(
+    def single_step_functional_forward(
         self,
-        query: torch.Tensor,
-        key: torch.Tensor,
-        value: torch.Tensor,
-        key_padding_mask: Optional[torch.Tensor] = None,
-        need_weights: bool = False,
-        attn_mask: Optional[torch.Tensor] = None,
-        average_attn_weights: bool = True,
-        is_causal: bool = False,
-    ) -> Tuple[torch.Tensor, None]:
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        query, key, value = inputs
+        key_padding_mask = kwargs.get("key_padding_mask")
+        need_weights = kwargs.get("need_weights", False)
+        attn_mask = kwargs.get("attn_mask")
+        average_attn_weights = kwargs.get("average_attn_weights", True)
+        is_causal = kwargs.get("is_causal", False)
         self._check_forward_options(
             key_padding_mask, need_weights, average_attn_weights
         )
@@ -2683,7 +2732,10 @@ class TDMultiheadAttention(TDModule):
                 "is_causal=True; use one masking mode at a time."
             )
         attn_mask = self._canonical_mha_attn_mask(attn_mask, q.shape[0])
-        q_cum, k_cum, v_cum = self._accumulate_inputs(q, k, v)
+        accumulated, x_cum, y_cum = self._accumulate_inputs(
+            (q, k, v), states[0], states[1]
+        )
+        q_cum, k_cum, v_cum = accumulated
         attn_cum = F.scaled_dot_product_attention(
             q_cum,
             k_cum,
@@ -2692,21 +2744,16 @@ class TDMultiheadAttention(TDModule):
             dropout_p=0.0,
             is_causal=is_causal,
         )
-        attn = self._diff_output(attn_cum)
+        attn, y_cum = self._diff_output(attn_cum, y_cum)
         out = self.out_proj.single_step_forward(self._merge_heads_single(attn))
-        return out, None
+        return (out,), (x_cum, y_cum)
 
-    def multi_step_forward(
+    def multi_step_functional_forward(
         self,
-        query_seq: torch.Tensor,
-        key_seq: torch.Tensor,
-        value_seq: torch.Tensor,
-        key_padding_mask: Optional[torch.Tensor] = None,
-        need_weights: bool = False,
-        attn_mask: Optional[torch.Tensor] = None,
-        average_attn_weights: bool = True,
-        is_causal: bool = False,
-    ) -> Tuple[torch.Tensor, None]:
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         r"""
         **API Language:**
         :ref:`中文 <TDMultiheadAttention.forward-cn>` |
@@ -2802,6 +2849,12 @@ class TDMultiheadAttention(TDModule):
         :raises ValueError: If unsupported masks/options or invalid shapes are
             passed.
         """
+        query_seq, key_seq, value_seq = inputs
+        key_padding_mask = kwargs.get("key_padding_mask")
+        need_weights = kwargs.get("need_weights", False)
+        attn_mask = kwargs.get("attn_mask")
+        average_attn_weights = kwargs.get("average_attn_weights", True)
+        is_causal = kwargs.get("is_causal", False)
         self._check_forward_options(
             key_padding_mask, need_weights, average_attn_weights
         )
@@ -2816,8 +2869,9 @@ class TDMultiheadAttention(TDModule):
         v_seq = self._split_heads(self.v_proj.multi_step_forward(value_seq))
         self._check_attention_leading_dims(q_seq, k_seq, v_seq, "TDMultiheadAttention")
         attn_mask = self._canonical_mha_attn_mask(attn_mask, q_seq.shape[1])
-        attn_seq = self._td_sequence_forward(
+        (attn_seq,), states = self._td_sequence_forward(
             (q_seq, k_seq, v_seq),
+            states,
             lambda q_cum, k_cum, v_cum: F.scaled_dot_product_attention(
                 q_cum,
                 k_cum,
@@ -2828,7 +2882,53 @@ class TDMultiheadAttention(TDModule):
             ),
         )
         out_seq = self.out_proj.multi_step_forward(self._merge_heads(attn_seq))
-        return out_seq, None
+        return (out_seq,), states
+
+    def single_step_forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        key_padding_mask: Optional[torch.Tensor] = None,
+        need_weights: bool = False,
+        attn_mask: Optional[torch.Tensor] = None,
+        average_attn_weights: bool = True,
+        is_causal: bool = False,
+    ) -> Tuple[torch.Tensor, None]:
+        output = super().single_step_forward(
+            query,
+            key,
+            value,
+            key_padding_mask=key_padding_mask,
+            need_weights=need_weights,
+            attn_mask=attn_mask,
+            average_attn_weights=average_attn_weights,
+            is_causal=is_causal,
+        )
+        return output, None
+
+    def multi_step_forward(
+        self,
+        query_seq: torch.Tensor,
+        key_seq: torch.Tensor,
+        value_seq: torch.Tensor,
+        key_padding_mask: Optional[torch.Tensor] = None,
+        need_weights: bool = False,
+        attn_mask: Optional[torch.Tensor] = None,
+        average_attn_weights: bool = True,
+        is_causal: bool = False,
+    ) -> Tuple[torch.Tensor, None]:
+        output = super().multi_step_forward(
+            query_seq,
+            key_seq,
+            value_seq,
+            key_padding_mask=key_padding_mask,
+            need_weights=need_weights,
+            attn_mask=attn_mask,
+            average_attn_weights=average_attn_weights,
+            is_causal=is_causal,
+        )
+        return output, None
 
     def extra_repr(self) -> str:
         return (

--- a/spikingjelly/activation_based/ann2snn/recipes/spikezip_qann.py
+++ b/spikingjelly/activation_based/ann2snn/recipes/spikezip_qann.py
@@ -90,32 +90,47 @@ class SpikeZIPLinear(TDLinear):
         self.register_memory("realize_time", self.bias_steps)
         self.register_memory("is_work", False)
 
-    def _release_bias(self, y: torch.Tensor) -> torch.Tensor:
-        if self.spikezip_bias is None or self.realize_time <= 0:
-            return y
-        self.realize_time -= 1
-        self.is_work = True
-        bias = self.spikezip_bias.to(device=y.device, dtype=y.dtype)
-        return y + bias / self.bias_steps
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        outputs, td_states = super().single_step_functional_forward(
+            inputs, states[:2], **kwargs
+        )
+        y = outputs[0]
+        realize_time = states[2]
+        released_bias = self.spikezip_bias is not None and realize_time > 0
+        if released_bias:
+            y = (
+                y
+                + self.spikezip_bias.to(device=y.device, dtype=y.dtype)
+                / self.bias_steps
+            )
+            realize_time -= 1
+        is_work = not bool((inputs[0] == 0).all()) or released_bias
+        return (y,), (*td_states, realize_time, is_work)
 
-    def single_step_forward(self, x: torch.Tensor) -> torch.Tensor:
-        y = super().single_step_forward(x)
-        self.is_work = not bool((x == 0).all())
-        return self._release_bias(y)
-
-    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
-        y_seq = super().multi_step_forward(x_seq)
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        (y_seq,), td_states = super().multi_step_functional_forward(
+            inputs, states[:2], **kwargs
+        )
+        x_seq = inputs[0]
         active = bool((x_seq != 0).any())
-        bias_steps = min(x_seq.shape[0], self.realize_time)
+        bias_steps = min(x_seq.shape[0], states[2])
         if self.spikezip_bias is not None and bias_steps > 0:
             bias = self.spikezip_bias.to(device=x_seq.device, dtype=x_seq.dtype)
             view_shape = (1,) * (y_seq.dim() - 1) + (bias.numel(),)
             y_seq[:bias_steps] = (
                 y_seq[:bias_steps] + bias.view(view_shape) / self.bias_steps
             )
-            self.realize_time -= bias_steps
-        self.is_work = active or bias_steps > 0
-        return y_seq
+        return (y_seq,), (*td_states, states[2] - bias_steps, active or bias_steps > 0)
 
 
 class SpikeZIPConv2d(TDConv2d):
@@ -153,31 +168,43 @@ class SpikeZIPConv2d(TDConv2d):
         self.register_memory("realize_time", self.bias_steps)
         self.register_memory("is_work", False)
 
-    def _release_bias(self, y: torch.Tensor) -> torch.Tensor:
-        if self.spikezip_bias is None or self.realize_time <= 0:
-            return y
-        self.realize_time -= 1
-        self.is_work = True
-        bias = self.spikezip_bias.to(device=y.device, dtype=y.dtype)
-        return y + bias.view(1, -1, 1, 1) / self.bias_steps
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        outputs, td_states = super().single_step_functional_forward(
+            inputs, states[:2], **kwargs
+        )
+        y = outputs[0]
+        realize_time = states[2]
+        released_bias = self.spikezip_bias is not None and realize_time > 0
+        if released_bias:
+            bias = self.spikezip_bias.to(device=y.device, dtype=y.dtype)
+            y = y + bias.view(1, -1, 1, 1) / self.bias_steps
+            realize_time -= 1
+        is_work = not bool((inputs[0] == 0).all()) or released_bias
+        return (y,), (*td_states, realize_time, is_work)
 
-    def single_step_forward(self, x: torch.Tensor) -> torch.Tensor:
-        y = super().single_step_forward(x)
-        self.is_work = not bool((x == 0).all())
-        return self._release_bias(y)
-
-    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
-        y_seq = super().multi_step_forward(x_seq)
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        (y_seq,), td_states = super().multi_step_functional_forward(
+            inputs, states[:2], **kwargs
+        )
+        x_seq = inputs[0]
         active = bool((x_seq != 0).any())
-        bias_steps = min(x_seq.shape[0], self.realize_time)
+        bias_steps = min(x_seq.shape[0], states[2])
         if self.spikezip_bias is not None and bias_steps > 0:
             bias = self.spikezip_bias.to(device=x_seq.device, dtype=x_seq.dtype)
             y_seq[:bias_steps] = (
                 y_seq[:bias_steps] + bias.view(1, 1, -1, 1, 1) / self.bias_steps
             )
-            self.realize_time -= bias_steps
-        self.is_work = active or bias_steps > 0
-        return y_seq
+        return (y_seq,), (*td_states, states[2] - bias_steps, active or bias_steps > 0)
 
 
 class SpikeZIPEmbedding(base.MemoryModule):
@@ -187,19 +214,31 @@ class SpikeZIPEmbedding(base.MemoryModule):
         self.step_mode = "s"
         self.register_memory("t", 0)
 
-    def single_step_forward(self, x: torch.Tensor) -> torch.Tensor:
-        if self.t == 0:
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        if states[0] == 0:
             y = self.embedding(x)
-            self.t += 1
-            return y
-        return torch.zeros(
-            *x.shape,
-            self.embedding.embedding_dim,
-            device=x.device,
-            dtype=self.embedding.weight.dtype,
-        )
+        else:
+            y = torch.zeros(
+                *x.shape,
+                self.embedding.embedding_dim,
+                device=x.device,
+                dtype=self.embedding.weight.dtype,
+            )
+        return (y,), (1 if states[0] == 0 else states[0],)
 
-    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x_seq = inputs[0]
         if x_seq.shape[0] == 0:
             raise ValueError("SpikeZIPEmbedding expects a non-empty sequence.")
         y0 = self.embedding(x_seq[0])
@@ -210,8 +249,7 @@ class SpikeZIPEmbedding(base.MemoryModule):
             dtype=y0.dtype,
         )
         y_seq[0] = y0
-        self.t = x_seq.shape[0]
-        return y_seq
+        return (y_seq,), (x_seq.shape[0],)
 
 
 class SpikeZIPLayerNorm(TDLayerNorm):
@@ -256,7 +294,7 @@ class SpikeZIPRobertaSelfAttention(base.MemoryModule):
         self.softmax = SpikeZIPSoftmax(dim=-1)
         self.dropout = copy.deepcopy(getattr(source, "dropout", nn.Identity()))
         self.step_mode = "s"
-        self.t = 0
+        self.register_memory("t", 0)
         self.position_embedding_type = getattr(
             source,
             "position_embedding_type",
@@ -281,7 +319,6 @@ class SpikeZIPRobertaSelfAttention(base.MemoryModule):
             self.softmax,
         ):
             module.reset()
-        self.t = 0
 
     def transpose_for_scores(self, x: torch.Tensor) -> torch.Tensor:
         shape = (*x.size()[:-1], self.num_attention_heads, self.attention_head_size)
@@ -303,16 +340,19 @@ class SpikeZIPRobertaSelfAttention(base.MemoryModule):
         if head_mask is not None:
             raise ValueError("SpikeZIPTFQANNRecipe v1 does not support head_mask.")
 
-    def single_step_forward(
+    def single_step_functional_forward(
         self,
-        hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
-        head_mask: Optional[torch.Tensor] = None,
-        encoder_hidden_states: Optional[torch.Tensor] = None,
-        encoder_attention_mask: Optional[torch.Tensor] = None,
-        past_key_value=None,
-        output_attentions: bool = False,
-    ):
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        hidden_states = inputs[0]
+        attention_mask = kwargs.get("attention_mask")
+        head_mask = kwargs.get("head_mask")
+        encoder_hidden_states = kwargs.get("encoder_hidden_states")
+        encoder_attention_mask = kwargs.get("encoder_attention_mask")
+        past_key_value = kwargs.get("past_key_value")
+        output_attentions = kwargs.get("output_attentions", False)
         self._validate_inputs(
             head_mask,
             encoder_hidden_states,
@@ -331,7 +371,7 @@ class SpikeZIPRobertaSelfAttention(base.MemoryModule):
         k_sum = self.transpose_for_scores(self.key_if.accumulated)
         scores = _matmul_delta(query_layer, key_layer, q_sum, k_sum, True)
         scores = scores / math.sqrt(self.attention_head_size)
-        if attention_mask is not None and self.t == 0:
+        if attention_mask is not None and states[0] == 0:
             scores = scores + attention_mask
         attention_probs = self.softmax(scores)
         attention_probs = self.dropout(attention_probs)
@@ -345,19 +385,22 @@ class SpikeZIPRobertaSelfAttention(base.MemoryModule):
         context = self.after_attn_if(context)
         context = context.transpose(-3, -2).contiguous()
         context = context.view(*context.size()[:-2], self.all_head_size)
-        self.t += 1
-        return (context, attention_probs) if output_attentions else (context,)
+        outputs = (context, attention_probs) if output_attentions else (context,)
+        return outputs, (states[0] + 1,)
 
-    def multi_step_forward(
+    def multi_step_functional_forward(
         self,
-        hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
-        head_mask: Optional[torch.Tensor] = None,
-        encoder_hidden_states: Optional[torch.Tensor] = None,
-        encoder_attention_mask: Optional[torch.Tensor] = None,
-        past_key_value=None,
-        output_attentions: bool = False,
-    ):
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        hidden_states = inputs[0]
+        attention_mask = kwargs.get("attention_mask")
+        head_mask = kwargs.get("head_mask")
+        encoder_hidden_states = kwargs.get("encoder_hidden_states")
+        encoder_attention_mask = kwargs.get("encoder_attention_mask")
+        past_key_value = kwargs.get("past_key_value")
+        output_attentions = kwargs.get("output_attentions", False)
         self._validate_inputs(
             head_mask,
             encoder_hidden_states,
@@ -402,11 +445,25 @@ class SpikeZIPRobertaSelfAttention(base.MemoryModule):
                 self.all_head_size,
             )
             if output_attentions:
-                return context_seq, attention_probs
-            return (context_seq,)
+                outputs = (context_seq, attention_probs)
+            else:
+                outputs = (context_seq,)
+            return outputs, states
         finally:
             for module, step_mode in step_modes.items():
                 module.step_mode = step_mode
+
+    def single_step_forward(
+        self, hidden_states: torch.Tensor, **kwargs: object
+    ) -> tuple[torch.Tensor, ...]:
+        outputs = super().single_step_forward(hidden_states, **kwargs)
+        return outputs if isinstance(outputs, tuple) else (outputs,)
+
+    def multi_step_forward(
+        self, hidden_states: torch.Tensor, **kwargs: object
+    ) -> tuple[torch.Tensor, ...]:
+        outputs = super().multi_step_forward(hidden_states, **kwargs)
+        return outputs if isinstance(outputs, tuple) else (outputs,)
 
 
 class SpikeZIPViTSelfAttention(base.MemoryModule):
@@ -452,7 +509,13 @@ class SpikeZIPViTSelfAttention(base.MemoryModule):
         qkv = self.qkv(x).reshape(*x.shape[:-1], 3, self.num_heads, self.head_dim)
         return qkv.movedim(-3, 0).transpose(-3, -2).unbind(0)
 
-    def single_step_forward(self, x: torch.Tensor) -> torch.Tensor:
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
         batch_size, seq_len, channels = x.shape
         query, key, value = self._split_qkv(x)
 
@@ -484,9 +547,15 @@ class SpikeZIPViTSelfAttention(base.MemoryModule):
         context = context.transpose(-3, -2).reshape(batch_size, seq_len, channels)
         context = self.proj(context)
         context = self.proj_drop(context)
-        return self.proj_if(context)
+        return (self.proj_if(context),), states
 
-    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x_seq = inputs[0]
         step_modes = {
             module: module.step_mode
             for module in self.modules()
@@ -522,7 +591,7 @@ class SpikeZIPViTSelfAttention(base.MemoryModule):
             context = context.transpose(-3, -2).reshape(x_seq.shape)
             context = self.proj(context)
             context = self.proj_drop(context)
-            return self.proj_if(context)
+            return (self.proj_if(context),), states
         finally:
             for module, step_mode in step_modes.items():
                 module.step_mode = step_mode

--- a/spikingjelly/activation_based/ann2snn/recipes/spikezip_qann.py
+++ b/spikingjelly/activation_based/ann2snn/recipes/spikezip_qann.py
@@ -123,8 +123,10 @@ class SpikeZIPLinear(TDLinear):
         )
         x_seq = inputs[0]
         active = bool((x_seq != 0).any())
-        bias_steps = min(x_seq.shape[0], states[2])
-        if self.spikezip_bias is not None and bias_steps > 0:
+        bias_steps = (
+            min(x_seq.shape[0], states[2]) if self.spikezip_bias is not None else 0
+        )
+        if bias_steps > 0:
             bias = self.spikezip_bias.to(device=x_seq.device, dtype=x_seq.dtype)
             view_shape = (1,) * (y_seq.dim() - 1) + (bias.numel(),)
             y_seq[:bias_steps] = (
@@ -198,8 +200,10 @@ class SpikeZIPConv2d(TDConv2d):
         )
         x_seq = inputs[0]
         active = bool((x_seq != 0).any())
-        bias_steps = min(x_seq.shape[0], states[2])
-        if self.spikezip_bias is not None and bias_steps > 0:
+        bias_steps = (
+            min(x_seq.shape[0], states[2]) if self.spikezip_bias is not None else 0
+        )
+        if bias_steps > 0:
             bias = self.spikezip_bias.to(device=x_seq.device, dtype=x_seq.dtype)
             y_seq[:bias_steps] = (
                 y_seq[:bias_steps] + bias.view(1, 1, -1, 1, 1) / self.bias_steps
@@ -307,6 +311,7 @@ class SpikeZIPRobertaSelfAttention(base.MemoryModule):
             )
 
     def reset(self) -> None:
+        super().reset()
         for module in (
             self.query,
             self.key,
@@ -428,7 +433,7 @@ class SpikeZIPRobertaSelfAttention(base.MemoryModule):
                 transpose_b=True,
             )
             scores = scores / math.sqrt(self.attention_head_size)
-            if attention_mask is not None:
+            if attention_mask is not None and states[0] == 0:
                 scores = scores.clone()
                 scores[0] = scores[0] + attention_mask
             attention_probs = self.softmax(scores)
@@ -448,7 +453,7 @@ class SpikeZIPRobertaSelfAttention(base.MemoryModule):
                 outputs = (context_seq, attention_probs)
             else:
                 outputs = (context_seq,)
-            return outputs, states
+            return outputs, (states[0] + hidden_states.shape[0],)
         finally:
             for module, step_mode in step_modes.items():
                 module.step_mode = step_mode
@@ -488,6 +493,7 @@ class SpikeZIPViTSelfAttention(base.MemoryModule):
             self.softmax = SpikeZIPSoftmax(dim=-1)
 
     def reset(self) -> None:
+        super().reset()
         modules = [
             self.qkv,
             self.proj,

--- a/spikingjelly/activation_based/ann2snn/recipes/sta_transformer.py
+++ b/spikingjelly/activation_based/ann2snn/recipes/sta_transformer.py
@@ -204,18 +204,7 @@ class _STASpikeEncoder(base.MemoryModule):
         states: tuple[object, ...],
         step_mode: str,
     ) -> tuple[object, ...]:
-        x = inputs[0]
-        if step_mode == "m":
-            if x.dim() < 2:
-                raise ValueError(
-                    "STA spike encoder multi-step forward expects an input "
-                    "sequence with a time dimension and at least one data dimension."
-                )
-            if x.shape[0] == 0:
-                raise ValueError(
-                    "STA spike encoder expects a non-empty time dimension."
-                )
-            x = x[0]
+        x = inputs[0][0] if step_mode == "m" else inputs[0]
         mem = states[0]
         if (
             mem is None
@@ -246,14 +235,6 @@ class _STASpikeEncoder(base.MemoryModule):
         spike_count = torch.trunc(mem / threshold)
         spike = spike_count * threshold
         return (spike,), (mem - spike,)
-
-    def multi_step_functional_forward(
-        self,
-        inputs: tuple[torch.Tensor, ...],
-        states: tuple[object, ...],
-        **kwargs: object,
-    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
-        return super().multi_step_functional_forward(inputs, states, **kwargs)
 
     def _reset_sta_state(self) -> None:
         self.reset()

--- a/spikingjelly/activation_based/ann2snn/recipes/sta_transformer.py
+++ b/spikingjelly/activation_based/ann2snn/recipes/sta_transformer.py
@@ -198,40 +198,62 @@ class _STASpikeEncoder(base.MemoryModule):
         self.register_memory("mem", None)
         self.step_mode = step_mode
 
+    def materialize_states(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        step_mode: str,
+    ) -> tuple[object, ...]:
+        x = inputs[0]
+        if step_mode == "m":
+            if x.dim() < 2:
+                raise ValueError(
+                    "STA spike encoder multi-step forward expects an input "
+                    "sequence with a time dimension and at least one data dimension."
+                )
+            if x.shape[0] == 0:
+                raise ValueError(
+                    "STA spike encoder expects a non-empty time dimension."
+                )
+            x = x[0]
+        mem = states[0]
+        if (
+            mem is None
+            or mem.shape != x.shape
+            or mem.device != x.device
+            or mem.dtype != x.dtype
+        ):
+            mem = torch.zeros_like(x)
+        return (mem,)
+
     @staticmethod
     def _broadcast_threshold(
         threshold: torch.Tensor, output: torch.Tensor, channel_dim: int
     ) -> torch.Tensor:
         return _broadcast_channel_vector(threshold, output, channel_dim)
 
-    def single_step_forward(self, x: torch.Tensor) -> torch.Tensor:
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
         threshold = self._broadcast_threshold(self.v_threshold, x, self.channel_dim)
         threshold = torch.clamp(threshold, min=torch.finfo(threshold.dtype).eps)
-        if (
-            self.mem is None
-            or self.mem.shape != x.shape
-            or self.mem.device != x.device
-            or self.mem.dtype != x.dtype
-        ):
-            self.mem = torch.zeros_like(x)
-        self.mem = self.mem + x
-        spike_count = torch.trunc(self.mem / threshold)
+        mem = states[0]
+        mem = mem + x
+        spike_count = torch.trunc(mem / threshold)
         spike = spike_count * threshold
-        self.mem = self.mem - spike
-        return spike
+        return (spike,), (mem - spike,)
 
-    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
-        if x_seq.dim() < 2:
-            raise ValueError(
-                "STA spike encoder multi-step forward expects an input sequence "
-                "with a time dimension and at least one data dimension."
-            )
-        if x_seq.shape[0] == 0:
-            raise ValueError("STA spike encoder expects a non-empty time dimension.")
-        outputs = []
-        for x in x_seq:
-            outputs.append(self.single_step_forward(x))
-        return torch.stack(outputs, dim=0)
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        return super().multi_step_functional_forward(inputs, states, **kwargs)
 
     def _reset_sta_state(self) -> None:
         self.reset()
@@ -258,13 +280,22 @@ class _STAConstant(base.MemoryModule):
         self.register_memory("t", 0)
         self.step_mode = step_mode
 
-    def single_step_forward(self) -> torch.Tensor:
-        output = self.value if self.t == 0 else torch.zeros_like(self.value)
-        self.t += 1
-        return output
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        output = self.value if states[0] == 0 else torch.zeros_like(self.value)
+        return (output,), (states[0] + 1,)
 
-    def multi_step_forward(self) -> torch.Tensor:
-        if self.t == 0:
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        if states[0] == 0:
             zeros = torch.zeros_like(self.value).expand(
                 self.time_steps - 1, *self.value.shape
             )
@@ -273,8 +304,21 @@ class _STAConstant(base.MemoryModule):
             output = torch.zeros_like(self.value).expand(
                 self.time_steps, *self.value.shape
             )
-        self.t += self.time_steps
-        return output
+        return (output,), (states[0] + self.time_steps,)
+
+    def single_step_forward(self) -> torch.Tensor:
+        outputs, states = self.single_step_functional_forward(
+            (), tuple(self._memories.values())
+        )
+        self.t = states[0]
+        return outputs[0]
+
+    def multi_step_forward(self) -> torch.Tensor:
+        outputs, states = self.multi_step_functional_forward(
+            (), tuple(self._memories.values())
+        )
+        self.t = states[0]
+        return outputs[0]
 
 
 class STATransformerRecipe(ConversionRecipe):

--- a/spikingjelly/activation_based/ann2snn/recipes/transformer_td_equivalent.py
+++ b/spikingjelly/activation_based/ann2snn/recipes/transformer_td_equivalent.py
@@ -47,9 +47,9 @@ class _TDTanh(TDModule):
     def multi_step_functional_forward(
         self,
         inputs: tuple[torch.Tensor, ...],
-        states: tuple[object, ...],
-        **kwargs: object,
-    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        states: tuple[Any, ...],
+        **kwargs: Any,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[Any, ...]]:
         return self._td_sequence_forward((inputs[0],), states, torch.tanh)
 
 

--- a/spikingjelly/activation_based/ann2snn/recipes/transformer_td_equivalent.py
+++ b/spikingjelly/activation_based/ann2snn/recipes/transformer_td_equivalent.py
@@ -44,8 +44,13 @@ class _TDTanh(TDModule):
     def ann_forward(self, x: torch.Tensor) -> torch.Tensor:
         return torch.tanh(x)
 
-    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
-        return self._td_sequence_forward((x_seq,), torch.tanh)
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        return self._td_sequence_forward((inputs[0],), states, torch.tanh)
 
 
 class TransformerTDEquivalentRecipe(ConversionRecipe):

--- a/spikingjelly/activation_based/base.py
+++ b/spikingjelly/activation_based/base.py
@@ -1544,7 +1544,9 @@ def to_functional_forward(
                 f"{module.__class__.__name__} expected {num_states} states, "
                 f"but got {len(states)}."
             )
-        original_memories = [memory_module._memories for memory_module, _ in layout]
+        original_attributes = [
+            memory_module.__dict__.copy() for memory_module, _ in layout
+        ]
         offset = 0
         for memory_module, names in layout:
             values = states[offset : offset + len(names)]
@@ -1564,8 +1566,9 @@ def to_functional_forward(
                 for name in names
             )
         finally:
-            for (memory_module, _), original in zip(layout, original_memories):
-                memory_module.__dict__["_memories"] = original
+            for (memory_module, _), original in zip(layout, original_attributes):
+                memory_module.__dict__.clear()
+                memory_module.__dict__.update(original)
         return outputs, updated_states
 
     return fallback_forward

--- a/spikingjelly/activation_based/base.py
+++ b/spikingjelly/activation_based/base.py
@@ -696,8 +696,6 @@ class MemoryModule(nn.Module, StepModule):
         """
         inputs = (x, *args)
         states = self.materialize_states(inputs, tuple(self._memories.values()), "s")
-        for name, value in zip(self._memories, states, strict=True):
-            self._memories[name] = value
         outputs, updated_states = self.single_step_functional_forward(
             inputs, states, **kwargs
         )
@@ -746,8 +744,6 @@ class MemoryModule(nn.Module, StepModule):
         """
         inputs = (x_seq, *args)
         states = self.materialize_states(inputs, tuple(self._memories.values()), "m")
-        for name, value in zip(self._memories, states, strict=True):
-            self._memories[name] = value
         outputs, updated_states = self.multi_step_functional_forward(
             inputs, states, **kwargs
         )

--- a/spikingjelly/activation_based/base.py
+++ b/spikingjelly/activation_based/base.py
@@ -1,6 +1,5 @@
 from spikingjelly.logger import logger
 import copy
-from abc import abstractmethod
 from typing import Tuple, Generator, Optional, Callable, Any
 
 import torch
@@ -440,7 +439,224 @@ class MemoryModule(nn.Module, StepModule):
         check_backend_library(value)
         self._backend = value
 
-    @abstractmethod
+    def materialize_states(
+        self,
+        inputs: tuple[Any, ...],
+        states: tuple[Any, ...],
+        step_mode: str,
+    ) -> tuple[Any, ...]:
+        r"""
+        **API Language** - :ref:`中文 <MemoryModule.materialize_states-cn>` | :ref:`English <MemoryModule.materialize_states-en>`
+
+        ----
+
+        .. _MemoryModule.materialize_states-cn:
+
+        * **中文**
+
+        默认实现原样返回 ``states``。需要将标量或空状态转换为输入相关张量的
+        模块可以重写本方法。``inputs`` 是当前前向传播的完整输入；实现根据
+        ``step_mode`` 选择合适的形状和设备参照。实现不得修改模块 memory 或
+        传入的 ``states``。
+
+        :param inputs: 当前前向传播的完整输入元组
+        :type inputs: tuple[Any, ...]
+        :param states: 待物化的显式状态
+        :type states: tuple[Any, ...]
+        :param step_mode: 当前前向传播的步进模式，取 ``"s"`` 或 ``"m"``
+        :type step_mode: str
+        :return: 可传入 functional forward 的状态
+        :rtype: tuple[Any, ...]
+
+        ----
+
+        .. _MemoryModule.materialize_states-en:
+
+        * **English**
+
+        The default implementation returns ``states`` unchanged. Modules that
+        need to turn scalar or empty states into input-dependent tensors may
+        override this method. ``inputs`` contains the complete inputs of the
+        current forward pass; implementations select an appropriate shape and
+        device reference according to ``step_mode``. Implementations must not
+        mutate module memories or the supplied ``states``.
+
+        :param inputs: Complete input tuple of the current forward pass
+        :type inputs: tuple[Any, ...]
+        :param states: Explicit states to materialize
+        :type states: tuple[Any, ...]
+        :param step_mode: Step mode of the current forward pass, ``"s"`` or ``"m"``
+        :type step_mode: str
+        :return: States ready for functional forward
+        :rtype: tuple[Any, ...]
+        """
+        return states
+
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[Any, ...],
+        **kwargs: Any,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[Any, ...]]:
+        r"""
+        **API Language** - :ref:`中文 <MemoryModule.single_step_functional_forward-cn>` | :ref:`English <MemoryModule.single_step_functional_forward-en>`
+
+        ----
+
+        .. _MemoryModule.single_step_functional_forward-cn:
+
+        * **中文**
+
+        使用显式状态执行单步前向传播。实现不得修改本模块注册的 memory
+        或传入的 ``states``。``states`` 的顺序与当前模块的
+        ``self._memories`` 一致，不包含子模块状态。复合模块的完整状态由
+        :func:`to_functional_forward` 负责展开。
+
+        :param inputs: 单步输入张量元组
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: 当前模块的显式状态元组
+        :type states: tuple[Any, ...]
+        :return: ``(outputs, updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple[Any, ...]]
+        :raises NotImplementedError: 当子类未实现单步 functional forward 时抛出
+
+        ----
+
+        .. _MemoryModule.single_step_functional_forward-en:
+
+        * **English**
+
+        Run a single-step forward pass with explicit state. The implementation
+        must not mutate this module's registered memories or the supplied
+        ``states``. State order follows ``self._memories`` and excludes states
+        owned by child modules. Use :func:`to_functional_forward` to flatten the
+        complete state of a composite module.
+
+        :param inputs: Tuple of single-step input tensors
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: Tuple of explicit states owned by this module
+        :type states: tuple[Any, ...]
+        :return: ``(outputs, updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple[Any, ...]]
+        :raises NotImplementedError: If the subclass does not implement single-step functional forward
+        """
+        raise NotImplementedError(
+            f"{self._get_name()} does not implement single_step_functional_forward."
+        )
+
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[Any, ...],
+        **kwargs: Any,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[Any, ...]]:
+        r"""
+        **API Language** - :ref:`中文 <MemoryModule.multi_step_functional_forward-cn>` | :ref:`English <MemoryModule.multi_step_functional_forward-en>`
+
+        ----
+
+        .. _MemoryModule.multi_step_functional_forward-cn:
+
+        * **中文**
+
+        使用显式状态执行多步前向传播。输入张量的第 0 维为时间维。
+        默认实现逐时间步调用 :meth:`single_step_functional_forward`；具有
+        专用多步实现或 kernel 的子类可以重写本方法。实现不得修改本模块
+        注册的 memory 或传入的 ``states``。
+
+        :param inputs: 多步输入张量元组
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: 当前模块的显式状态元组
+        :type states: tuple[Any, ...]
+        :return: ``(outputs, updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple[Any, ...]]
+
+        ----
+
+        .. _MemoryModule.multi_step_functional_forward-en:
+
+        * **English**
+
+        Run a multi-step forward pass with explicit state. Dimension 0 of each
+        input tensor is the time dimension. The default implementation calls
+        :meth:`single_step_functional_forward` at each time step. Subclasses with
+        a specialized sequence implementation or kernel may override this method.
+        The implementation must not mutate this module's registered memories or
+        the supplied ``states``.
+
+        :param inputs: Tuple of multi-step input tensors
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: Tuple of explicit states owned by this module
+        :type states: tuple[Any, ...]
+        :return: ``(outputs, updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple[Any, ...]]
+        """
+        output_steps = []
+        for t in range(inputs[0].shape[0]):
+            outputs, states = self.single_step_functional_forward(
+                tuple(x[t] for x in inputs), states, **kwargs
+            )
+            output_steps.append(outputs)
+
+        return (
+            tuple(
+                torch.stack(output_seq)
+                for output_seq in zip(*output_steps, strict=True)
+            ),
+            states,
+        )
+
+    def functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[Any, ...],
+        **kwargs: Any,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[Any, ...]]:
+        r"""
+        **API Language** - :ref:`中文 <MemoryModule.functional_forward-cn>` | :ref:`English <MemoryModule.functional_forward-en>`
+
+        ----
+
+        .. _MemoryModule.functional_forward-cn:
+
+        * **中文**
+
+        先调用 :meth:`materialize_states`，再按当前 ``step_mode`` 调用单步或
+        多步 functional forward。
+
+        :param inputs: 输入张量元组
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: 当前模块的显式状态元组
+        :type states: tuple[Any, ...]
+        :return: ``(outputs, updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple[Any, ...]]
+        :raises ValueError: 当 ``step_mode`` 不是 ``"s"`` 或 ``"m"`` 时抛出
+
+        ----
+
+        .. _MemoryModule.functional_forward-en:
+
+        * **English**
+
+        Call :meth:`materialize_states`, then dispatch to single-step or
+        multi-step functional forward according to the current ``step_mode``.
+
+        :param inputs: Tuple of input tensors
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: Tuple of explicit states owned by this module
+        :type states: tuple[Any, ...]
+        :return: ``(outputs, updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple[Any, ...]]
+        :raises ValueError: If ``step_mode`` is neither ``"s"`` nor ``"m"``
+        """
+        if self.step_mode == "s":
+            states = self.materialize_states(inputs, states, "s")
+            return self.single_step_functional_forward(inputs, states, **kwargs)
+        if self.step_mode == "m":
+            states = self.materialize_states(inputs, states, "m")
+            return self.multi_step_functional_forward(inputs, states, **kwargs)
+        raise ValueError(self.step_mode)
+
     def single_step_forward(self, x: torch.Tensor, *args, **kwargs):
         r"""
         **API Language** - :ref:`中文 <MemoryModule.single_step_forward-cn>` | :ref:`English <MemoryModule.single_step_forward-en>`
@@ -451,13 +667,15 @@ class MemoryModule(nn.Module, StepModule):
 
         * **中文**
 
-        本模块的单步的前向传播函数。
+        基于 :meth:`single_step_functional_forward` 执行单步前向传播：读取
+        ``self._memories``，执行显式状态转移，再写回更新后的状态。
 
         :param x: 输入张量，约定 ``shape = [N, *]``，其中 ``N`` 通常为 batch 维
         :type x: torch.Tensor
 
         :return: 单步前向传播的输出
         :rtype: Any
+        :raises ValueError: 更新状态数量与已注册 memory 数量不一致时抛出
 
         ----
 
@@ -465,15 +683,27 @@ class MemoryModule(nn.Module, StepModule):
 
         * **English**
 
-        The single-step forward function for this module.
+        Run a single-step forward pass through
+        :meth:`single_step_functional_forward`: read ``self._memories``, execute
+        the explicit state transition, and write the updated states back.
 
         :param x: Input tensor, conventionally with ``shape = [N, *]`` where ``N`` is usually the batch dimension
         :type x: torch.Tensor
 
         :return: Output of the single-step forward pass
         :rtype: Any
+        :raises ValueError: If the number of updated states does not match the registered memories
         """
-        pass
+        inputs = (x, *args)
+        states = self.materialize_states(inputs, tuple(self._memories.values()), "s")
+        for name, value in zip(self._memories, states, strict=True):
+            self._memories[name] = value
+        outputs, updated_states = self.single_step_functional_forward(
+            inputs, states, **kwargs
+        )
+        for name, value in zip(self._memories.keys(), updated_states, strict=True):
+            self._memories[name] = value
+        return outputs[0] if len(outputs) == 1 else outputs
 
     def multi_step_forward(self, x_seq: torch.Tensor, *args, **kwargs):
         r"""
@@ -485,7 +715,8 @@ class MemoryModule(nn.Module, StepModule):
 
         * **中文**
 
-        本模块的多步的前向传播函数，通过调用 ``T`` 次 ``single_step_forward(x[t], *args, **kwargs)`` 实现
+        基于 :meth:`multi_step_functional_forward` 执行多步前向传播：读取
+        ``self._memories``，执行显式状态转移，再写回更新后的状态。
 
         :param x_seq: 输入序列张量，约定 ``shape = [T, N, *]``，其中第 0 维为时间维
         :type x_seq: torch.Tensor
@@ -493,7 +724,7 @@ class MemoryModule(nn.Module, StepModule):
         :return: 按时间堆叠的输出序列
         :rtype: torch.Tensor
 
-        :raises RuntimeError: 若某个时间步返回值无法被 ``torch.stack`` 堆叠，则底层异常会原样向上传播
+        :raises ValueError: 更新状态数量与已注册 memory 数量不一致时抛出
 
         ----
 
@@ -501,8 +732,9 @@ class MemoryModule(nn.Module, StepModule):
 
         * **English**
 
-        The multi-step forward function for this module, which is implemented by
-        calling ``single_step_forward(x[t], *args, **kwargs)`` over ``T`` time steps.
+        Run a multi-step forward pass through
+        :meth:`multi_step_functional_forward`: read ``self._memories``, execute
+        the explicit state transition, and write the updated states back.
 
         :param x_seq: Input sequence tensor, conventionally with ``shape = [T, N, *]`` and the time axis at dimension 0
         :type x_seq: torch.Tensor
@@ -510,15 +742,18 @@ class MemoryModule(nn.Module, StepModule):
         :return: Output sequence stacked along the time dimension
         :rtype: torch.Tensor
 
-        :raises RuntimeError: Any stacking failure raised by ``torch.stack`` is propagated unchanged
+        :raises ValueError: If the number of updated states does not match the registered memories
         """
-        T = x_seq.shape[0]
-        y_seq = []
-        for t in range(T):
-            y = self.single_step_forward(x_seq[t], *args, **kwargs)
-            y_seq.append(y)
-
-        return torch.stack(y_seq, dim=0)
+        inputs = (x_seq, *args)
+        states = self.materialize_states(inputs, tuple(self._memories.values()), "m")
+        for name, value in zip(self._memories, states, strict=True):
+            self._memories[name] = value
+        outputs, updated_states = self.multi_step_functional_forward(
+            inputs, states, **kwargs
+        )
+        for name, value in zip(self._memories, updated_states, strict=True):
+            self._memories[name] = value
+        return outputs[0] if len(outputs) == 1 else outputs
 
     def forward(self, *args, **kwargs):
         r"""
@@ -530,8 +765,8 @@ class MemoryModule(nn.Module, StepModule):
 
         * **中文**
 
-        若为单步模式 ``step_mode == "s"``，则调用 ``self.single_step_forward(...)`` 。
-        若为多步模式 ``step_mode == "m"``，则调用 ``self.multi_step_forward(...)`` 。
+        按 ``step_mode`` 调用 :meth:`single_step_forward` 或
+        :meth:`multi_step_forward`。functional 状态读写由这两个方法负责。
 
         :return: 与当前 ``step_mode`` 对应的前向传播结果
         :rtype: Any
@@ -544,8 +779,9 @@ class MemoryModule(nn.Module, StepModule):
 
         * **English**
 
-        Call ``self.single_step_forward(...)`` if ``step_mode == "s"``.
-        Call ``self.multi_step_forward(...)`` if ``step_mode == "m"``.
+        Dispatch to :meth:`single_step_forward` or :meth:`multi_step_forward`
+        according to ``step_mode``. Those methods own functional state loading
+        and committing.
 
         :return: Forward result selected according to the current ``step_mode``
         :rtype: Any
@@ -554,10 +790,9 @@ class MemoryModule(nn.Module, StepModule):
         """
         if self.step_mode == "s":
             return self.single_step_forward(*args, **kwargs)
-        elif self.step_mode == "m":
+        if self.step_mode == "m":
             return self.multi_step_forward(*args, **kwargs)
-        else:
-            raise ValueError(self.step_mode)
+        raise ValueError(self.step_mode)
 
     def extra_repr(self):
         r"""
@@ -1081,33 +1316,9 @@ def load_memories(module: nn.Module, memory_list: list):
         _assign_memory_by_name(module, name, value)
 
 
-class _FunctionalForward:
-    def __init__(self, module: nn.Module, fn: Optional[Callable] = None):
-        self.module = module
-        self.fn = fn if fn is not None else module.forward
-        self.num_states = len(list(named_memories(module)))
-
-    def __call__(self, *args):
-        if self.num_states == 0:  # stateless
-            return self.fn(*args)
-
-        inputs = args[: -self.num_states]
-        states = args[-self.num_states :]
-        original_states = extract_memories(self.module)
-        load_memories(self.module, states)
-
-        try:
-            outputs = self.fn(*inputs)
-            new_states = extract_memories(self.module)
-        finally:
-            load_memories(self.module, original_states)
-
-        if not isinstance(outputs, tuple):
-            outputs = (outputs,)
-        return (*outputs, *new_states)
-
-
-def to_functional_forward(module: nn.Module, fn: Optional[Callable] = None):
+def to_functional_forward(
+    module: nn.Module, fn: Optional[Callable] = None
+) -> Callable[..., tuple[tuple[torch.Tensor, ...], tuple[Any, ...]]]:
     r"""
     **API Language** - :ref:`中文 <to_functional_forward-cn>` | :ref:`English <to_functional_forward-en>`
 
@@ -1119,7 +1330,8 @@ def to_functional_forward(module: nn.Module, fn: Optional[Callable] = None):
 
     给定一个可能包含隐式状态变量（记忆，memory）的模块，获取其显式状态的前向传播函数。
 
-    对于包含状态的模块，返回的函数签名为 ``(*inputs, *states) -> (*outputs, *new_states)`` ，
+    返回的函数签名为
+    ``(inputs, states, **kwargs) -> (outputs, updated_states)`` ，
     其中：
 
     - ``inputs`` 为原始 ``forward`` 所需的常规输入参数；
@@ -1127,13 +1339,13 @@ def to_functional_forward(module: nn.Module, fn: Optional[Callable] = None):
     - ``outputs`` 为原始 ``forward`` 的输出结果；
     - ``new_states`` 为执行前向传播后更新得到的状态变量。
 
-    若模块中不存在任何状态变量，则直接返回 ``module.forward`` 本身。
+    单个输入和输出也使用 tuple 包装。状态顺序与
+    ``extract_memories(module)`` 一致。
 
     .. note::
 
-        该函数通过在调用过程中 **临时替换模块内部状态** 的方式实现功能转换，
-        并在执行结束后 **恢复原始状态** ，
-        因此对模块本身不产生副作用。
+        转换优先直接使用 MemoryModule 的 functional 实现，其次递归组合
+        ``nn.Sequential``，其他模块才使用临时 ``_memories`` 字典替换。
 
     .. warning::
 
@@ -1151,7 +1363,7 @@ def to_functional_forward(module: nn.Module, fn: Optional[Callable] = None):
     :return: 带有显式输入输出状态的前向传播函数
     :rtype: Callable
 
-    :raises ValueError: 若后续调用时提供的显式状态数量与 ``module`` 当前 memory 布局不一致，则相关 helper 可能抛出异常
+    :raises ValueError: 调用时的状态数量或 memory 布局与转换时不一致
 
     ----
 
@@ -1162,8 +1374,8 @@ def to_functional_forward(module: nn.Module, fn: Optional[Callable] = None):
     Given a module that may contain implicit state variables, get the forward function
     with explicit state variables.
 
-    For a stateful module, the returned function has the following signature
-    ``(*inputs, *states) -> (*outputs, *new_states)``
+    The returned function has the signature
+    ``(inputs, states, **kwargs) -> (outputs, updated_states)``
     where:
 
     - ``inputs`` are the regular input arguments required by the original ``forward``;
@@ -1172,14 +1384,14 @@ def to_functional_forward(module: nn.Module, fn: Optional[Callable] = None):
     - ``outputs`` are the outputs of the original ``forward`` method;
     - ``new_states`` are the updated memory variables after the forward pass.
 
-    If the module does not contain any memory variables, ``module.forward`` is returned directly.
+    Single inputs and outputs are still wrapped in tuples. State order matches
+    ``extract_memories(module)``.
 
     .. note::
 
-        The conversion is implemented by **temporarily loading the provided states** into
-        the module, executing the original forward pass, extracting the updated states,
-        and finally **restoring the original internal states**. Therefore, this operation
-        has no side effects on the module itself.
+        Conversion first uses a MemoryModule functional implementation directly,
+        then recursively composes ``nn.Sequential`` modules. Other modules use a
+        temporary ``_memories`` dictionary swap as the fallback.
 
     .. warning::
 
@@ -1196,8 +1408,9 @@ def to_functional_forward(module: nn.Module, fn: Optional[Callable] = None):
            Defaults to ``None``.
     :type fn: Optional[Callable]
 
-    :return: a functional-style forward function with explicit and flattened states
+    :return: a functional-style forward function with grouped inputs and states
     :rtype: Callable
+    :raises ValueError: If the state count or memory layout differs from conversion time
 
     ----
 
@@ -1223,9 +1436,140 @@ def to_functional_forward(module: nn.Module, fn: Optional[Callable] = None):
         f_forward = base.to_functional_forward(module)
         x = torch.randn(3, 10)
         initial_state = torch.tensor(0.0)
-        output, new_state = f_forward(x, initial_state)
+        outputs, new_states = f_forward((x,), (initial_state,))
 
-        assert torch.equal(output, module.linear(x))
-        assert torch.equal(new_state, initial_state + 1.0)
+        assert torch.equal(outputs[0], module.linear(x))
+        assert torch.equal(new_states[0], initial_state + 1.0)
     """
-    return _FunctionalForward(module, fn)
+    memory_modules = [
+        child for child in module.modules() if isinstance(child, MemoryModule)
+    ]
+    layout = [(child, tuple(child._memories)) for child in memory_modules]
+    num_states = sum(len(names) for _, names in layout)
+
+    if fn is None and isinstance(module, nn.Sequential):
+        occurrences = [
+            id(child) for _, child in module.named_modules(remove_duplicate=False)
+        ]
+        if len(occurrences) == len(set(occurrences)) and not (
+            isinstance(module, MemoryModule) and module._memories
+        ):
+            children = list(module._modules.values())
+            child_forwards = [to_functional_forward(child) for child in children]
+            child_state_counts = [
+                sum(
+                    len(memory_module._memories)
+                    for memory_module in child.modules()
+                    if isinstance(memory_module, MemoryModule)
+                )
+                for child in children
+            ]
+
+            def sequential_forward(
+                inputs: tuple[torch.Tensor, ...],
+                states: tuple[Any, ...],
+                **kwargs: Any,
+            ) -> tuple[tuple[torch.Tensor, ...], tuple[Any, ...]]:
+                if len(states) != num_states:
+                    raise ValueError(
+                        f"{module.__class__.__name__} expected {num_states} states, "
+                        f"but got {len(states)}."
+                    )
+                outputs = inputs
+                updated_states = []
+                offset = 0
+                for index, (child_forward, state_count) in enumerate(
+                    zip(child_forwards, child_state_counts)
+                ):
+                    child_states = states[offset : offset + state_count]
+                    outputs, child_updated_states = child_forward(
+                        outputs,
+                        child_states,
+                        **(kwargs if index == 0 else {}),
+                    )
+                    updated_states.extend(child_updated_states)
+                    offset += state_count
+                return outputs, tuple(updated_states)
+
+            return sequential_forward
+
+    if fn is None and isinstance(module, MemoryModule):
+        method_names = ["functional_forward"]
+        if module.step_mode == "s":
+            method_names.append("single_step_functional_forward")
+        elif module.step_mode == "m":
+            method_names.extend(
+                ("single_step_functional_forward", "multi_step_functional_forward")
+            )
+        has_functional_forward = any(
+            getattr(type(module), name) is not getattr(MemoryModule, name)
+            for name in method_names
+        )
+        if has_functional_forward and len(memory_modules) == 1:
+
+            def direct_forward(
+                inputs: tuple[torch.Tensor, ...],
+                states: tuple[Any, ...],
+                **kwargs: Any,
+            ) -> tuple[tuple[torch.Tensor, ...], tuple[Any, ...]]:
+                if len(states) != num_states:
+                    raise ValueError(
+                        f"{module._get_name()} expected {num_states} states, "
+                        f"but got {len(states)}."
+                    )
+                outputs, updated_states = module.functional_forward(
+                    inputs, states, **kwargs
+                )
+                return outputs, updated_states
+
+            return direct_forward
+
+    if fn is None and isinstance(module, nn.Sequential):
+
+        def forward_fn(*inputs, **kwargs):
+            outputs = inputs
+            for index, child in enumerate(module._modules.values()):
+                result = child(*outputs, **(kwargs if index == 0 else {}))
+                outputs = (
+                    tuple(result) if isinstance(result, (tuple, list)) else (result,)
+                )
+            return outputs[0] if len(outputs) == 1 else outputs
+
+    else:
+        forward_fn = module.forward if fn is None else fn
+
+    def fallback_forward(
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[Any, ...],
+        **kwargs: Any,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[Any, ...]]:
+        if len(states) != num_states:
+            raise ValueError(
+                f"{module.__class__.__name__} expected {num_states} states, "
+                f"but got {len(states)}."
+            )
+        original_memories = [memory_module._memories for memory_module, _ in layout]
+        offset = 0
+        for memory_module, names in layout:
+            values = states[offset : offset + len(names)]
+            temporary = dict(zip(names, values))
+            memory_module.__dict__["_memories"] = temporary
+            offset += len(names)
+
+        try:
+            outputs = forward_fn(*inputs, **kwargs)
+            if isinstance(outputs, (tuple, list)):
+                outputs = tuple(outputs)
+            else:
+                outputs = (outputs,)
+            updated_states = tuple(
+                memory_module._memories[name]
+                for memory_module, names in layout
+                for name in names
+            )
+        finally:
+            for (memory_module, _), original in zip(layout, original_memories):
+                memory_module.__dict__["_memories"] = original
+        return outputs, updated_states
+
+    return fallback_forward

--- a/spikingjelly/activation_based/encoding.py
+++ b/spikingjelly/activation_based/encoding.py
@@ -67,7 +67,6 @@ class StatelessEncoder(nn.Module, base.StepModule):
 
         :param x: 输入数据
         :type x: torch.Tensor
-
         :return: 脉冲张量，形状与 ``x.shape`` 相同
         :rtype: torch.Tensor
 
@@ -81,7 +80,6 @@ class StatelessEncoder(nn.Module, base.StepModule):
 
         :param x: input data
         :type x: torch.Tensor
-
         :return: spike, whose shape is same with ``x.shape``
         :rtype: torch.Tensor
         """
@@ -177,15 +175,22 @@ class StatefulEncoder(base.MemoryModule):
         :rtype: torch.Tensor
         """
 
-        if self.spike is None:
-            self.single_step_encode(x)
+        return super().single_step_forward(x)
 
-        t = self.t
-        self.t = (self.t + 1) % self.T
-        return self.spike[t]
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        spike, t = states
+        if spike is None:
+            spike = self.single_step_encode(inputs[0])
+        output = spike[t]
+        return (output,), (spike, (t + 1) % spike.shape[0])
 
     @abstractmethod
-    def single_step_encode(self, x: torch.Tensor):
+    def single_step_encode(self, x: torch.Tensor) -> torch.Tensor:
         r"""
         **API Language** - :ref:`中文 <StatefulEncoder.single_step_encode-cn>` | :ref:`English <StatefulEncoder.single_step_encode-en>`
 
@@ -283,7 +288,7 @@ class PeriodicEncoder(StatefulEncoder):
         """
         super().__init__(spike.shape[0], step_mode)
 
-    def single_step_encode(self, spike: torch.Tensor):
+    def single_step_encode(self, spike: torch.Tensor) -> torch.Tensor:
         r"""
         **API Language** - :ref:`中文 <PeriodicEncoder.single_step_encode-cn>` | :ref:`English <PeriodicEncoder.single_step_encode-en>`
 
@@ -310,8 +315,7 @@ class PeriodicEncoder(StatefulEncoder):
         :param spike: the spike tensor, whose 0-th dimension is the encoding period
         :type spike: torch.Tensor
         """
-        self.spike = spike
-        self.T = spike.shape[0]
+        return spike
 
 
 class LatencyEncoder(StatefulEncoder):
@@ -413,7 +417,7 @@ class LatencyEncoder(StatefulEncoder):
 
         self.enc_function = enc_function
 
-    def single_step_encode(self, x: torch.Tensor):
+    def single_step_encode(self, x: torch.Tensor) -> torch.Tensor:
         r"""
         **API Language** - :ref:`中文 <LatencyEncoder.single_step_encode-cn>` | :ref:`English <LatencyEncoder.single_step_encode-en>`
 
@@ -445,11 +449,11 @@ class LatencyEncoder(StatefulEncoder):
         else:
             t_f = ((self.T - 1.0) * (1.0 - x)).round().long()
 
-        self.spike = F.one_hot(t_f, num_classes=self.T).to(x)
+        spike = F.one_hot(t_f, num_classes=self.T).to(x)
         # [*, T] -> [T, *]
-        d_seq = list(range(self.spike.ndim - 1))
-        d_seq.insert(0, self.spike.ndim - 1)
-        self.spike = self.spike.permute(d_seq)
+        d_seq = list(range(spike.ndim - 1))
+        d_seq.insert(0, spike.ndim - 1)
+        return spike.permute(d_seq)
 
 
 class PoissonEncoder(StatelessEncoder):
@@ -607,7 +611,7 @@ class WeightedPhaseEncoder(StatefulEncoder):
         """
         super().__init__(K, step_mode)
 
-    def single_step_encode(self, x: torch.Tensor):
+    def single_step_encode(self, x: torch.Tensor) -> torch.Tensor:
         r"""
         **API Language** - :ref:`中文 <WeightedPhaseEncoder.single_step_encode-cn>` | :ref:`English <WeightedPhaseEncoder.single_step_encode-en>`
 
@@ -638,14 +642,15 @@ class WeightedPhaseEncoder(StatefulEncoder):
         """
         assert (x >= 0).all() and (x <= 1 - 2 ** (-self.T)).all()
         inputs = x.clone()
-        self.spike = torch.empty(
+        spike = torch.empty(
             (self.T,) + x.shape, device=x.device
         )  # Encoding to [T, batch_size, *]
         w = 0.5
         for i in range(self.T):
-            self.spike[i] = inputs >= w
-            inputs -= w * self.spike[i]
+            spike[i] = inputs >= w
+            inputs -= w * spike[i]
             w *= 0.5
+        return spike
 
 
 class PopSpikeEncoderDeterministic(nn.Module):

--- a/spikingjelly/activation_based/examples/Spiking_A2C.py
+++ b/spikingjelly/activation_based/examples/Spiking_A2C.py
@@ -31,35 +31,10 @@ torch.manual_seed(seed)
 torch.backends.cudnn.deterministic = True
 
 
-class NonSpikingLIFNode(neuron.LIFNode):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
+class NonSpikingLIFNode(neuron.SimpleLIFNode):
     def single_step_forward(self, x: torch.Tensor):
-        self.v_float_to_tensor(x)
-
-        if self.training:
-            self.neuronal_charge(x)
-        else:
-            if self.v_reset is None:
-                if self.decay_input:
-                    self.v = self.neuronal_charge_decay_input_reset0(
-                        x, self.v, self.tau
-                    )
-                else:
-                    self.v = self.neuronal_charge_no_decay_input_reset0(
-                        x, self.v, self.tau
-                    )
-
-            else:
-                if self.decay_input:
-                    self.v = self.neuronal_charge_decay_input(
-                        x, self.v, self.v_reset, self.tau
-                    )
-                else:
-                    self.v = self.neuronal_charge_no_decay_input(
-                        x, self.v, self.v_reset, self.tau
-                    )
+        self.neuronal_charge(x)
+        return self.v
 
 
 # Neural Network
@@ -71,14 +46,14 @@ class ActorCritic(nn.Module):
             layer.Linear(num_inputs, hidden_size),
             neuron.IFNode(),
             layer.Linear(hidden_size, 1),
-            NonSpikingLIFNode(tau=2.0),
+            NonSpikingLIFNode(tau=2.0, decay_input=True),
         )
 
         self.actor = nn.Sequential(
             layer.Linear(num_inputs, hidden_size),
             neuron.IFNode(),
             layer.Linear(hidden_size, num_outputs),
-            NonSpikingLIFNode(tau=2.0),
+            NonSpikingLIFNode(tau=2.0, decay_input=True),
         )
 
         self.T = T

--- a/spikingjelly/activation_based/examples/Spiking_DQN_state.py
+++ b/spikingjelly/activation_based/examples/Spiking_DQN_state.py
@@ -37,35 +37,15 @@ class ReplayMemory(object):
         return len(self.memory)
 
 
-class NonSpikingLIFNode(neuron.LIFNode):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+class NonSpikingLIFNode(neuron.SimpleLIFNode):
+    r"""A LIF integrator without spike generation for the DQN readout layer.
+
+    用于 DQN 读出层、不生成脉冲的 LIF 积分器。
+    """
 
     def single_step_forward(self, x: torch.Tensor):
-        self.v_float_to_tensor(x)
-
-        if self.training:
-            self.neuronal_charge(x)
-        else:
-            if self.v_reset is None:
-                if self.decay_input:
-                    self.v = self.neuronal_charge_decay_input_reset0(
-                        x, self.v, self.tau
-                    )
-                else:
-                    self.v = self.neuronal_charge_no_decay_input_reset0(
-                        x, self.v, self.tau
-                    )
-
-            else:
-                if self.decay_input:
-                    self.v = self.neuronal_charge_decay_input(
-                        x, self.v, self.v_reset, self.tau
-                    )
-                else:
-                    self.v = self.neuronal_charge_no_decay_input(
-                        x, self.v, self.v_reset, self.tau
-                    )
+        self.neuronal_charge(x)
+        return self.v
 
 
 # Spiking DQN algorithm
@@ -77,7 +57,7 @@ class DQSN(nn.Module):
             layer.Linear(input_size, hidden_size),
             neuron.IFNode(),
             layer.Linear(hidden_size, output_size),
-            NonSpikingLIFNode(tau=2.0),
+            NonSpikingLIFNode(tau=2.0, decay_input=True),
         )
 
         self.T = T

--- a/spikingjelly/activation_based/examples/Spiking_PPO.py
+++ b/spikingjelly/activation_based/examples/Spiking_PPO.py
@@ -50,35 +50,10 @@ if __name__ == "__main__":
     env.seed(seed)
 
     # Neural Network
-    class NonSpikingLIFNode(neuron.LIFNode):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-
+    class NonSpikingLIFNode(neuron.SimpleLIFNode):
         def single_step_forward(self, x: torch.Tensor):
-            self.v_float_to_tensor(x)
-
-            if self.training:
-                self.neuronal_charge(x)
-            else:
-                if self.v_reset is None:
-                    if self.decay_input:
-                        self.v = self.neuronal_charge_decay_input_reset0(
-                            x, self.v, self.tau
-                        )
-                    else:
-                        self.v = self.neuronal_charge_no_decay_input_reset0(
-                            x, self.v, self.tau
-                        )
-
-                else:
-                    if self.decay_input:
-                        self.v = self.neuronal_charge_decay_input(
-                            x, self.v, self.v_reset, self.tau
-                        )
-                    else:
-                        self.v = self.neuronal_charge_no_decay_input(
-                            x, self.v, self.v_reset, self.tau
-                        )
+            self.neuronal_charge(x)
+            return self.v
 
     class ActorCritic(nn.Module):
         def __init__(self, num_inputs, num_outputs, hidden_size, T=16, std=0.0):
@@ -88,14 +63,14 @@ if __name__ == "__main__":
                 layer.Linear(num_inputs, hidden_size),
                 neuron.IFNode(),
                 layer.Linear(hidden_size, 1),
-                NonSpikingLIFNode(tau=2.0),
+                NonSpikingLIFNode(tau=2.0, decay_input=True),
             )
 
             self.actor = nn.Sequential(
                 layer.Linear(num_inputs, hidden_size),
                 neuron.IFNode(),
                 layer.Linear(hidden_size, num_outputs),
-                NonSpikingLIFNode(tau=2.0),
+                NonSpikingLIFNode(tau=2.0, decay_input=True),
             )
 
             self.log_std = nn.Parameter(torch.ones(1, num_outputs) * std)

--- a/spikingjelly/activation_based/functional/layer.py
+++ b/spikingjelly/activation_based/functional/layer.py
@@ -5,8 +5,72 @@ import torch
 
 __all__ = [
     "delay_step",
+    "neunorm_step",
     "synapse_filter_step",
 ]
+
+
+def neunorm_step(
+    in_spikes: torch.Tensor,
+    state: torch.Tensor,
+    weight: torch.Tensor,
+    momentum: float,
+    input_scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    r"""
+    **API Language** - :ref:`中文 <neunorm_step-cn>` | :ref:`English <neunorm_step-en>`
+
+    ----
+
+    .. _neunorm_step-cn:
+
+    * **中文**
+
+    执行一次 NeuNorm 状态转移，返回归一化输出和下一状态。函数不读取或修改
+    module memory。
+
+    :param in_spikes: 当前输入脉冲，shape 为 ``[N, C, H, W]``
+    :type in_spikes: torch.Tensor
+    :param state: 已物化的 NeuNorm 状态，shape 为 ``[N, 1, H, W]``
+    :type state: torch.Tensor
+    :param weight: 可广播到 ``in_spikes`` 的 NeuNorm 权重
+    :type weight: torch.Tensor
+    :param momentum: 旧状态的系数
+    :type momentum: float
+    :param input_scale: 通道求和结果的系数
+    :type input_scale: float
+    :return: ``(output, state_next)``
+    :rtype: Tuple[torch.Tensor, torch.Tensor]
+
+    ----
+
+    .. _neunorm_step-en:
+
+    * **English**
+
+    Run one NeuNorm state transition and return its normalized output and next
+    state. The function does not read or mutate module memory.
+
+    :param in_spikes: Current input spikes shaped ``[N, C, H, W]``
+    :type in_spikes: torch.Tensor
+    :param state: Materialized NeuNorm state shaped ``[N, 1, H, W]``
+    :type state: torch.Tensor
+    :param weight: NeuNorm weight broadcastable to ``in_spikes``
+    :type weight: torch.Tensor
+    :param momentum: Coefficient applied to the previous state
+    :type momentum: float
+    :param input_scale: Coefficient applied to the channel sum
+    :type input_scale: float
+    :return: ``(output, state_next)``
+    :rtype: Tuple[torch.Tensor, torch.Tensor]
+
+    .. note::
+
+       本函数没有独立多步形式；多步执行由调用者逐步循环。
+       This function has no independent multi-step form; callers iterate it.
+    """
+    state_next = momentum * state + input_scale * in_spikes.sum(dim=1, keepdim=True)
+    return in_spikes - weight * state_next, state_next
 
 
 def delay_step(

--- a/spikingjelly/activation_based/functional/neuron.py
+++ b/spikingjelly/activation_based/functional/neuron.py
@@ -19,6 +19,8 @@ __all__ = [
     "eif_step",
     "lif_charge",
     "lif_step",
+    "liaf_step",
+    "ilif_step",
     "plif_step",
     "izhikevich_step",
     "klif_step",
@@ -39,6 +41,7 @@ __all__ = [
     "plif_multi_step_triton",
     "stbif_single_step_triton",
     "sliding_psn_step",
+    "masked_psn_step",
     "gated_lif_step",
     "stbif_step",
     "activation_aware_if_step",
@@ -928,6 +931,172 @@ def lif_step(
     v_charged = lif_charge(x, v, tau, decay_input, v_reset)
     spike = surrogate_function(v_charged - v_threshold)
     return spike, voltage_reset(v_charged, spike, v_threshold, v_reset, detach_reset)
+
+
+def liaf_step(
+    x: torch.Tensor,
+    v: torch.Tensor,
+    tau: float,
+    decay_input: bool,
+    v_threshold: float,
+    v_reset: Optional[float],
+    act: Callable[[torch.Tensor], torch.Tensor],
+    threshold_related: bool,
+    surrogate_function: SurrogateFunction,
+    detach_reset: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    r"""
+    **API Language** - :ref:`中文 <liaf_step-cn>` | :ref:`English <liaf_step-en>`
+
+    ----
+
+    .. _liaf_step-cn:
+
+    * **中文**
+
+    执行一次 LIAF 状态转移，返回模拟输出和重置后的膜电位。函数不读取或修改
+    module memory。
+
+    :param x: 当前输入张量
+    :type x: torch.Tensor
+    :param v: 已物化的当前膜电位，shape、dtype 和 device 与 ``x`` 兼容
+    :type v: torch.Tensor
+    :param tau: 膜电位时间常数
+    :type tau: float
+    :param decay_input: 输入是否参与衰减
+    :type decay_input: bool
+    :param v_threshold: 放电阈值
+    :type v_threshold: float
+    :param v_reset: 重置电位；``None`` 表示 soft reset
+    :type v_reset: Optional[float]
+    :param act: 生成模拟输出的激活函数
+    :type act: Callable[[torch.Tensor], torch.Tensor]
+    :param threshold_related: 为 ``True`` 时将 ``act`` 作用于充电电位减阈值，
+        否则直接作用于充电电位
+    :type threshold_related: bool
+    :param surrogate_function: 计算 reset 所需脉冲的替代函数
+    :type surrogate_function: Callable[[torch.Tensor], torch.Tensor]
+    :param detach_reset: 是否在 reset 分支中分离脉冲的计算图
+    :type detach_reset: bool
+    :return: ``(analog_output, v_next)``
+    :rtype: Tuple[torch.Tensor, torch.Tensor]
+
+    ----
+
+    .. _liaf_step-en:
+
+    * **English**
+
+    Run one LIAF state transition and return the analog output and reset membrane
+    voltage. The function does not read or mutate module memory.
+
+    :param x: Current input tensor
+    :type x: torch.Tensor
+    :param v: Materialized membrane voltage with shape, dtype, and device
+        compatible with ``x``
+    :type v: torch.Tensor
+    :param tau: Membrane-voltage time constant
+    :type tau: float
+    :param decay_input: Whether the input participates in decay
+    :type decay_input: bool
+    :param v_threshold: Firing threshold
+    :type v_threshold: float
+    :param v_reset: Reset voltage; ``None`` selects soft reset
+    :type v_reset: Optional[float]
+    :param act: Activation function that produces the analog output
+    :type act: Callable[[torch.Tensor], torch.Tensor]
+    :param threshold_related: Apply ``act`` to charged voltage minus the threshold
+        when ``True``; otherwise apply it directly to charged voltage
+    :type threshold_related: bool
+    :param surrogate_function: Surrogate function used to obtain the spike for reset
+    :type surrogate_function: Callable[[torch.Tensor], torch.Tensor]
+    :param detach_reset: Whether to detach the spike in the reset branch
+    :type detach_reset: bool
+    :return: ``(analog_output, v_next)``
+    :rtype: Tuple[torch.Tensor, torch.Tensor]
+
+    .. note::
+
+       本函数没有独立多步形式；多步执行由调用者逐步循环。
+       This function has no independent multi-step form; callers iterate it.
+    """
+    v_charged = lif_charge(x, v, tau, decay_input, v_reset)
+    output = act(v_charged - v_threshold if threshold_related else v_charged)
+    spike = surrogate_function(v_charged - v_threshold)
+    v_next = voltage_reset(v_charged, spike, v_threshold, v_reset, detach_reset)
+    return output, v_next
+
+
+def ilif_step(
+    x: torch.Tensor,
+    v: torch.Tensor,
+    tau: float,
+    v_threshold: float,
+    surrogate_function: SurrogateFunction,
+    detach_reset: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    r"""
+    **API Language** - :ref:`中文 <ilif_step-cn>` | :ref:`English <ilif_step-en>`
+
+    ----
+
+    .. _ilif_step-cn:
+
+    * **中文**
+
+    执行一次 I-LIF 状态转移，返回多级脉冲计数和 soft reset 后的膜电位。
+    函数不读取或修改 module memory。
+
+    :param x: 当前输入张量
+    :type x: torch.Tensor
+    :param v: 已物化的当前膜电位，shape、dtype 和 device 与 ``x`` 兼容
+    :type v: torch.Tensor
+    :param tau: 膜电位时间常数
+    :type tau: float
+    :param v_threshold: 放电阈值
+    :type v_threshold: float
+    :param surrogate_function: 作用于归一化充电电位的多级脉冲计数函数
+    :type surrogate_function: Callable[[torch.Tensor], torch.Tensor]
+    :param detach_reset: 是否在 reset 分支中分离脉冲计数的计算图
+    :type detach_reset: bool
+    :return: ``(spike_count, v_next)``
+    :rtype: Tuple[torch.Tensor, torch.Tensor]
+
+    ----
+
+    .. _ilif_step-en:
+
+    * **English**
+
+    Run one I-LIF state transition and return the multi-level spike count and
+    membrane voltage after soft reset. The function does not read or mutate
+    module memory.
+
+    :param x: Current input tensor
+    :type x: torch.Tensor
+    :param v: Materialized membrane voltage with shape, dtype, and device
+        compatible with ``x``
+    :type v: torch.Tensor
+    :param tau: Membrane-voltage time constant
+    :type tau: float
+    :param v_threshold: Firing threshold
+    :type v_threshold: float
+    :param surrogate_function: Multi-level spike-count function applied to the
+        normalized charged voltage
+    :type surrogate_function: Callable[[torch.Tensor], torch.Tensor]
+    :param detach_reset: Whether to detach the spike count in the reset branch
+    :type detach_reset: bool
+    :return: ``(spike_count, v_next)``
+    :rtype: Tuple[torch.Tensor, torch.Tensor]
+
+    .. note::
+
+       本函数没有独立多步形式；多步执行由调用者逐步循环。
+       This function has no independent multi-step form; callers iterate it.
+    """
+    v_charged = lif_charge(x, v, tau, False, None)
+    spike = surrogate_function(v_charged / v_threshold)
+    return spike, voltage_reset(v_charged, spike, v_threshold, None, detach_reset)
 
 
 def lif_multi_step_inductor(
@@ -2765,6 +2934,91 @@ def sliding_psn_step(
     h = torch.sum(psn_weight * x_seq, 0)
     spike = surrogate_function(h + bias)
     return spike.view(x.shape), queue_next
+
+
+def masked_psn_step(
+    x: torch.Tensor,
+    time_step: int,
+    queue: tuple[torch.Tensor, ...],
+    masked_weight: torch.Tensor,
+    bias: torch.Tensor,
+    k: int,
+    surrogate_function: SurrogateFunction,
+) -> tuple[torch.Tensor, int, tuple[torch.Tensor, ...]]:
+    r"""
+    **API Language** - :ref:`中文 <masked_psn_step-cn>` | :ref:`English <masked_psn_step-en>`
+
+    ----
+
+    .. _masked_psn_step-cn:
+
+    * **中文**
+
+    使用显式时间索引和输入队列执行一次 MaskedPSN 状态转移。调用者负责提供当前
+    ``lambda`` 对应的完整 masked weight，并保证时间索引位于其范围内。
+
+    :param x: 当前输入张量
+    :type x: torch.Tensor
+    :param time_step: 当前时间索引
+    :type time_step: int
+    :param queue: 旧输入队列，元素是 flatten 后的张量，按旧到新排列
+    :type queue: Tuple[torch.Tensor, ...]
+    :param masked_weight: shape 为 ``[T, T]`` 的 masked weight
+    :type masked_weight: torch.Tensor
+    :param bias: shape 为 ``[T, 1]`` 的偏置
+    :type bias: torch.Tensor
+    :param k: 队列保留的最大时间步数
+    :type k: int
+    :param surrogate_function: 作用于膜电位的替代函数
+    :type surrogate_function: Callable[[torch.Tensor], torch.Tensor]
+    :return: ``(spike, time_step_next, queue_next)``
+    :rtype: Tuple[torch.Tensor, int, Tuple[torch.Tensor, ...]]
+
+    ----
+
+    .. _masked_psn_step-en:
+
+    * **English**
+
+    Run one MaskedPSN state transition with an explicit time index and input
+    queue. The caller provides the complete masked weight for the current
+    ``lambda`` and ensures that the time index is in range.
+
+    :param x: Current input tensor
+    :type x: torch.Tensor
+    :param time_step: Current time index
+    :type time_step: int
+    :param queue: Previous input queue containing flattened tensors ordered from
+        oldest to newest
+    :type queue: Tuple[torch.Tensor, ...]
+    :param masked_weight: Masked weight shaped ``[T, T]``
+    :type masked_weight: torch.Tensor
+    :param bias: Bias shaped ``[T, 1]``
+    :type bias: torch.Tensor
+    :param k: Maximum number of time steps retained in the queue
+    :type k: int
+    :param surrogate_function: Surrogate function applied to membrane voltage
+    :type surrogate_function: Callable[[torch.Tensor], torch.Tensor]
+    :return: ``(spike, time_step_next, queue_next)``
+    :rtype: Tuple[torch.Tensor, int, Tuple[torch.Tensor, ...]]
+
+    .. note::
+
+       MaskedPSN 已有独立的矩阵化多步实现，本函数只描述其单步递推。
+       MaskedPSN has an independent matrix-based multi-step implementation; this
+       function describes only its single-step recurrence.
+    """
+    queue_next = (*queue, x.flatten())
+    if len(queue_next) > k:
+        queue_next = queue_next[1:]
+
+    weight = masked_weight[
+        time_step,
+        time_step + 1 - len(queue_next) : time_step + 1,
+    ]
+    h = torch.sum(weight.unsqueeze(-1) * torch.stack(queue_next), 0)
+    spike = surrogate_function(h + bias[time_step])
+    return spike.view(x.shape), time_step + 1, queue_next
 
 
 def gated_lif_step(

--- a/spikingjelly/activation_based/functional/neuron.py
+++ b/spikingjelly/activation_based/functional/neuron.py
@@ -815,11 +815,16 @@ def lif_step(
        :func:`lif_multi_step_inductor`, :func:`lif_multi_step_cupy`,
        :func:`lif_multi_step_triton`.
     """
-    v_reset_value = 0.0 if v_reset is None else v_reset
     if decay_input:
-        v_charged = v + (x - (v - v_reset_value)) / tau
+        if v_reset is None or v_reset == 0.0:
+            v_charged = v + (x - v) / tau
+        else:
+            v_charged = v + (x - (v - v_reset)) / tau
     else:
-        v_charged = v - (v - v_reset_value) / tau + x
+        if v_reset is None or v_reset == 0.0:
+            v_charged = v * (1.0 - 1.0 / tau) + x
+        else:
+            v_charged = v - (v - v_reset) / tau + x
     spike = surrogate_function(v_charged - v_threshold)
     return spike, _reset(v_charged, spike, v_threshold, v_reset, detach_reset)
 

--- a/spikingjelly/activation_based/functional/neuron.py
+++ b/spikingjelly/activation_based/functional/neuron.py
@@ -17,6 +17,7 @@ __all__ = [
     "if_step",
     "qif_step",
     "eif_step",
+    "lif_charge",
     "lif_step",
     "plif_step",
     "izhikevich_step",
@@ -42,6 +43,7 @@ __all__ = [
     "stbif_step",
     "activation_aware_if_step",
     "activation_aware_if_multi_step_triton",
+    "voltage_reset",
 ]
 
 
@@ -155,18 +157,68 @@ def lava_cuba_lif_step(
         s_scale,
     )
     spike = surrogate_function(voltage_charged - (v_threshold + v_threshold_eps))
-    spike_d = spike.detach() if detach_reset else spike
-    voltage_next = spike_d * v_reset + (1.0 - spike_d) * voltage_charged
+    voltage_next = voltage_reset(
+        voltage_charged,
+        spike,
+        v_threshold,
+        v_reset,
+        detach_reset,
+    )
     return spike, current_next, voltage_next
 
 
-def _reset(
+def voltage_reset(
     v: torch.Tensor,
     spike: torch.Tensor,
     v_threshold: float,
     v_reset: Optional[float],
     detach_reset: bool,
 ) -> torch.Tensor:
+    r"""
+    **API Language** - :ref:`中文 <voltage_reset-cn>` | :ref:`English <voltage_reset-en>`
+
+    ----
+
+    .. _voltage_reset-cn:
+
+    * **中文**
+
+    根据脉冲对膜电位执行硬重置或软重置。
+
+    :param v: 重置前的膜电位
+    :type v: torch.Tensor
+    :param spike: 当前时间步的脉冲
+    :type spike: torch.Tensor
+    :param v_threshold: soft reset 时从膜电位减去的阈值
+    :type v_threshold: float
+    :param v_reset: hard reset 的目标电位；``None`` 表示使用 soft reset
+    :type v_reset: Optional[float]
+    :param detach_reset: 是否在重置分支中分离脉冲梯度
+    :type detach_reset: bool
+    :return: 重置后的膜电位
+    :rtype: torch.Tensor
+
+    ----
+
+    .. _voltage_reset-en:
+
+    * **English**
+
+    Apply a hard or soft reset to membrane voltage according to the spike.
+
+    :param v: Membrane voltage before reset
+    :type v: torch.Tensor
+    :param spike: Spike at the current time step
+    :type spike: torch.Tensor
+    :param v_threshold: Threshold subtracted by soft reset
+    :type v_threshold: float
+    :param v_reset: Target voltage for hard reset; ``None`` selects soft reset
+    :type v_reset: Optional[float]
+    :param detach_reset: Whether to detach the spike in the reset branch
+    :type detach_reset: bool
+    :return: Membrane voltage after reset
+    :rtype: torch.Tensor
+    """
     spike_d = spike.detach() if detach_reset else spike
     if v_reset is None:
         return v - spike_d * v_threshold
@@ -254,7 +306,7 @@ def if_step(
     """
     v_charged = v + x
     spike = surrogate_function(v_charged - v_threshold)
-    return spike, _reset(v_charged, spike, v_threshold, v_reset, detach_reset)
+    return spike, voltage_reset(v_charged, spike, v_threshold, v_reset, detach_reset)
 
 
 def qif_step(
@@ -341,7 +393,7 @@ def qif_step(
     """
     v_charged = v + (x + a0 * (v - v_rest) * (v - v_c)) / tau
     spike = surrogate_function(v_charged - v_threshold)
-    return spike, _reset(v_charged, spike, v_threshold, v_reset, detach_reset)
+    return spike, voltage_reset(v_charged, spike, v_threshold, v_reset, detach_reset)
 
 
 def eif_step(
@@ -430,7 +482,7 @@ def eif_step(
         v + (x + v_rest - v + delta_t * torch.exp((v - theta_rh) / delta_t)) / tau
     )
     spike = surrogate_function(v_charged - v_threshold)
-    return spike, _reset(v_charged, spike, v_threshold, v_reset, detach_reset)
+    return spike, voltage_reset(v_charged, spike, v_threshold, v_reset, detach_reset)
 
 
 def activation_aware_if_step(
@@ -739,6 +791,64 @@ def if_multi_step_inductor(
     return _normalize_multi_step_output(graph(x_seq, v), store_v_seq)
 
 
+def lif_charge(
+    x: torch.Tensor,
+    v: torch.Tensor,
+    tau: float,
+    decay_input: bool,
+    v_reset: Optional[float],
+) -> torch.Tensor:
+    r"""
+    **API Language** - :ref:`中文 <lif_charge-cn>` | :ref:`English <lif_charge-en>`
+
+    ----
+
+    .. _lif_charge-cn:
+
+    * **中文**
+
+    执行 LIF 神经元的充电方程，不进行放电或重置。
+
+    :param x: 当前输入张量
+    :type x: torch.Tensor
+    :param v: 当前膜电位
+    :type v: torch.Tensor
+    :param tau: 膜电位时间常数
+    :type tau: float
+    :param decay_input: 输入是否参与衰减
+    :type decay_input: bool
+    :param v_reset: 重置电位；``None`` 在充电方程中按 ``0.0`` 处理
+    :type v_reset: Optional[float]
+    :return: 充电后的膜电位
+    :rtype: torch.Tensor
+
+    ----
+
+    .. _lif_charge-en:
+
+    * **English**
+
+    Apply the LIF charging equation without firing or resetting.
+
+    :param x: Current input tensor
+    :type x: torch.Tensor
+    :param v: Current membrane voltage
+    :type v: torch.Tensor
+    :param tau: Membrane-voltage time constant
+    :type tau: float
+    :param decay_input: Whether the input participates in decay
+    :type decay_input: bool
+    :param v_reset: Reset voltage; ``None`` is treated as ``0.0`` by the charging equation
+    :type v_reset: Optional[float]
+    :return: Charged membrane voltage
+    :rtype: torch.Tensor
+    """
+    v_reset_value = 0.0 if v_reset is None else v_reset
+    if decay_input:
+        return v + (x - (v - v_reset_value)) / tau
+    return v - (v - v_reset_value) / tau + x
+
+
 def lif_step(
     x: torch.Tensor,
     v: torch.Tensor,
@@ -815,18 +925,9 @@ def lif_step(
        :func:`lif_multi_step_inductor`, :func:`lif_multi_step_cupy`,
        :func:`lif_multi_step_triton`.
     """
-    if decay_input:
-        if v_reset is None or v_reset == 0.0:
-            v_charged = v + (x - v) / tau
-        else:
-            v_charged = v + (x - (v - v_reset)) / tau
-    else:
-        if v_reset is None or v_reset == 0.0:
-            v_charged = v * (1.0 - 1.0 / tau) + x
-        else:
-            v_charged = v - (v - v_reset) / tau + x
+    v_charged = lif_charge(x, v, tau, decay_input, v_reset)
     spike = surrogate_function(v_charged - v_threshold)
-    return spike, _reset(v_charged, spike, v_threshold, v_reset, detach_reset)
+    return spike, voltage_reset(v_charged, spike, v_threshold, v_reset, detach_reset)
 
 
 def lif_multi_step_inductor(
@@ -1024,7 +1125,7 @@ def plif_step(
     else:
         v_charged = v - (v - v_reset_value) * reciprocal_tau + x
     spike = surrogate_function(v_charged - v_threshold)
-    return spike, _reset(v_charged, spike, v_threshold, v_reset, detach_reset)
+    return spike, voltage_reset(v_charged, spike, v_threshold, v_reset, detach_reset)
 
 
 def plif_multi_step_inductor(
@@ -1342,14 +1443,14 @@ def klif_step(
     v_charged = torch.relu(k * v_charged)
     spike = surrogate_function(v_charged - v_threshold)
     if scale_reset:
-        return spike, _reset(
+        return spike, voltage_reset(
             v_charged / k,
             spike,
             v_threshold / k,
             v_reset,
             detach_reset,
         )
-    return spike, _reset(v_charged, spike, v_threshold, v_reset, detach_reset)
+    return spike, voltage_reset(v_charged, spike, v_threshold, v_reset, detach_reset)
 
 
 def cuba_lif_step(
@@ -1432,7 +1533,7 @@ def cuba_lif_step(
     current_next = current * current_decay + x
     v_charged = v * voltage_decay + current_next
     spike = surrogate_function(v_charged - v_threshold)
-    v_next = _reset(v_charged, spike, v_threshold, v_reset, detach_reset)
+    v_next = voltage_reset(v_charged, spike, v_threshold, v_reset, detach_reset)
     return spike, current_next, v_next
 
 
@@ -2388,7 +2489,7 @@ def if_multi_step_triton(
         store_v_seq,
     )
     if store_v_seq:
-        return spike_seq, voltage[-1], voltage
+        return spike_seq, voltage[-1].clone(), voltage
     return spike_seq, voltage, None
 
 
@@ -2483,7 +2584,7 @@ def lif_multi_step_triton(
         store_v_seq,
     )
     if store_v_seq:
-        return spike_seq, voltage[-1], voltage
+        return spike_seq, voltage[-1].clone(), voltage
     return spike_seq, voltage, None
 
 

--- a/spikingjelly/activation_based/lava_exchange.py
+++ b/spikingjelly/activation_based/lava_exchange.py
@@ -665,12 +665,23 @@ class CubaLIFNode(neuron.BaseNode):
             )
 
     # computation process
-    def state_initialization(self, x: torch.Tensor):
-        if isinstance(self.current_state, float):
-            self.current_state = torch.zeros_like(x.data)
-
-        if isinstance(self.voltage_state, float):
-            self.voltage_state = torch.zeros_like(x.data)
+    def materialize_states(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        step_mode: str,
+    ) -> tuple[object, ...]:
+        x = inputs[0]
+        if step_mode == "m" and x.dim() > 0 and x.shape[0] > 0:
+            x = x[0]
+        materialized = []
+        for state in states[-2:]:
+            if not isinstance(state, torch.Tensor) or state.shape != x.shape:
+                state = torch.zeros_like(x)
+            elif state.dtype != x.dtype or state.device != x.device:
+                state = state.to(dtype=x.dtype, device=x.device)
+            materialized.append(state)
+        return (*states[:-2], *materialized)
 
     def neuronal_charge(self, x: torch.Tensor):
         if self.requires_grad:
@@ -711,35 +722,74 @@ class CubaLIFNode(neuron.BaseNode):
             self.voltage_state, spike_d, self.v_reset
         )
 
-    def single_step_forward(self, x):
-        self.state_initialization(x)
-        self.neuronal_charge(x)
-        spike = self.neuronal_fire()
-        self.neuronal_reset(spike)
-        return spike
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        current_state, voltage_state = states[-2:]
+        current_decay = (
+            self.current_decay.clamp(min=0.0, max=self.p_scale)
+            if self.requires_grad
+            else self.current_decay
+        )
+        voltage_decay = (
+            self.voltage_decay.clamp(min=0.0, max=self.p_scale)
+            if self.requires_grad
+            else self.voltage_decay
+        )
+        current_state = LeakyIntegratorStep.apply(
+            x,
+            step_quantize(current_decay),
+            current_state.contiguous(),
+            self.s_scale,
+        )
+        if self.norm is not None:
+            current_state = self.norm(current_state)
+        voltage_state = LeakyIntegratorStep.apply(
+            current_state,
+            step_quantize(voltage_decay),
+            voltage_state.contiguous(),
+            self.s_scale,
+        )
+        spike = self.surrogate_function(
+            voltage_state - (self.v_threshold + self.v_threshold_eps)
+        )
+        reset_spike = spike.detach() if self.detach_reset else spike
+        voltage_state = self.apply_hard_reset(voltage_state, reset_spike, self.v_reset)
+        return (spike,), (*states[:-2], current_state, voltage_state)
 
-    def multi_step_forward(self, x_seq: torch.Tensor):
-        T = x_seq.shape[0]
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x_seq = inputs[0]
         y_seq = []
         if self.store_v_seq:
             v_seq = []
         if self.store_i_seq:
             i_seq = []
 
-        for t in range(T):
-            y = self.single_step_forward(x_seq[t])
-            y_seq.append(y)
+        for t in range(x_seq.shape[0]):
+            outputs, states = self.single_step_functional_forward(
+                (x_seq[t],), states, **kwargs
+            )
+            y_seq.append(outputs[0])
             if self.store_v_seq:
-                v_seq.append(self.voltage_state)
+                v_seq.append(states[-1])
             if self.store_i_seq:
-                i_seq.append(self.current_state)
+                i_seq.append(states[-2])
 
+        updated_states = list(states)
         if self.store_v_seq:
-            self.v_seq = torch.stack(v_seq)
+            updated_states[1] = torch.stack(v_seq)
         if self.store_i_seq:
-            self.i_seq = torch.stack(i_seq)
-
-        return torch.stack(y_seq)
+            updated_states[2 if self.store_v_seq else 1] = torch.stack(i_seq)
+        return (torch.stack(y_seq),), tuple(updated_states)
 
 
 try:

--- a/spikingjelly/activation_based/lava_exchange.py
+++ b/spikingjelly/activation_based/lava_exchange.py
@@ -684,45 +684,6 @@ class CubaLIFNode(neuron.BaseNode):
             materialized.append(state)
         return (*states[:-2], *materialized)
 
-    def neuronal_charge(self, x: torch.Tensor):
-        if self.requires_grad:
-            self.clamp_decay_parameters()
-
-        current = LeakyIntegratorStep.apply(
-            x,
-            step_quantize(self.current_decay),
-            self.current_state.contiguous(),
-            self.s_scale,
-        )
-
-        if self.norm is not None:
-            current = self.norm(current)
-
-        voltage = LeakyIntegratorStep.apply(
-            current,
-            step_quantize(self.voltage_decay),
-            self.voltage_state.contiguous(),
-            self.s_scale,
-        )
-
-        self.current_state = current
-        self.voltage_state = voltage
-
-    def neuronal_fire(self):
-        return self.surrogate_function(
-            self.voltage_state - (self.v_threshold + self.v_threshold_eps)
-        )
-
-    def neuronal_reset(self, spike):
-        if self.detach_reset:
-            spike_d = spike.detach()
-        else:
-            spike_d = spike
-
-        self.voltage_state = self.apply_hard_reset(
-            self.voltage_state, spike_d, self.v_reset
-        )
-
     def single_step_functional_forward(
         self,
         inputs: tuple[torch.Tensor, ...],

--- a/spikingjelly/activation_based/lava_exchange.py
+++ b/spikingjelly/activation_based/lava_exchange.py
@@ -5,6 +5,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from . import base, neuron, surrogate
+from .functional import neuron as functional
 
 from spikingjelly.logger import logger
 
@@ -650,9 +651,11 @@ class CubaLIFNode(neuron.BaseNode):
     @store_i_seq.setter
     def store_i_seq(self, value: bool):
         self._store_i_seq = value
-        if value:
-            if not hasattr(self, "i_seq"):
-                self.register_memory("i_seq", None)
+        self.i_seq = None
+
+    def reset(self):
+        super().reset()
+        self.i_seq = None
 
     @property
     def supported_backends(self):
@@ -671,9 +674,7 @@ class CubaLIFNode(neuron.BaseNode):
         states: tuple[object, ...],
         step_mode: str,
     ) -> tuple[object, ...]:
-        x = inputs[0]
-        if step_mode == "m" and x.dim() > 0 and x.shape[0] > 0:
-            x = x[0]
+        x = inputs[0][0] if step_mode == "m" else inputs[0]
         materialized = []
         for state in states[-2:]:
             if not isinstance(state, torch.Tensor) or state.shape != x.shape:
@@ -740,6 +741,22 @@ class CubaLIFNode(neuron.BaseNode):
             if self.requires_grad
             else self.voltage_decay
         )
+        if self.norm is None:
+            spike, current_state, voltage_state = functional.lava_cuba_lif_step(
+                x,
+                current_state,
+                voltage_state,
+                current_decay,
+                voltage_decay,
+                self.s_scale,
+                self.v_threshold,
+                self.v_threshold_eps,
+                self.v_reset,
+                self.surrogate_function,
+                self.detach_reset,
+            )
+            return (spike,), (*states[:-2], current_state, voltage_state)
+
         current_state = LeakyIntegratorStep.apply(
             x,
             step_quantize(current_decay),
@@ -757,8 +774,13 @@ class CubaLIFNode(neuron.BaseNode):
         spike = self.surrogate_function(
             voltage_state - (self.v_threshold + self.v_threshold_eps)
         )
-        reset_spike = spike.detach() if self.detach_reset else spike
-        voltage_state = self.apply_hard_reset(voltage_state, reset_spike, self.v_reset)
+        voltage_state = functional.voltage_reset(
+            voltage_state,
+            spike,
+            self.v_threshold,
+            self.v_reset,
+            self.detach_reset,
+        )
         return (spike,), (*states[:-2], current_state, voltage_state)
 
     def multi_step_functional_forward(
@@ -767,29 +789,31 @@ class CubaLIFNode(neuron.BaseNode):
         states: tuple[object, ...],
         **kwargs: object,
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
-        x_seq = inputs[0]
-        y_seq = []
-        if self.store_v_seq:
-            v_seq = []
-        if self.store_i_seq:
-            i_seq = []
+        return super().multi_step_functional_forward(inputs, states, **kwargs)
 
+    def multi_step_forward(self, x_seq: torch.Tensor, *args, **kwargs):
+        inputs = (x_seq, *args)
+        states = self.materialize_states(inputs, tuple(self._memories.values()), "m")
+        output_steps = []
+        voltage_steps = []
+        current_steps = []
         for t in range(x_seq.shape[0]):
             outputs, states = self.single_step_functional_forward(
-                (x_seq[t],), states, **kwargs
+                tuple(x[t] for x in inputs), states, **kwargs
             )
-            y_seq.append(outputs[0])
+            output_steps.append(outputs[0])
             if self.store_v_seq:
-                v_seq.append(states[-1])
+                voltage_steps.append(states[-1])
             if self.store_i_seq:
-                i_seq.append(states[-2])
+                current_steps.append(states[-2])
 
-        updated_states = list(states)
+        for name, value in zip(self._memories, states, strict=True):
+            self._memories[name] = value
         if self.store_v_seq:
-            updated_states[1] = torch.stack(v_seq)
+            self.v_seq = torch.stack(voltage_steps)
         if self.store_i_seq:
-            updated_states[2 if self.store_v_seq else 1] = torch.stack(i_seq)
-        return (torch.stack(y_seq),), tuple(updated_states)
+            self.i_seq = torch.stack(current_steps)
+        return torch.stack(output_steps)
 
 
 try:

--- a/spikingjelly/activation_based/layer/bn.py
+++ b/spikingjelly/activation_based/layer/bn.py
@@ -310,10 +310,16 @@ class NeuNorm(base.MemoryModule):
             self.w = nn.Parameter(Tensor(in_channels, height, width))
         nn.init.kaiming_uniform_(self.w, a=math.sqrt(5))
 
-    def single_step_forward(self, in_spikes: Tensor):
-        self.x = self.k0 * self.x + self.k1 * in_spikes.sum(dim=1, keepdim=True)
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[Tensor, ...], tuple[object, ...]]:
+        in_spikes = inputs[0]
+        x = self.k0 * states[0] + self.k1 * in_spikes.sum(dim=1, keepdim=True)
         # x.shape = [batch_size, 1, height, width]
-        return in_spikes - self.w * self.x
+        return (in_spikes - self.w * x,), (x,)
 
     def extra_repr(self) -> str:
         return f"shape={self.w.shape}"
@@ -722,18 +728,24 @@ class _BatchNormThroughTimeBase(base.MemoryModule):
         self.step_mode = step_mode
         self.register_memory("t", -1)
 
-    def single_step_forward(self, x: torch.Tensor):
-        self.t += 1
-        bn = self.bn_list[self.t]
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[Tensor, ...], tuple[object, ...]]:
+        t = states[0] + 1
+        bn = self.bn_list[t]
         if not in_gc_1st_forward():
-            return bn(x)
+            return (bn(inputs[0]),), (t,)
 
         track_running_stats = bn.track_running_stats
         bn.track_running_stats = False
         try:
-            return bn(x)
+            output = bn(inputs[0])
         finally:
             bn.track_running_stats = track_running_stats
+        return (output,), (t,)
 
 
 class BatchNormThroughTime1d(_BatchNormThroughTimeBase):

--- a/spikingjelly/activation_based/layer/bn.py
+++ b/spikingjelly/activation_based/layer/bn.py
@@ -310,16 +310,27 @@ class NeuNorm(base.MemoryModule):
             self.w = nn.Parameter(Tensor(in_channels, height, width))
         nn.init.kaiming_uniform_(self.w, a=math.sqrt(5))
 
+    def materialize_states(
+        self,
+        inputs: tuple[Tensor, ...],
+        states: tuple[object, ...],
+        step_mode: str,
+    ) -> tuple[object, ...]:
+        if isinstance(states[0], Tensor):
+            return states
+        reference = inputs[0][0] if step_mode == "m" else inputs[0]
+        return (torch.full_like(reference[:, :1], states[0]),)
+
     def single_step_functional_forward(
         self,
         inputs: tuple[Tensor, ...],
         states: tuple[object, ...],
         **kwargs: object,
     ) -> tuple[tuple[Tensor, ...], tuple[object, ...]]:
-        in_spikes = inputs[0]
-        x = self.k0 * states[0] + self.k1 * in_spikes.sum(dim=1, keepdim=True)
-        # x.shape = [batch_size, 1, height, width]
-        return (in_spikes - self.w * x,), (x,)
+        output, state = functional.neunorm_step(
+            inputs[0], states[0], self.w, self.k0, self.k1
+        )
+        return (output,), (state,)
 
     def extra_repr(self) -> str:
         return f"shape={self.w.shape}"

--- a/spikingjelly/activation_based/layer/container.py
+++ b/spikingjelly/activation_based/layer/container.py
@@ -188,7 +188,7 @@ class ElementWiseRecurrentContainer(base.MemoryModule):
 
         .. math::
 
-            i[t] = f(x[t], y[t-1])
+            i[t] = f(y[t-1], x[t])
 
         其中 :math:`f` 是用户自定义的逐元素函数。我们默认 :math:`y[-1] = 0`。
 
@@ -200,7 +200,7 @@ class ElementWiseRecurrentContainer(base.MemoryModule):
         :param sub_module: 被包含的模块
         :type sub_module: torch.nn.Module
 
-        :param element_wise_function: 用户自定义的逐元素函数，应该形如 ``z=f(x, y)``
+        :param element_wise_function: 用户自定义的逐元素函数，应该形如 ``z=f(y, x)``
         :type element_wise_function: Callable
 
         :param step_mode: 步进模式，可以为 `'s'` (单步) 或 `'m'` (多步)
@@ -218,7 +218,7 @@ class ElementWiseRecurrentContainer(base.MemoryModule):
 
         .. math::
 
-            i[t] = f(x[t], y[t-1])
+            i[t] = f(y[t-1], x[t])
 
         where :math:`f` is the user-defined element-wise function. We set :math:`y[-1] = 0`.
 
@@ -230,7 +230,7 @@ class ElementWiseRecurrentContainer(base.MemoryModule):
         :param sub_module: the contained module
         :type sub_module: torch.nn.Module
 
-        :param element_wise_function: the user-defined element-wise function, which should have the format ``z=f(x, y)``
+        :param element_wise_function: the user-defined element-wise function, which should have the format ``z=f(y, x)``
         :type element_wise_function: Callable
 
         :param step_mode: the step mode, which can be `s` (single-step) or `m` (multi-step)

--- a/spikingjelly/activation_based/layer/container.py
+++ b/spikingjelly/activation_based/layer/container.py
@@ -261,11 +261,25 @@ class ElementWiseRecurrentContainer(base.MemoryModule):
         self.element_wise_function = element_wise_function
         self.register_memory("y", None)
 
-    def single_step_forward(self, x: Tensor):
-        if self.y is None:
-            self.y = torch.zeros_like(x)
-        self.y = self.sub_module(self.element_wise_function(self.y, x))
-        return self.y
+    def materialize_states(
+        self,
+        inputs: tuple[Tensor, ...],
+        states: tuple[object, ...],
+        step_mode: str,
+    ) -> tuple[object, ...]:
+        x = inputs[0] if step_mode == "s" else inputs[0][0]
+        return (torch.zeros_like(x) if states[0] is None else states[0],)
+
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        y = states[0]
+        y = self.sub_module(self.element_wise_function(y, x))
+        return (y,), (y,)
 
     def extra_repr(self) -> str:
         return f"element-wise function={self.element_wise_function}, step_mode={self.step_mode}"
@@ -390,12 +404,28 @@ class LinearRecurrentContainer(base.MemoryModule):
         self.sub_module = sub_module
         self.register_memory("y", None)
 
-    def single_step_forward(self, x: Tensor):
-        if self.y is None:
-            self.y = x.new_zeros(*x.shape[:-1], self.sub_module_out_features)
-        x = torch.cat((x, self.y), dim=-1)
-        self.y = self.sub_module(self.rc(x))
-        return self.y
+    def materialize_states(
+        self,
+        inputs: tuple[Tensor, ...],
+        states: tuple[object, ...],
+        step_mode: str,
+    ) -> tuple[object, ...]:
+        x = inputs[0] if step_mode == "s" else inputs[0][0]
+        y = states[0]
+        if y is None:
+            y = x.new_zeros(*x.shape[:-1], self.sub_module_out_features)
+        return (y,)
+
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        y = states[0]
+        y = self.sub_module(self.rc(torch.cat((x, y), dim=-1)))
+        return (y,), (y,)
 
     def extra_repr(self) -> str:
         return f", step_mode={self.step_mode}"

--- a/spikingjelly/activation_based/layer/dropout.py
+++ b/spikingjelly/activation_based/layer/dropout.py
@@ -94,21 +94,36 @@ class Dropout(base.MemoryModule):
     def extra_repr(self):
         return f"p={self.p}"
 
-    def create_mask(self, x: Tensor):
-        self.mask = F.dropout(torch.ones_like(x), self.p, training=True)
+    def create_mask(self, x: Tensor) -> Tensor:
+        return F.dropout(torch.ones_like(x), self.p, training=True)
 
-    def _forward(self, x: Tensor, mask_input: Tensor):
-        if not self.training:
-            return x
-        if self.mask is None:
-            self.create_mask(mask_input)
-        return x * self.mask
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        mask = states[0]
+        if self.training:
+            if mask is None:
+                mask = self.create_mask(x)
+            x = x * mask
+        return (x,), (mask,)
 
-    def single_step_forward(self, x: Tensor):
-        return self._forward(x, x)
-
-    def multi_step_forward(self, x_seq: Tensor):
-        return self._forward(x_seq, x_seq[0])
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[Tensor, ...], tuple[object, ...]]:
+        x_seq = inputs[0]
+        mask = states[0]
+        if self.training:
+            if mask is None:
+                mask = self.create_mask(x_seq[0])
+            x_seq = x_seq * mask
+        return (x_seq,), (mask,)
 
 
 class Dropout2d(Dropout):
@@ -153,8 +168,8 @@ class Dropout2d(Dropout):
 """
         super().__init__(p, step_mode)
 
-    def create_mask(self, x: Tensor):
-        self.mask = F.dropout2d(torch.ones_like(x), self.p, training=True)
+    def create_mask(self, x: Tensor) -> Tensor:
+        return F.dropout2d(torch.ones_like(x), self.p, training=True)
 
 
 class DropConnectLinear(base.MemoryModule):
@@ -336,14 +351,14 @@ class DropConnectLinear(base.MemoryModule):
         if hasattr(self.activation, "reset"):
             self.activation.reset()
 
-    def drop(self, batch_size: int):
+    def drop(self, batch_size: int) -> tuple[Tensor, Optional[Tensor]]:
         mask_w = (
             torch.rand_like(
                 self.weight.unsqueeze(0).expand(batch_size, *self.weight.shape)
             )
             > self.p
         )
-        self.dropped_w = self.weight * mask_w
+        dropped_w = self.weight * mask_w
 
         if self.bias is not None:
             mask_b = (
@@ -352,16 +367,31 @@ class DropConnectLinear(base.MemoryModule):
                 )
                 > self.p
             )
-            self.dropped_b = self.bias * mask_b
+            dropped_b = self.bias * mask_b
+        else:
+            dropped_b = None
+        return dropped_w, dropped_b
 
-    def single_step_forward(self, input: Tensor) -> Tensor:
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[Tensor, ...], tuple[object, ...]]:
+        input = inputs[0]
+        dropped_w = states[0]
+        dropped_b = states[1] if self.bias is not None else None
         if self.training:
-            if not self.invariant or self.dropped_w is None:
-                self.drop(input.shape[0])
-            ret = torch.bmm(self.dropped_w, input.unsqueeze(-1)).squeeze(-1)
+            if not self.invariant or dropped_w is None:
+                dropped_w, dropped_b = self.drop(input.shape[0])
+            ret = torch.bmm(dropped_w, input.unsqueeze(-1)).squeeze(-1)
             if self.bias is not None:
-                ret = ret + self.dropped_b
-            return ret if self.activation is None else self.activation(ret)
+                ret = ret + dropped_b
+            output = ret if self.activation is None else self.activation(ret)
+            updated_states = (
+                (dropped_w, dropped_b) if self.bias is not None else (dropped_w,)
+            )
+            return (output,), updated_states
 
         mu = (1 - self.p) * F.linear(input, self.weight, self.bias)
         sigma2 = (
@@ -378,7 +408,8 @@ class DropConnectLinear(base.MemoryModule):
         )
         if self.activation is not None:
             samples = self.activation(samples)
-        return samples.mean(dim=0)
+        output = samples.mean(dim=0)
+        return (output,), states
 
     def extra_repr(self) -> str:
         return f"in_features={self.in_features}, out_features={self.out_features}, bias={self.bias is not None}, p={self.p}, invariant={self.invariant}"

--- a/spikingjelly/activation_based/layer/misc.py
+++ b/spikingjelly/activation_based/layer/misc.py
@@ -163,12 +163,36 @@ class SynapseFilter(base.MemoryModule):
 
         return f"tau={tau}, learnable={self.learnable}, step_mode={self.step_mode}"
 
-    def single_step_forward(self, x: Tensor):
-        if isinstance(self.out_i, float):
-            self.out_i = torch.full_like(x, self.out_i)
+    def materialize_states(
+        self,
+        inputs: tuple[Tensor, ...],
+        states: tuple[object, ...],
+        step_mode: str,
+    ) -> tuple[object, ...]:
+        x = inputs[0]
+        if step_mode == "m" and x.dim() > 0 and x.shape[0] > 0:
+            x = x[0]
+        out_i = states[0]
+        if isinstance(out_i, float):
+            out_i = torch.full_like(x, out_i)
+        elif isinstance(out_i, Tensor):
+            if out_i.shape != x.shape:
+                out_i = torch.zeros_like(x)
+            elif out_i.dtype != x.dtype or out_i.device != x.device:
+                out_i = out_i.to(dtype=x.dtype, device=x.device)
+        return (out_i,)
+
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        out_i = states[0]
         inv_tau = self.w.sigmoid() if self.learnable else 1.0 / self.tau
-        self.out_i = functional.synapse_filter_step(x, self.out_i, inv_tau)
-        return self.out_i
+        out_i = functional.synapse_filter_step(x, out_i, inv_tau)
+        return (out_i,), (out_i,)
 
 
 class PrintShapeModule(nn.Module):
@@ -350,13 +374,27 @@ class Delay(base.MemoryModule):
     def delay_steps(self):
         return self._delay_steps
 
-    def single_step_forward(self, x: torch.Tensor):
-        y, queue_next = functional.delay_step(x, tuple(self.queue), self.delay_steps)
-        self.queue[:] = queue_next
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[Tensor, ...], tuple[object, ...]]:
+        y, queue = functional.delay_step(inputs[0], tuple(states[0]), self.delay_steps)
+        return (y,), (list(queue),)
+
+    def single_step_forward(self, x: Tensor) -> Tensor:
+        (y,), (queue,) = self.single_step_functional_forward((x,), (self.queue,))
+        self.queue[:] = queue
         return y
 
-    def multi_step_forward(self, x_seq: torch.Tensor):
-        return functional.delay(x_seq, self.delay_steps)
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[Tensor, ...], tuple[object, ...]]:
+        return (functional.delay(inputs[0], self.delay_steps),), states
 
 
 class SpikeCountToBinary(nn.Module, base.MultiStepModule):

--- a/spikingjelly/activation_based/layer/misc.py
+++ b/spikingjelly/activation_based/layer/misc.py
@@ -394,7 +394,12 @@ class Delay(base.MemoryModule):
         states: tuple[object, ...],
         **kwargs: object,
     ) -> tuple[tuple[Tensor, ...], tuple[object, ...]]:
-        return (functional.delay(inputs[0], self.delay_steps),), states
+        outputs = []
+        queue = tuple(states[0])
+        for x in inputs[0]:
+            y, queue = functional.delay_step(x, queue, self.delay_steps)
+            outputs.append(y)
+        return (torch.stack(outputs),), (list(queue),)
 
 
 class SpikeCountToBinary(nn.Module, base.MultiStepModule):

--- a/spikingjelly/activation_based/memopt/checkpointing.py
+++ b/spikingjelly/activation_based/memopt/checkpointing.py
@@ -452,8 +452,6 @@ class GCContainer(nn.Sequential):
             return (*outputs, *updated_states)
 
         ret = input_compressed_gc(flat_forward, self.x_compressor, x, *args, *states)
-        if isinstance(ret, torch.Tensor):
-            ret = (ret,)
         outputs, states = ret[: -self.num_states], ret[-self.num_states :]
         base.load_memories(self, states)
         return outputs[0] if len(outputs) == 1 else outputs

--- a/spikingjelly/activation_based/memopt/checkpointing.py
+++ b/spikingjelly/activation_based/memopt/checkpointing.py
@@ -1,7 +1,7 @@
 import contextlib
 import functools
 import threading
-from typing import Callable, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple
 
 import torch
 import torch.autograd as autograd
@@ -418,13 +418,13 @@ class GCContainer(nn.Sequential):
         self.x_compressor = (
             NullSpikeCompressor() if x_compressor is None else x_compressor
         )
-        self.f_forward = base.to_functional_forward(self, fn=self.super_forward)
+        self.f_forward = base.to_functional_forward(self)
         self.num_states = len(list(base.memories(self)))
         self._forward = (
             self.stateless_forward if self.num_states == 0 else self.stateful_forward
         )
 
-    def super_forward(self, input):
+    def super_forward(self, *inputs: Any) -> Any:
         """
         The same as ``nn.Sequential.forward`` .
 
@@ -432,16 +432,28 @@ class GCContainer(nn.Sequential):
         using ``super().forward`` in order to avoid infinite recursion in multiprocess
         scenarios!!
         """
+        outputs = inputs
         for module in self:
-            input = module(input)
-        return input
+            result = module(*outputs)
+            outputs = tuple(result) if isinstance(result, (tuple, list)) else (result,)
+        return outputs[0] if len(outputs) == 1 else outputs
 
-    def stateless_forward(self, x, *args):
+    def stateless_forward(self, x: torch.Tensor, *args: Any) -> Any:
         return input_compressed_gc(self.super_forward, self.x_compressor, x, *args)
 
-    def stateful_forward(self, x, *args):
-        states = base.extract_memories(self)
-        ret = input_compressed_gc(self.f_forward, self.x_compressor, x, *args, *states)
+    def stateful_forward(self, x: torch.Tensor, *args: Any) -> Any:
+        states = tuple(base.extract_memories(self))
+        num_inputs = 1 + len(args)
+
+        def flat_forward(*flat_args):
+            inputs = tuple(flat_args[:num_inputs])
+            current_states = tuple(flat_args[num_inputs:])
+            outputs, updated_states = self.f_forward(inputs, current_states)
+            return (*outputs, *updated_states)
+
+        ret = input_compressed_gc(flat_forward, self.x_compressor, x, *args, *states)
+        if isinstance(ret, torch.Tensor):
+            ret = (ret,)
         outputs, states = ret[: -self.num_states], ret[-self.num_states :]
         base.load_memories(self, states)
         return outputs[0] if len(outputs) == 1 else outputs

--- a/spikingjelly/activation_based/model/spike_dhs.py
+++ b/spikingjelly/activation_based/model/spike_dhs.py
@@ -154,49 +154,114 @@ class DSpike(SurrogateFunctionBase):
 
 
 class save_v_LIFNode(LIFNode):
-    r"""
-    **API Language** - :ref:`中文 <save_v_LIFNode-cn>` | :ref:`English <save_v_LIFNode-en>`
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        r"""
+        **API Language** - :ref:`中文 <save_v_LIFNode.__init__-cn>` | :ref:`English <save_v_LIFNode.__init__-en>`
 
-    ----
+        ----
 
-    .. _save_v_LIFNode-cn:
+        .. _save_v_LIFNode.__init__-cn:
 
-    * **中文**
+        * **中文**
 
-    保存膜电位的 LIF 神经元节点。在 DSpike 搜索中用于记录中间膜电位。
+        保存放电前平均膜电位的 LIF 神经元，用于 DSpike 搜索。构造参数与
+        :class:`LIFNode` 相同。
 
-    ----
+        :param args: 传递给 :class:`LIFNode` 的位置参数
+        :type args: tuple[object, ...]
+        :param kwargs: 传递给 :class:`LIFNode` 的关键字参数
+        :type kwargs: dict[str, object]
 
-    .. _save_v_LIFNode-en:
+        ----
 
-    * **English**
+        .. _save_v_LIFNode.__init__-en:
 
-    LIF neuron node that saves membrane potential. Used in DSpike search.
-    """
+        * **English**
 
-    def single_step_forward(self, x: torch.Tensor):
-        self.v_float_to_tensor(x)
-        self.neuronal_charge(x)
-        self.v_before_spike = (self.v - self.v_threshold).mean()
-        spike = self.neuronal_fire()
-        self.neuronal_reset(spike)
-        return spike
+        LIF neuron that stores the mean pre-spike membrane voltage for DSpike
+        search. Constructor arguments are the same as :class:`LIFNode`.
 
-    def multi_step_forward(self, x_seq: torch.Tensor):
-        T = x_seq.shape[0]
-        y_seq = []
-        if self.store_v_seq:
-            v_seq = []
-        for t in range(T):
-            y = self.single_step_forward(x_seq[t])
-            y_seq.append(y)
+        :param args: Positional arguments forwarded to :class:`LIFNode`
+        :type args: tuple[object, ...]
+        :param kwargs: Keyword arguments forwarded to :class:`LIFNode`
+        :type kwargs: dict[str, object]
+        """
+        super().__init__(*args, **kwargs)
+        self.register_memory("v_before_spike", 0.0)
+
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        r"""Execute one observed LIF step with explicit state. / 使用显式状态执行一个带观测的 LIF 时间步。
+
+        :param inputs: 仅包含 ``x`` 的元组 / Tuple containing only ``x``
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: 按 memory 顺序排列的状态 / States in memory order
+        :type states: tuple
+        :return: ``((spike,), updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
+        """
+        x = inputs[0]
+        v = states[0]
+
+        if self.decay_input:
+            if self.v_reset is None or self.v_reset == 0.0:
+                charged = v + (x - v) / self.tau
+            else:
+                charged = v + (x - (v - self.v_reset)) / self.tau
+        else:
+            if self.v_reset is None or self.v_reset == 0.0:
+                charged = v * (1.0 - 1.0 / self.tau) + x
+            else:
+                charged = v - (v - self.v_reset) / self.tau + x
+        v_before_spike = (charged - self.v_threshold).mean()
+        spike = self.surrogate_function(charged - self.v_threshold)
+        reset_spike = spike.detach() if self.detach_reset else spike
+        if self.v_reset is None:
+            v = charged - reset_spike * self.v_threshold
+        else:
+            v = reset_spike * self.v_reset + (1.0 - reset_spike) * charged
+
+        updated_states = list(states)
+        updated_states[0] = v
+        updated_states[-1] = v_before_spike
+        return (spike,), tuple(updated_states)
+
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        r"""Execute observed LIF sequence forward with explicit state. / 使用显式状态执行带观测的 LIF 序列前向。
+
+        :param inputs: 仅包含 ``x_seq`` 的元组 / Tuple containing only ``x_seq``
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: 按 memory 顺序排列的状态 / States in memory order
+        :type states: tuple
+        :return: ``((spike_seq,), updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
+        """
+        spikes = []
+        observed_voltages = []
+        current_states = states
+        x_seq = inputs[0]
+        for t in range(x_seq.shape[0]):
+            x = x_seq[t]
+            (spike,), current_states = self.single_step_functional_forward(
+                (x,), current_states
+            )
+            spikes.append(spike)
             if self.store_v_seq:
-                v_seq.append(self.v_before_spike)
-
+                observed_voltages.append(current_states[-1])
         if self.store_v_seq:
-            self.v_seq = torch.stack(v_seq)
-
-        return torch.stack(y_seq)
+            current_states = list(current_states)
+            current_states[1] = torch.stack(observed_voltages)
+            current_states = tuple(current_states)
+        return (torch.stack(spikes),), current_states
 
 
 def getSpikingNode(v_threshold=0.5):

--- a/spikingjelly/activation_based/model/spike_dhs.py
+++ b/spikingjelly/activation_based/model/spike_dhs.py
@@ -10,7 +10,7 @@ from torch import Tensor
 from torch.autograd import Function
 from torch.nn.functional import interpolate
 
-from ...activation_based import layer
+from ...activation_based import functional, layer
 from ..neuron import LIFNode
 from ..surrogate import SurrogateFunctionBase, heaviside
 
@@ -207,61 +207,21 @@ class save_v_LIFNode(LIFNode):
         x = inputs[0]
         v = states[0]
 
-        if self.decay_input:
-            if self.v_reset is None or self.v_reset == 0.0:
-                charged = v + (x - v) / self.tau
-            else:
-                charged = v + (x - (v - self.v_reset)) / self.tau
-        else:
-            if self.v_reset is None or self.v_reset == 0.0:
-                charged = v * (1.0 - 1.0 / self.tau) + x
-            else:
-                charged = v - (v - self.v_reset) / self.tau + x
+        charged = functional.lif_charge(x, v, self.tau, self.decay_input, self.v_reset)
         v_before_spike = (charged - self.v_threshold).mean()
         spike = self.surrogate_function(charged - self.v_threshold)
-        reset_spike = spike.detach() if self.detach_reset else spike
-        if self.v_reset is None:
-            v = charged - reset_spike * self.v_threshold
-        else:
-            v = reset_spike * self.v_reset + (1.0 - reset_spike) * charged
+        v = functional.voltage_reset(
+            charged,
+            spike,
+            self.v_threshold,
+            self.v_reset,
+            self.detach_reset,
+        )
 
         updated_states = list(states)
         updated_states[0] = v
         updated_states[-1] = v_before_spike
         return (spike,), tuple(updated_states)
-
-    def multi_step_functional_forward(
-        self,
-        inputs: tuple[torch.Tensor, ...],
-        states: tuple[object, ...],
-        **kwargs: object,
-    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
-        r"""Execute observed LIF sequence forward with explicit state. / 使用显式状态执行带观测的 LIF 序列前向。
-
-        :param inputs: 仅包含 ``x_seq`` 的元组 / Tuple containing only ``x_seq``
-        :type inputs: tuple[torch.Tensor, ...]
-        :param states: 按 memory 顺序排列的状态 / States in memory order
-        :type states: tuple
-        :return: ``((spike_seq,), updated_states)``
-        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
-        """
-        spikes = []
-        observed_voltages = []
-        current_states = states
-        x_seq = inputs[0]
-        for t in range(x_seq.shape[0]):
-            x = x_seq[t]
-            (spike,), current_states = self.single_step_functional_forward(
-                (x,), current_states
-            )
-            spikes.append(spike)
-            if self.store_v_seq:
-                observed_voltages.append(current_states[-1])
-        if self.store_v_seq:
-            current_states = list(current_states)
-            current_states[1] = torch.stack(observed_voltages)
-            current_states = tuple(current_states)
-        return (torch.stack(spikes),), current_states
 
 
 def getSpikingNode(v_threshold=0.5):

--- a/spikingjelly/activation_based/model/spike_dhs.py
+++ b/spikingjelly/activation_based/model/spike_dhs.py
@@ -187,26 +187,11 @@ class save_v_LIFNode(LIFNode):
         :type kwargs: dict[str, object]
         """
         super().__init__(*args, **kwargs)
-        self.register_memory("v_before_spike", 0.0)
+        self.v_before_spike = None
 
-    def single_step_functional_forward(
-        self,
-        inputs: tuple[torch.Tensor, ...],
-        states: tuple[object, ...],
-        **kwargs: object,
-    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
-        r"""Execute one observed LIF step with explicit state. / 使用显式状态执行一个带观测的 LIF 时间步。
-
-        :param inputs: 仅包含 ``x`` 的元组 / Tuple containing only ``x``
-        :type inputs: tuple[torch.Tensor, ...]
-        :param states: 按 memory 顺序排列的状态 / States in memory order
-        :type states: tuple
-        :return: ``((spike,), updated_states)``
-        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
-        """
-        x = inputs[0]
-        v = states[0]
-
+    def _step_with_observation(
+        self, x: torch.Tensor, v: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         charged = functional.lif_charge(x, v, self.tau, self.decay_input, self.v_reset)
         v_before_spike = (charged - self.v_threshold).mean()
         spike = self.surrogate_function(charged - self.v_threshold)
@@ -217,11 +202,41 @@ class save_v_LIFNode(LIFNode):
             self.v_reset,
             self.detach_reset,
         )
+        return spike, v, v_before_spike
 
-        updated_states = list(states)
-        updated_states[0] = v
-        updated_states[-1] = v_before_spike
-        return (spike,), tuple(updated_states)
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        v = states[0]
+
+        spike, v, _ = self._step_with_observation(x, v)
+        return (spike,), (v, *states[1:])
+
+    def single_step_forward(self, x: torch.Tensor) -> torch.Tensor:
+        states = self.materialize_states((x,), tuple(self._memories.values()), "s")
+        spike, v, self.v_before_spike = self._step_with_observation(x, states[0])
+        self.v = v
+        return spike
+
+    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+        states = self.materialize_states((x_seq,), tuple(self._memories.values()), "m")
+        v = states[0]
+        spikes = []
+        observations = []
+        for x in x_seq:
+            spike, v, observation = self._step_with_observation(x, v)
+            spikes.append(spike)
+            observations.append(observation)
+
+        self.v = v
+        self.v_before_spike = observations[-1]
+        if self.store_v_seq:
+            self.v_seq = torch.stack(observations)
+        return torch.stack(spikes)
 
 
 def getSpikingNode(v_threshold=0.5):

--- a/spikingjelly/activation_based/neuron/adapt.py
+++ b/spikingjelly/activation_based/neuron/adapt.py
@@ -150,69 +150,6 @@ class AdaptBaseNode(BaseNode):
             self.w, self.tau_w, self.a, self.v_rest, self.v
         )
 
-    @staticmethod
-    def apply_hard_reset(
-        v: torch.Tensor,
-        w: torch.Tensor,
-        spike_d: torch.Tensor,
-        v_reset: float,
-        b: float,
-        spike: torch.Tensor,
-    ):
-        v = (1.0 - spike_d) * v + spike * v_reset
-        w = w + b * spike
-        return v, w
-
-    @staticmethod
-    def apply_soft_reset(
-        v: torch.Tensor,
-        w: torch.Tensor,
-        spike_d: torch.Tensor,
-        v_threshold: float,
-        b: float,
-        spike: torch.Tensor,
-    ):
-        v = v - spike_d * v_threshold
-        w = w + b * spike
-        return v, w
-
-    def neuronal_reset(self, spike):
-        """
-        **API Language** - :ref:`中文 <AdaptBaseNode.neuronal_reset-cn>` | :ref:`English <AdaptBaseNode.neuronal_reset-en>`
-
-        ----
-
-        .. _AdaptBaseNode.neuronal_reset-cn:
-
-        * **中文**
-
-        根据当前神经元释放的脉冲，对膜电位进行重置。
-
-        ----
-
-        .. _AdaptBaseNode.neuronal_reset-en:
-
-        * **English**
-
-        Reset the membrane potential according to neurons' output spikes.
-        """
-        if self.detach_reset:
-            spike_d = spike.detach()
-        else:
-            spike_d = spike
-
-        if self.v_reset is None:
-            # soft reset
-            self.v, self.w = self.apply_soft_reset(
-                self.v, self.w, spike_d, self.v_threshold, self.b, spike
-            )
-
-        else:
-            # hard reset
-            self.v, self.w = self.apply_hard_reset(
-                self.v, self.w, spike_d, self.v_reset, self.b, spike
-            )
-
     def extra_repr(self):
         return (
             super().extra_repr()
@@ -363,13 +300,6 @@ class IzhikevichNode(AdaptBaseNode):
 
     def extra_repr(self):
         return super().extra_repr() + f", tau={self.tau}, v_c={self.v_c}, a0={self.a0}"
-
-    def neuronal_charge(self, x: torch.Tensor):
-        self.v = (
-            self.v
-            + (x + self.a0 * (self.v - self.v_rest) * (self.v - self.v_c) - self.w)
-            / self.tau
-        )
 
     def single_step_functional_forward(
         self,

--- a/spikingjelly/activation_based/neuron/adapt.py
+++ b/spikingjelly/activation_based/neuron/adapt.py
@@ -380,18 +380,23 @@ class IzhikevichNode(AdaptBaseNode):
         x = inputs[0]
         v = states[0]
         w = states[-1]
-        v = v + (x + self.a0 * (v - self.v_rest) * (v - self.v_c) - w) / self.tau
-        w = self.jit_neuronal_adaptation(w, self.tau_w, self.a, self.v_rest, v)
-        spike = self.surrogate_function(v - self.v_threshold)
-        reset_spike = spike.detach() if self.detach_reset else spike
-        if self.v_reset is None:
-            v, w = self.apply_soft_reset(
-                v, w, reset_spike, self.v_threshold, self.b, spike
-            )
-        else:
-            v, w = self.apply_hard_reset(v, w, reset_spike, self.v_reset, self.b, spike)
-        updated_states = (v, states[1], w) if self.store_v_seq else (v, w)
-        return (spike,), updated_states
+        spike, v, w = functional.izhikevich_step(
+            x,
+            v,
+            w,
+            self.tau,
+            self.a0,
+            self.v_rest,
+            self.v_c,
+            self.tau_w,
+            self.a,
+            self.b,
+            self.v_threshold,
+            self.v_reset,
+            self.surrogate_function,
+            self.detach_reset,
+        )
+        return (spike,), (v, w)
 
     @property
     def supported_backends(self):
@@ -414,7 +419,7 @@ class IzhikevichNode(AdaptBaseNode):
             x_seq = inputs[0]
             v = states[0]
             w = states[-1]
-            spike_seq, v, w, v_seq, _ = functional.izhikevich_multi_step_cupy(
+            spike_seq, v, w, _, _ = functional.izhikevich_multi_step_cupy(
                 x_seq,
                 v,
                 w,
@@ -429,9 +434,36 @@ class IzhikevichNode(AdaptBaseNode):
                 self.a0,
                 self.detach_reset,
                 self.surrogate_function,
-                self.store_v_seq,
+                False,
             )
-            updated_states = (v, v_seq, w) if self.store_v_seq else (v, w)
-            return (spike_seq,), updated_states
+            return (spike_seq,), (v, w)
         else:
             raise ValueError(self.backend)
+
+    def multi_step_forward(self, x_seq: torch.Tensor, *args, **kwargs):
+        if not self.store_v_seq or self.backend != "cupy":
+            return super().multi_step_forward(x_seq, *args, **kwargs)
+
+        states = self.materialize_states(
+            (x_seq, *args), tuple(self._memories.values()), "m"
+        )
+        spike_seq, self.v, self.w, self.v_seq, _ = (
+            functional.izhikevich_multi_step_cupy(
+                x_seq,
+                states[0],
+                states[-1],
+                self.tau,
+                self.v_threshold,
+                self.v_reset,
+                self.v_rest,
+                self.a,
+                self.b,
+                self.tau_w,
+                self.v_c,
+                self.a0,
+                self.detach_reset,
+                self.surrogate_function,
+                True,
+            )
+        )
+        return spike_seq

--- a/spikingjelly/activation_based/neuron/adapt.py
+++ b/spikingjelly/activation_based/neuron/adapt.py
@@ -219,50 +219,23 @@ class AdaptBaseNode(BaseNode):
             + f", v_rest={self.v_rest}, w_rest={self.w_rest}, tau_w={self.tau_w}, a={self.a}, b={self.b}"
         )
 
-    def single_step_forward(self, x: torch.Tensor):
-        """
-        **API Language** - :ref:`中文 <AdaptBaseNode.single_step_forward-cn>` | :ref:`English <AdaptBaseNode.single_step_forward-en>`
-
-        ----
-
-        .. _AdaptBaseNode.single_step_forward-cn:
-
-        * **中文**
-
-        按照充电、适应、放电、重置的顺序进行前向传播。
-
-        :param x: 输入到神经元的电压增量
-        :type x: torch.Tensor
-
-        :return: 神经元的输出脉冲
-        :rtype: torch.Tensor
-
-        ----
-
-        .. _AdaptBaseNode.single_step_forward-en:
-
-        * **English**
-
-        Forward by the order of ``neuronal_charge``, ``neuronal_adaptation``, ``neuronal_fire``, and ``neuronal_reset``.
-
-        :param x: increment of voltage inputted to neurons
-        :type x: torch.Tensor
-
-        :return: out spikes of neurons
-        :rtype: torch.Tensor
-        """
-        self.v_float_to_tensor(x)
-        self.w_float_to_tensor(x)
-        self.neuronal_charge(x)
-        self.neuronal_adaptation()
-        spike = self.neuronal_fire()
-        self.neuronal_reset(spike)
-        return spike
-
-    def w_float_to_tensor(self, x: torch.Tensor):
-        if isinstance(self.w, float):
-            w_init = self.w
-            self.w = torch.full_like(x.data, fill_value=w_init)
+    def materialize_states(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        step_mode: str,
+    ) -> tuple[object, ...]:
+        states = super().materialize_states(inputs, states, step_mode)
+        x = states[0]
+        w = states[-1]
+        if isinstance(w, float):
+            w = torch.full_like(x, w, requires_grad=False)
+        elif isinstance(w, torch.Tensor):
+            if w.shape != x.shape:
+                w = torch.full_like(x, self.w_rest, requires_grad=False)
+            elif w.dtype != x.dtype or w.device != x.device:
+                w = w.to(dtype=x.dtype, device=x.device)
+        return (*states[:-1], w)
 
 
 class IzhikevichNode(AdaptBaseNode):
@@ -398,6 +371,28 @@ class IzhikevichNode(AdaptBaseNode):
             / self.tau
         )
 
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        v = states[0]
+        w = states[-1]
+        v = v + (x + self.a0 * (v - self.v_rest) * (v - self.v_c) - w) / self.tau
+        w = self.jit_neuronal_adaptation(w, self.tau_w, self.a, self.v_rest, v)
+        spike = self.surrogate_function(v - self.v_threshold)
+        reset_spike = spike.detach() if self.detach_reset else spike
+        if self.v_reset is None:
+            v, w = self.apply_soft_reset(
+                v, w, reset_spike, self.v_threshold, self.b, spike
+            )
+        else:
+            v, w = self.apply_hard_reset(v, w, reset_spike, self.v_reset, self.b, spike)
+        updated_states = (v, states[1], w) if self.store_v_seq else (v, w)
+        return (spike,), updated_states
+
     @property
     def supported_backends(self):
         if self.step_mode == "s":
@@ -407,16 +402,22 @@ class IzhikevichNode(AdaptBaseNode):
         else:
             raise ValueError(self.step_mode)
 
-    def multi_step_forward(self, x_seq: torch.Tensor):
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         if self.backend == "torch":
-            return super().multi_step_forward(x_seq)
+            return super().multi_step_functional_forward(inputs, states, **kwargs)
         elif self.backend == "cupy":
-            self.v_float_to_tensor(x_seq[0])
-            self.w_float_to_tensor(x_seq[0])
-            spike_seq, self.v, self.w, v_seq, _ = functional.izhikevich_multi_step_cupy(
+            x_seq = inputs[0]
+            v = states[0]
+            w = states[-1]
+            spike_seq, v, w, v_seq, _ = functional.izhikevich_multi_step_cupy(
                 x_seq,
-                self.v,
-                self.w,
+                v,
+                w,
                 self.tau,
                 self.v_threshold,
                 self.v_reset,
@@ -430,8 +431,7 @@ class IzhikevichNode(AdaptBaseNode):
                 self.surrogate_function,
                 self.store_v_seq,
             )
-            if self.store_v_seq:
-                self.v_seq = v_seq
-            return spike_seq
+            updated_states = (v, v_seq, w) if self.store_v_seq else (v, w)
+            return (spike_seq,), updated_states
         else:
             raise ValueError(self.backend)

--- a/spikingjelly/activation_based/neuron/base_node.py
+++ b/spikingjelly/activation_based/neuron/base_node.py
@@ -376,10 +376,11 @@ class BaseNode(base.MemoryModule):
     @store_v_seq.setter
     def store_v_seq(self, value: bool):
         self._store_v_seq = value
-        if value and "v_seq" not in self._memories:
-            self.register_memory("v_seq", None)
-        elif not value and "v_seq" in self._memories:
-            del self.v_seq
+        self.v_seq = None
+
+    def reset(self):
+        super().reset()
+        self.v_seq = None
 
     @staticmethod
     def apply_hard_reset(v: torch.Tensor, spike: torch.Tensor, v_reset: float):
@@ -442,31 +443,28 @@ class BaseNode(base.MemoryModule):
     def extra_repr(self):
         return f"v_threshold={self.v_threshold}, v_reset={self.v_reset}, detach_reset={self.detach_reset}, step_mode={self.step_mode}, backend={self.backend}"
 
-    def multi_step_functional_forward(
-        self,
-        inputs: tuple[torch.Tensor, ...],
-        states: tuple[object, ...],
-        **kwargs: object,
-    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+    def multi_step_forward(self, x_seq: torch.Tensor, *args, **kwargs):
+        if not self.store_v_seq:
+            return super().multi_step_forward(x_seq, *args, **kwargs)
+
+        inputs = (x_seq, *args)
+        states = self.materialize_states(inputs, tuple(self._memories.values()), "m")
         output_steps = []
         v_steps = []
-        for t in range(inputs[0].shape[0]):
+        for t in range(x_seq.shape[0]):
             outputs, states = self.single_step_functional_forward(
                 tuple(x[t] for x in inputs), states, **kwargs
             )
             output_steps.append(outputs)
-            if self.store_v_seq:
-                v_steps.append(states[0])
+            v_steps.append(states[0])
 
-        if self.store_v_seq:
-            states = (states[0], torch.stack(v_steps), *states[2:])
-        return (
-            tuple(
-                torch.stack(output_seq)
-                for output_seq in zip(*output_steps, strict=True)
-            ),
-            states,
+        for name, value in zip(self._memories, states, strict=True):
+            self._memories[name] = value
+        self.v_seq = torch.stack(v_steps)
+        outputs = tuple(
+            torch.stack(output_seq) for output_seq in zip(*output_steps, strict=True)
         )
+        return outputs[0] if len(outputs) == 1 else outputs
 
     def materialize_states(
         self,
@@ -474,9 +472,7 @@ class BaseNode(base.MemoryModule):
         states: tuple[object, ...],
         step_mode: str,
     ) -> tuple[object, ...]:
-        x = inputs[0]
-        if step_mode == "m" and x.dim() > 0 and x.shape[0] > 0:
-            x = x[0]
+        x = inputs[0][0] if step_mode == "m" else inputs[0]
         v = states[0]
         if isinstance(v, float):
             v = torch.full_like(x, v, requires_grad=False)

--- a/spikingjelly/activation_based/neuron/base_node.py
+++ b/spikingjelly/activation_based/neuron/base_node.py
@@ -27,7 +27,11 @@ class SimpleBaseNode(base.MemoryModule):
 
         * **中文**
 
-        :class:`BaseNode` 的简化版，便于用户修改或扩展神经元。
+        :class:`BaseNode` 的简化版，面向神经元动力学的修改和实验。常规前向按照
+        :meth:`neuronal_charge`、:meth:`neuronal_fire`、:meth:`neuronal_reset`
+        的顺序执行；用户通常只需要重写充电方程。该类不提供原生 functional
+        状态转移，:func:`spikingjelly.activation_based.base.to_functional_forward`
+        会通过通用状态替换路径转换其实例。
 
         :param v_threshold: 神经元的阈值电压
         :type v_threshold: float
@@ -46,7 +50,13 @@ class SimpleBaseNode(base.MemoryModule):
 
         * **English**
 
-        A simple version of :class:`BaseNode`. Users can modify this neuron easily.
+        A simplified :class:`BaseNode` for modifying and experimenting with neuron
+        dynamics. Regular forward executes :meth:`neuronal_charge`,
+        :meth:`neuronal_fire`, and :meth:`neuronal_reset` in order; users normally
+        only need to override the charge equation. This class does not provide a
+        native functional transition. Instances are converted by
+        :func:`spikingjelly.activation_based.base.to_functional_forward` through
+        the general state-substitution path.
 
         :param v_threshold: threshold of this neurons layer
         :type v_threshold: float
@@ -67,19 +77,158 @@ class SimpleBaseNode(base.MemoryModule):
         self.step_mode = step_mode
         self.register_memory(name="v", value=0.0)
 
-    def single_step_forward(self, x: torch.Tensor):
+    def single_step_forward(self, x: torch.Tensor) -> torch.Tensor:
+        r"""
+        **API Language** - :ref:`中文 <SimpleBaseNode.single_step_forward-cn>` | :ref:`English <SimpleBaseNode.single_step_forward-en>`
+
+        ----
+
+        .. _SimpleBaseNode.single_step_forward-cn:
+
+        * **中文**
+
+        依次执行充电、放电和重置，完成一个时间步的前向传播。
+
+        :param x: 单步输入张量
+        :type x: torch.Tensor
+        :return: 输出脉冲
+        :rtype: torch.Tensor
+
+        ----
+
+        .. _SimpleBaseNode.single_step_forward-en:
+
+        * **English**
+
+        Run one time step by applying charge, fire, and reset in order.
+
+        :param x: Single-step input tensor
+        :type x: torch.Tensor
+        :return: Output spikes
+        :rtype: torch.Tensor
+        """
         self.neuronal_charge(x)
         spike = self.neuronal_fire()
         self.neuronal_reset(spike)
         return spike
 
-    def neuronal_charge(self, x: torch.Tensor):
+    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+        r"""
+        **API Language** - :ref:`中文 <SimpleBaseNode.multi_step_forward-cn>` | :ref:`English <SimpleBaseNode.multi_step_forward-en>`
+
+        ----
+
+        .. _SimpleBaseNode.multi_step_forward-cn:
+
+        * **中文**
+
+        沿时间维逐步调用 :meth:`single_step_forward`。
+
+        :param x_seq: 输入序列，形状约定为 ``[T, N, *]``
+        :type x_seq: torch.Tensor
+        :return: 沿时间维堆叠的输出脉冲序列
+        :rtype: torch.Tensor
+
+        ----
+
+        .. _SimpleBaseNode.multi_step_forward-en:
+
+        * **English**
+
+        Apply :meth:`single_step_forward` successively along the time dimension.
+
+        :param x_seq: Input sequence with conventional shape ``[T, N, *]``
+        :type x_seq: torch.Tensor
+        :return: Output spike sequence stacked along the time dimension
+        :rtype: torch.Tensor
+        """
+        return torch.stack([self.single_step_forward(x) for x in x_seq])
+
+    def neuronal_charge(self, x: torch.Tensor) -> None:
+        r"""
+        **API Language** - :ref:`中文 <SimpleBaseNode.neuronal_charge-cn>` | :ref:`English <SimpleBaseNode.neuronal_charge-en>`
+
+        ----
+
+        .. _SimpleBaseNode.neuronal_charge-cn:
+
+        * **中文**
+
+        使用单步输入更新 ``self.v``。自定义 Simple 神经元通常只需要实现本方法。
+
+        :param x: 单步输入张量
+        :type x: torch.Tensor
+        :raises NotImplementedError: 子类未实现充电方程时抛出
+
+        ----
+
+        .. _SimpleBaseNode.neuronal_charge-en:
+
+        * **English**
+
+        Update ``self.v`` from one input step. Custom simple neurons normally only
+        need to implement this method.
+
+        :param x: Single-step input tensor
+        :type x: torch.Tensor
+        :raises NotImplementedError: If the subclass does not implement a charge equation
+        """
         raise NotImplementedError
 
-    def neuronal_fire(self):
+    def neuronal_fire(self) -> torch.Tensor:
+        r"""
+        **API Language** - :ref:`中文 <SimpleBaseNode.neuronal_fire-cn>` | :ref:`English <SimpleBaseNode.neuronal_fire-en>`
+
+        ----
+
+        .. _SimpleBaseNode.neuronal_fire-cn:
+
+        * **中文**
+
+        根据当前膜电位和阈值计算脉冲。
+
+        :return: 输出脉冲
+        :rtype: torch.Tensor
+
+        ----
+
+        .. _SimpleBaseNode.neuronal_fire-en:
+
+        * **English**
+
+        Calculate spikes from the current membrane potential and threshold.
+
+        :return: Output spikes
+        :rtype: torch.Tensor
+        """
         return self.surrogate_function(self.v - self.v_threshold)
 
-    def neuronal_reset(self, spike):
+    def neuronal_reset(self, spike: torch.Tensor) -> None:
+        r"""
+        **API Language** - :ref:`中文 <SimpleBaseNode.neuronal_reset-cn>` | :ref:`English <SimpleBaseNode.neuronal_reset-en>`
+
+        ----
+
+        .. _SimpleBaseNode.neuronal_reset-cn:
+
+        * **中文**
+
+        根据输出脉冲对 ``self.v`` 执行硬重置或软重置。
+
+        :param spike: 当前时间步的输出脉冲
+        :type spike: torch.Tensor
+
+        ----
+
+        .. _SimpleBaseNode.neuronal_reset-en:
+
+        * **English**
+
+        Apply hard or soft reset to ``self.v`` according to the output spikes.
+
+        :param spike: Output spikes of the current time step
+        :type spike: torch.Tensor
+        """
         if self.detach_reset:
             spike_d = spike.detach()
         else:
@@ -114,7 +263,11 @@ class BaseNode(base.MemoryModule):
 
         * **中文**
 
-        可微分SNN神经元的基类神经元。
+        生产级可微分 SNN 神经元的基类。常规前向由显式状态的 functional
+        状态转移支持；子类应实现 ``single_step_functional_forward``，并仅在存在
+        独立序列实现或专用 kernel 时重写 ``multi_step_functional_forward``。
+        若需要通过 ``neuronal_charge`` 修改 Python 神经元方程，请继承
+        :class:`SimpleBaseNode`。
 
         :param v_threshold: 神经元的阈值电压
         :type v_threshold: float
@@ -148,7 +301,12 @@ class BaseNode(base.MemoryModule):
 
         * **English**
 
-        This class is the base class of differentiable spiking neurons.
+        Base class for production differentiable spiking neurons. Regular forward
+        is backed by an explicit-state functional transition. Subclasses should
+        implement ``single_step_functional_forward`` and override
+        ``multi_step_functional_forward`` only for an independent sequence
+        implementation or specialized kernel. Inherit :class:`SimpleBaseNode`
+        instead to modify Python neuron equations through ``neuronal_charge``.
 
         :param v_threshold: threshold of this neurons layer
         :type v_threshold: float
@@ -212,9 +370,10 @@ class BaseNode(base.MemoryModule):
     @store_v_seq.setter
     def store_v_seq(self, value: bool):
         self._store_v_seq = value
-        if value:
-            if not hasattr(self, "v_seq"):
-                self.register_memory("v_seq", None)
+        if value and "v_seq" not in self._memories:
+            self.register_memory("v_seq", None)
+        elif not value and "v_seq" in self._memories:
+            del self.v_seq
 
     @staticmethod
     def apply_hard_reset(v: torch.Tensor, spike: torch.Tensor, v_reset: float):
@@ -226,153 +385,105 @@ class BaseNode(base.MemoryModule):
         v = v - spike * v_threshold
         return v
 
-    @abstractmethod
-    def neuronal_charge(self, x: torch.Tensor):
-        """
-        **API Language** - :ref:`中文 <BaseNode.neuronal_charge-cn>` | :ref:`English <BaseNode.neuronal_charge-en>`
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        r"""
+        **API Language** - :ref:`中文 <BaseNode.single_step_functional_forward-cn>` | :ref:`English <BaseNode.single_step_functional_forward-en>`
 
         ----
 
-        .. _BaseNode.neuronal_charge-cn:
+        .. _BaseNode.single_step_functional_forward-cn:
 
         * **中文**
 
-        定义神经元的充电差分方程。子类必须实现这个函数。
+        使用显式状态执行一个神经元时间步。生产级神经元子类必须实现本方法，
+        且不得修改模块 memory 或传入的 ``states``。
+
+        :param inputs: 单步输入张量元组
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: 当前神经元的显式状态元组
+        :type states: tuple[object, ...]
+        :return: ``(outputs, updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple[object, ...]]
+        :raises NotImplementedError: 子类未实现 functional 状态转移时抛出
 
         ----
 
-        .. _BaseNode.neuronal_charge-en:
+        .. _BaseNode.single_step_functional_forward-en:
 
         * **English**
 
-        Define the charge difference equation. The sub-class must implement this function.
+        Run one neuron time step with explicit states. Production neuron
+        subclasses must implement this method without mutating module memories
+        or the supplied ``states``.
+
+        :param inputs: Tuple of single-step input tensors
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: Tuple of explicit neuron states
+        :type states: tuple[object, ...]
+        :return: ``(outputs, updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple[object, ...]]
+        :raises NotImplementedError: If the subclass does not implement a functional state transition
         """
-
-    def neuronal_fire(self):
-        """
-        **API Language** - :ref:`中文 <BaseNode.neuronal_fire-cn>` | :ref:`English <BaseNode.neuronal_fire-en>`
-
-        ----
-
-        .. _BaseNode.neuronal_fire-cn:
-
-        * **中文**
-
-        根据当前神经元的电压、阈值，计算输出脉冲。
-
-        ----
-
-        .. _BaseNode.neuronal_fire-en:
-
-        * **English**
-
-        Calculate out spikes of neurons by their current membrane potential and threshold voltage.
-        """
-        return self.surrogate_function(self.v - self.v_threshold)
-
-    def neuronal_reset(self, spike):
-        """
-        **API Language** - :ref:`中文 <BaseNode.neuronal_reset-cn>` | :ref:`English <BaseNode.neuronal_reset-en>`
-
-        ----
-
-        .. _BaseNode.neuronal_reset-cn:
-
-        * **中文**
-
-        根据当前神经元释放的脉冲，对膜电位进行重置。
-
-        ----
-
-        .. _BaseNode.neuronal_reset-en:
-
-        * **English**
-
-        Reset the membrane potential according to neurons' output spikes.
-        """
-        if self.detach_reset:
-            spike_d = spike.detach()
-        else:
-            spike_d = spike
-
-        if self.v_reset is None:
-            # soft reset
-            self.v = self.apply_soft_reset(self.v, spike_d, self.v_threshold)
-
-        else:
-            # hard reset
-            self.v = self.apply_hard_reset(self.v, spike_d, self.v_reset)
+        raise NotImplementedError(
+            f"{self._get_name()} must implement single_step_functional_forward."
+        )
 
     def extra_repr(self):
         return f"v_threshold={self.v_threshold}, v_reset={self.v_reset}, detach_reset={self.detach_reset}, step_mode={self.step_mode}, backend={self.backend}"
 
-    def single_step_forward(self, x: torch.Tensor):
-        """
-        **API Language** - :ref:`中文 <BaseNode.single_step_forward-cn>` | :ref:`English <BaseNode.single_step_forward-en>`
-
-        ----
-
-        .. _BaseNode.single_step_forward-cn:
-
-        * **中文**
-
-        按照充电、放电、重置的顺序进行前向传播。
-
-        :param x: 输入到神经元的电压增量
-        :type x: torch.Tensor
-
-        :return: 神经元的输出脉冲
-        :rtype: torch.Tensor
-
-        ----
-
-        .. _BaseNode.single_step_forward-en:
-
-        * **English**
-
-        Forward by the order of ``neuronal_charge``, ``neuronal_fire``, and ``neuronal_reset``.
-
-        :param x: increment of voltage inputted to neurons
-        :type x: torch.Tensor
-
-        :return: out spikes of neurons
-        :rtype: torch.Tensor
-        """
-        self.v_float_to_tensor(x)
-        self.neuronal_charge(x)
-        spike = self.neuronal_fire()
-        self.neuronal_reset(spike)
-        return spike
-
-    def multi_step_forward(self, x_seq: torch.Tensor):
-        T = x_seq.shape[0]
-        y_seq = []
-        if self.store_v_seq:
-            v_seq = []
-        for t in range(T):
-            y = self.single_step_forward(x_seq[t])
-            y_seq.append(y)
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        output_steps = []
+        v_steps = []
+        for t in range(inputs[0].shape[0]):
+            outputs, states = self.single_step_functional_forward(
+                tuple(x[t] for x in inputs), states, **kwargs
+            )
+            output_steps.append(outputs)
             if self.store_v_seq:
-                v_seq.append(self.v)
+                v_steps.append(states[0])
 
         if self.store_v_seq:
-            self.v_seq = torch.stack(v_seq)
+            states = (states[0], torch.stack(v_steps), *states[2:])
+        return (
+            tuple(
+                torch.stack(output_seq)
+                for output_seq in zip(*output_steps, strict=True)
+            ),
+            states,
+        )
 
-        return torch.stack(y_seq)
-
-    def v_float_to_tensor(self, x: torch.Tensor):
-        if isinstance(self.v, float):
-            v_init = self.v
-            self.v = torch.full_like(x, v_init, requires_grad=False)
-        elif isinstance(self.v, torch.Tensor):
-            if self.v.shape != x.shape:
-                self.v = torch.full_like(
+    def materialize_states(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        step_mode: str,
+    ) -> tuple[object, ...]:
+        x = inputs[0]
+        if step_mode == "m" and x.dim() > 0 and x.shape[0] > 0:
+            x = x[0]
+        v = states[0]
+        if isinstance(v, float):
+            v = torch.full_like(x, v, requires_grad=False)
+        elif isinstance(v, torch.Tensor):
+            if v.shape != x.shape:
+                v = torch.full_like(
                     x,
                     self.v_reset if self.v_reset is not None else 0.0,
                     requires_grad=False,
                 )
-            elif self.v.dtype != x.dtype or self.v.device != x.device:
-                self.v = self.v.to(dtype=x.dtype, device=x.device)
+            elif v.dtype != x.dtype or v.device != x.device:
+                v = v.to(dtype=x.dtype, device=x.device)
+        return (v, *states[1:])
 
 
 class NonSpikingBaseNode(nn.Module, base.MultiStepModule):

--- a/spikingjelly/activation_based/neuron/base_node.py
+++ b/spikingjelly/activation_based/neuron/base_node.py
@@ -27,11 +27,13 @@ class SimpleBaseNode(base.MemoryModule):
 
         * **中文**
 
-        :class:`BaseNode` 的简化版，面向神经元动力学的修改和实验。常规前向按照
-        :meth:`neuronal_charge`、:meth:`neuronal_fire`、:meth:`neuronal_reset`
-        的顺序执行；用户通常只需要重写充电方程。该类不提供原生 functional
-        状态转移，:func:`spikingjelly.activation_based.base.to_functional_forward`
-        会通过通用状态替换路径转换其实例。
+        面向教学和神经元动力学自定义的纯 PyTorch 接口。``Simple`` 描述的是接口
+        目标，并不表示一种神经元数学模型。该类将 SNN 神经元的充电、放电和重置
+        职责直接表达为 :meth:`neuronal_charge`、:meth:`neuronal_fire` 和
+        :meth:`neuronal_reset`；用户通常只需要重写充电方程。该类不提供原生
+        functional 状态转移，
+        :func:`spikingjelly.activation_based.base.to_functional_forward` 会通过通用
+        状态替换路径转换其实例。
 
         :param v_threshold: 神经元的阈值电压
         :type v_threshold: float
@@ -50,11 +52,13 @@ class SimpleBaseNode(base.MemoryModule):
 
         * **English**
 
-        A simplified :class:`BaseNode` for modifying and experimenting with neuron
-        dynamics. Regular forward executes :meth:`neuronal_charge`,
-        :meth:`neuronal_fire`, and :meth:`neuronal_reset` in order; users normally
-        only need to override the charge equation. This class does not provide a
-        native functional transition. Instances are converted by
+        A pure-PyTorch interface for teaching and customizing neuron dynamics.
+        ``Simple`` describes the interface goal; it is not a neuron mathematical
+        model. The class exposes the charge, fire, and reset responsibilities of an
+        SNN neuron directly as :meth:`neuronal_charge`, :meth:`neuronal_fire`, and
+        :meth:`neuronal_reset`; users normally only need to override the charge
+        equation. This class does not provide a native functional transition.
+        Instances are converted by
         :func:`spikingjelly.activation_based.base.to_functional_forward` through
         the general state-substitution path.
 
@@ -154,7 +158,8 @@ class SimpleBaseNode(base.MemoryModule):
 
         * **中文**
 
-        使用单步输入更新 ``self.v``。自定义 Simple 神经元通常只需要实现本方法。
+        使用单步输入更新 ``self.v``。继承 :class:`SimpleBaseNode` 自定义动力学时，
+        通常只需要实现本方法。
 
         :param x: 单步输入张量
         :type x: torch.Tensor
@@ -166,8 +171,9 @@ class SimpleBaseNode(base.MemoryModule):
 
         * **English**
 
-        Update ``self.v`` from one input step. Custom simple neurons normally only
-        need to implement this method.
+        Update ``self.v`` from one input step. Subclasses of
+        :class:`SimpleBaseNode` normally only need to implement this method to
+        customize their dynamics.
 
         :param x: Single-step input tensor
         :type x: torch.Tensor

--- a/spikingjelly/activation_based/neuron/dsr.py
+++ b/spikingjelly/activation_based/neuron/dsr.py
@@ -131,14 +131,18 @@ class DSRIFNode(base.MemoryModule):
             + f", vth_g_scale={self.v_threshold_grad_scaling}"
         )
 
-    def multi_step_forward(self, x_seq: torch.Tensor):
-        with torch.no_grad():
-            self.v_threshold.clamp_(min=self.v_threshold_lower_bound)
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        v_threshold = self.v_threshold.clamp(min=self.v_threshold_lower_bound)
         iffunc = self.DSRIFFunction.apply
         y_seq = iffunc(
-            x_seq, self.T, self.v_threshold, self.alpha, self.v_threshold_grad_scaling
+            inputs[0], self.T, v_threshold, self.alpha, self.v_threshold_grad_scaling
         )
-        return y_seq
+        return (y_seq,), states
 
     class DSRIFFunction(torch.autograd.Function):
         @staticmethod
@@ -329,20 +333,24 @@ class DSRLIFNode(base.MemoryModule):
             + f", vth_g_scale={self.v_threshold_grad_scaling}"
         )
 
-    def multi_step_forward(self, x_seq: torch.Tensor):
-        with torch.no_grad():
-            self.v_threshold.clamp_(min=self.v_threshold_lower_bound)
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        v_threshold = self.v_threshold.clamp(min=self.v_threshold_lower_bound)
         liffunc = self.DSRLIFFunction.apply
         y_seq = liffunc(
-            x_seq,
+            inputs[0],
             self.T,
-            self.v_threshold,
+            v_threshold,
             self.tau,
             self.delta_t,
             self.alpha,
             self.v_threshold_grad_scaling,
         )
-        return y_seq
+        return (y_seq,), states
 
     @classmethod
     def weight_rate_spikes(cls, data, tau, delta_t):

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -1315,42 +1315,67 @@ class FlexSN(base.MemoryModule):
         else:
             raise ValueError(f"Unsupported step mode: {step_mode}")
 
-    def single_step_forward(self, *args):
-        # only torch backend is supported for single-step forward
-        results = self.core(*args, *self.states)  # [*outputs, *states]
-        self.states = results[self.num_outputs :]
-        return results[: self.num_outputs]
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        state_values = states[1] if self.store_state_seqs else states[0]
+        if state_values is None:
+            state_values = self.init_states(self.num_states, "s", *inputs)
+        results = self.core(*inputs, *state_values)
+        updated_states = (
+            (states[0], list(results[self.num_outputs :]))
+            if self.store_state_seqs
+            else (list(results[self.num_outputs :]),)
+        )
+        return tuple(results[: self.num_outputs]), updated_states
 
-    def multi_step_forward(self, *args):
-        T = args[0].shape[0]
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        T = inputs[0].shape[0]
+        state_values = states[1] if self.store_state_seqs else states[0]
+        state_sequences = states[0] if self.store_state_seqs else None
         if T == 0:
             if self.backend not in self.supported_backends:
                 raise ValueError(f"Unsupported backend: {self.backend}")
-            if self.states is None:
-                self.states = self.init_states(self.num_states, self.step_mode, *args)
+            if state_values is None:
+                state_values = self.init_states(
+                    self.num_states, self.step_mode, *inputs
+                )
             if self.backend == "hop":
-                state_args = [state.contiguous() for state in self.states]
+                state_args = [state.contiguous() for state in state_values]
                 result_seqs = _run_hop_scan(
                     self.core,
                     self.num_inputs,
                     self.num_states,
                     self.num_outputs,
                     self.store_state_seqs,
-                    *args,
+                    *inputs,
                     *state_args,
                     output_template_specs=self._output_template_specs,
                 )
                 output_seqs = list(result_seqs[: self.num_outputs])
                 state_results = list(result_seqs[self.num_outputs :])
                 if self.store_state_seqs:
-                    self.state_seqs = state_results
-                    self.states = [
-                        _last_state_or_current(v, self.states[i])
+                    state_sequences = state_results
+                    state_values = [
+                        _last_state_or_current(v, state_values[i])
                         for i, v in enumerate(state_results)
                     ]
                 else:
-                    self.states = state_results
-                return output_seqs
+                    state_values = state_results
+                updated_states = (
+                    (state_sequences, state_values)
+                    if self.store_state_seqs
+                    else (state_values,)
+                )
+                return tuple(output_seqs), updated_states
             if (
                 self.backend == "torch"
                 and self.num_outputs > 0
@@ -1362,87 +1387,101 @@ class FlexSN(base.MemoryModule):
                     "match core's per-step return contract without executing core."
                 )
             output_seqs = _empty_multistep_outputs(
-                args,
-                self.states,
+                inputs,
+                state_values,
                 self.num_outputs,
                 self._output_template_specs,
                 use_template_device=False,
             )
             if self.store_state_seqs:
-                self.state_seqs = [s.new_empty((0, *s.shape)) for s in self.states]
-            return output_seqs
+                state_sequences = [s.new_empty((0, *s.shape)) for s in state_values]
+            updated_states = (
+                (state_sequences, state_values)
+                if self.store_state_seqs
+                else (state_values,)
+            )
+            return tuple(output_seqs), updated_states
 
         if self.backend == "torch":
-            if self.states is None:
-                self.states = self.init_states(self.num_states, self.step_mode, *args)
+            if state_values is None:
+                state_values = self.init_states(
+                    self.num_states, self.step_mode, *inputs
+                )
             output_seqs = [[] for _ in range(self.num_outputs)]
             if self.store_state_seqs:
                 state_seqs = [[] for _ in range(self.num_states)]
 
             for t in range(T):
-                outputs = self.single_step_forward(*[arg[t] for arg in args])
+                results = self.core(*(arg[t] for arg in inputs), *state_values)
+                outputs = results[: self.num_outputs]
+                state_values = list(results[self.num_outputs :])
                 for i in range(self.num_outputs):
                     output_seqs[i].append(outputs[i])
                 if self.store_state_seqs:
                     for i in range(self.num_states):
-                        state_seqs[i].append(self.states[i])
+                        state_seqs[i].append(state_values[i])
 
             if self.store_state_seqs:
-                self.state_seqs = [torch.stack(v, dim=0) for v in state_seqs]
-
-            return [torch.stack(y, dim=0) for y in output_seqs]
+                state_sequences = [torch.stack(v, dim=0) for v in state_seqs]
+            updated_states = (
+                (state_sequences, state_values)
+                if self.store_state_seqs
+                else (state_values,)
+            )
+            return tuple(torch.stack(y, dim=0) for y in output_seqs), updated_states
 
         elif self.backend == "hop":
-            if self.states is None:
-                self.states = self.init_states(self.num_states, self.step_mode, *args)
-            state_args = [state.contiguous() for state in self.states]
+            if state_values is None:
+                state_values = self.init_states(
+                    self.num_states, self.step_mode, *inputs
+                )
+            state_args = [state.contiguous() for state in state_values]
             result_seqs = _run_hop_scan(
                 self.core,
                 self.num_inputs,
                 self.num_states,
                 self.num_outputs,
                 self.store_state_seqs,
-                *args,
+                *inputs,
                 *state_args,
                 output_template_specs=self._output_template_specs,
             )
             output_seqs = list(result_seqs[: self.num_outputs])
             state_results = list(result_seqs[self.num_outputs :])
             if self.store_state_seqs:
-                state_seqs = state_results
-                self.states = [
-                    _last_state_or_current(v, self.states[i])
-                    for i, v in enumerate(state_seqs)
+                state_sequences = state_results
+                state_values = [
+                    _last_state_or_current(v, state_values[i])
+                    for i, v in enumerate(state_sequences)
                 ]
-                self.state_seqs = state_seqs
             else:
-                self.states = state_results
-            return output_seqs
+                state_values = state_results
+            updated_states = (
+                (state_sequences, state_values)
+                if self.store_state_seqs
+                else (state_values,)
+            )
+            return tuple(output_seqs), updated_states
 
         elif _is_flexsn_triton_backend(self.backend):
             result_has_state_seqs = self.store_state_seqs
-            can_elide_zero_states = (
-                self.states is None and _can_elide_zero_state_inputs(self)
-            )
-            # The first init_states branch handles the case where zero-state elision
-            # is impossible. _no_grad then determines whether use_implicit_zero_states
-            # can skip explicit state tensors entirely. The second init_states branch
-            # only runs if self.states is still None, so re-initialization cannot occur.
-            if self.states is None and not can_elide_zero_states:
-                self.states = self.init_states(self.num_states, self.step_mode, *args)
-            _no_grad = not torch.is_grad_enabled() or (
-                not _value_requires_grad(args)
-                and not _value_requires_grad(self.states)
+            no_grad = not torch.is_grad_enabled() or (
+                not _value_requires_grad(inputs)
+                and not _value_requires_grad(state_values)
                 and not _core_requires_grad(self.core)
             )
-            use_implicit_zero_states = can_elide_zero_states and _no_grad
-            if self.states is None and not use_implicit_zero_states:
-                self.states = self.init_states(self.num_states, self.step_mode, *args)
-            state_args = [] if use_implicit_zero_states else list(self.states)
-            flat_args = [*args, *state_args]
+            use_implicit_zero_states = (
+                state_values is None and _can_elide_zero_state_inputs(self) and no_grad
+            )
+            if state_values is None and not use_implicit_zero_states:
+                state_values = self.init_states(
+                    self.num_states, self.step_mode, *inputs
+                )
+            state_args = [] if use_implicit_zero_states else list(state_values)
+            flat_args = [*inputs, *state_args]
             all_cuda, same_device = _flat_args_on_single_cuda_device(flat_args)
             if self._inductor_handle is not None and all_cuda and same_device:
-                if _no_grad:
+                if no_grad:
                     if (
                         not self.store_state_seqs
                         and self._inductor_inference_final_state_available
@@ -1451,8 +1490,13 @@ class FlexSN(base.MemoryModule):
                             self._inductor_handle, flat_args
                         )
                         output_seqs = list(result_seqs[: self.num_outputs])
-                        self.states = list(result_seqs[self.num_outputs :])
-                        return output_seqs
+                        state_values = list(result_seqs[self.num_outputs :])
+                        updated_states = (
+                            (state_sequences, state_values)
+                            if self.store_state_seqs
+                            else (state_values,)
+                        )
+                        return tuple(output_seqs), updated_states
                     elif self._inductor_inference_available:
                         result_seqs = flexsn_inductor_inference(
                             self._inductor_handle, flat_args
@@ -1460,18 +1504,23 @@ class FlexSN(base.MemoryModule):
                         result_has_state_seqs = True
                     else:
                         result_seqs = None
-                elif (not _no_grad) and self._inductor_training_available:
+                elif self._inductor_training_available:
                     if not self.store_state_seqs:
                         result_seqs = flexsn_inductor_training_final_state(
                             self._inductor_handle, flat_args
                         )
                         output_seqs = list(result_seqs[: self.num_outputs])
-                        self.states = list(
+                        state_values = list(
                             result_seqs[
                                 self.num_outputs : self.num_outputs + self.num_states
                             ]
                         )
-                        return output_seqs
+                        updated_states = (
+                            (state_sequences, state_values)
+                            if self.store_state_seqs
+                            else (state_values,)
+                        )
+                        return tuple(output_seqs), updated_states
                     result_seqs = flexsn_inductor_training(
                         self._inductor_handle, flat_args
                     )
@@ -1482,18 +1531,18 @@ class FlexSN(base.MemoryModule):
                 result_seqs = None
 
             if result_seqs is None:
-                if self.states is None:
-                    self.states = self.init_states(
-                        self.num_states, self.step_mode, *args
+                if state_values is None:
+                    state_values = self.init_states(
+                        self.num_states, self.step_mode, *inputs
                     )
-                state_args = [state.contiguous() for state in self.states]
+                state_args = [state.contiguous() for state in state_values]
                 result_seqs = _run_hop_scan(
                     self.core,
                     self.num_inputs,
                     self.num_states,
                     self.num_outputs,
                     self.store_state_seqs,
-                    *args,
+                    *inputs,
                     *state_args,
                     output_template_specs=self._output_template_specs,
                 )
@@ -1501,39 +1550,46 @@ class FlexSN(base.MemoryModule):
             output_seqs = list(result_seqs[: self.num_outputs])
             state_seqs = list(result_seqs[self.num_outputs :])
             if result_has_state_seqs:
-                if self.states is None:
-                    self.states = self.init_states(
-                        self.num_states, self.step_mode, *args
+                if state_values is None:
+                    state_values = self.init_states(
+                        self.num_states, self.step_mode, *inputs
                     )
-                self.states = [
-                    _last_state_or_current(v, self.states[i])
+                state_values = [
+                    _last_state_or_current(v, state_values[i])
                     for i, v in enumerate(state_seqs)
                 ]
                 if self.store_state_seqs:
-                    self.state_seqs = state_seqs
+                    state_sequences = state_seqs
             else:
-                self.states = state_seqs
-            return output_seqs
+                state_values = state_seqs
+            updated_states = (
+                (state_sequences, state_values)
+                if self.store_state_seqs
+                else (state_values,)
+            )
+            return tuple(output_seqs), updated_states
 
         else:
             raise ValueError(f"Unsupported backend: {self.backend}")
 
-    def forward(self, *args):
-        can_elide = (
-            self.step_mode == "m"
-            and _can_elide_zero_state_inputs(self)
-            and (
-                not torch.is_grad_enabled()
-                or (
-                    not _value_requires_grad(args)
-                    and not _core_requires_grad(self.core)
-                )
-            )
-        )
-        if self.states is None and not can_elide:
-            self.states = self.init_states(self.num_states, self.step_mode, *args)
-        output = super().forward(*args)
-        return output[0] if len(output) == 1 else output
+    def single_step_forward(self, *args: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        outputs = super().single_step_forward(*args)
+        return outputs if isinstance(outputs, tuple) else (outputs,)
+
+    def multi_step_forward(self, *args: torch.Tensor) -> list[torch.Tensor]:
+        outputs = super().multi_step_forward(*args)
+        return list(outputs) if isinstance(outputs, tuple) else [outputs]
+
+    def forward(
+        self, *args: torch.Tensor
+    ) -> torch.Tensor | tuple[torch.Tensor, ...] | list[torch.Tensor]:
+        if self.step_mode == "s":
+            outputs = self.single_step_forward(*args)
+        elif self.step_mode == "m":
+            outputs = self.multi_step_forward(*args)
+        else:
+            raise ValueError(self.step_mode)
+        return outputs[0] if len(outputs) == 1 else outputs
 
     def extra_repr(self):
         core_name = getattr(self.core, "__name__", type(self.core).__name__)

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -1246,9 +1246,11 @@ class FlexSN(base.MemoryModule):
     @store_state_seqs.setter
     def store_state_seqs(self, value: bool):
         self._store_state_seqs = value
-        if value:
-            if not hasattr(self, "state_seqs"):
-                self.register_memory("state_seqs", None)
+        self.state_seqs = None
+
+    def reset(self):
+        super().reset()
+        self.state_seqs = None
 
     @staticmethod
     def init_states(num_states: int, step_mode: str, *args) -> List[torch.Tensor]:
@@ -1321,26 +1323,20 @@ class FlexSN(base.MemoryModule):
         states: tuple[object, ...],
         **kwargs: object,
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
-        state_values = states[1] if self.store_state_seqs else states[0]
+        state_values = states[0]
         if state_values is None:
             state_values = self.init_states(self.num_states, "s", *inputs)
         results = self.core(*inputs, *state_values)
-        updated_states = (
-            (states[0], list(results[self.num_outputs :]))
-            if self.store_state_seqs
-            else (list(results[self.num_outputs :]),)
-        )
-        return tuple(results[: self.num_outputs]), updated_states
+        return tuple(results[: self.num_outputs]), (list(results[self.num_outputs :]),)
 
-    def multi_step_functional_forward(
+    def _multi_step(
         self,
         inputs: tuple[torch.Tensor, ...],
-        states: tuple[object, ...],
-        **kwargs: object,
+        state_values: list[torch.Tensor] | None,
+        store_state_seqs: bool,
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         T = inputs[0].shape[0]
-        state_values = states[1] if self.store_state_seqs else states[0]
-        state_sequences = states[0] if self.store_state_seqs else None
+        state_sequences = None
         if T == 0:
             if self.backend not in self.supported_backends:
                 raise ValueError(f"Unsupported backend: {self.backend}")
@@ -1355,14 +1351,14 @@ class FlexSN(base.MemoryModule):
                     self.num_inputs,
                     self.num_states,
                     self.num_outputs,
-                    self.store_state_seqs,
+                    store_state_seqs,
                     *inputs,
                     *state_args,
                     output_template_specs=self._output_template_specs,
                 )
                 output_seqs = list(result_seqs[: self.num_outputs])
                 state_results = list(result_seqs[self.num_outputs :])
-                if self.store_state_seqs:
+                if store_state_seqs:
                     state_sequences = state_results
                     state_values = [
                         _last_state_or_current(v, state_values[i])
@@ -1372,7 +1368,7 @@ class FlexSN(base.MemoryModule):
                     state_values = state_results
                 updated_states = (
                     (state_sequences, state_values)
-                    if self.store_state_seqs
+                    if store_state_seqs
                     else (state_values,)
                 )
                 return tuple(output_seqs), updated_states
@@ -1393,12 +1389,10 @@ class FlexSN(base.MemoryModule):
                 self._output_template_specs,
                 use_template_device=False,
             )
-            if self.store_state_seqs:
+            if store_state_seqs:
                 state_sequences = [s.new_empty((0, *s.shape)) for s in state_values]
             updated_states = (
-                (state_sequences, state_values)
-                if self.store_state_seqs
-                else (state_values,)
+                (state_sequences, state_values) if store_state_seqs else (state_values,)
             )
             return tuple(output_seqs), updated_states
 
@@ -1408,7 +1402,7 @@ class FlexSN(base.MemoryModule):
                     self.num_states, self.step_mode, *inputs
                 )
             output_seqs = [[] for _ in range(self.num_outputs)]
-            if self.store_state_seqs:
+            if store_state_seqs:
                 state_seqs = [[] for _ in range(self.num_states)]
 
             for t in range(T):
@@ -1417,16 +1411,14 @@ class FlexSN(base.MemoryModule):
                 state_values = list(results[self.num_outputs :])
                 for i in range(self.num_outputs):
                     output_seqs[i].append(outputs[i])
-                if self.store_state_seqs:
+                if store_state_seqs:
                     for i in range(self.num_states):
                         state_seqs[i].append(state_values[i])
 
-            if self.store_state_seqs:
+            if store_state_seqs:
                 state_sequences = [torch.stack(v, dim=0) for v in state_seqs]
             updated_states = (
-                (state_sequences, state_values)
-                if self.store_state_seqs
-                else (state_values,)
+                (state_sequences, state_values) if store_state_seqs else (state_values,)
             )
             return tuple(torch.stack(y, dim=0) for y in output_seqs), updated_states
 
@@ -1441,14 +1433,14 @@ class FlexSN(base.MemoryModule):
                 self.num_inputs,
                 self.num_states,
                 self.num_outputs,
-                self.store_state_seqs,
+                store_state_seqs,
                 *inputs,
                 *state_args,
                 output_template_specs=self._output_template_specs,
             )
             output_seqs = list(result_seqs[: self.num_outputs])
             state_results = list(result_seqs[self.num_outputs :])
-            if self.store_state_seqs:
+            if store_state_seqs:
                 state_sequences = state_results
                 state_values = [
                     _last_state_or_current(v, state_values[i])
@@ -1457,14 +1449,12 @@ class FlexSN(base.MemoryModule):
             else:
                 state_values = state_results
             updated_states = (
-                (state_sequences, state_values)
-                if self.store_state_seqs
-                else (state_values,)
+                (state_sequences, state_values) if store_state_seqs else (state_values,)
             )
             return tuple(output_seqs), updated_states
 
         elif _is_flexsn_triton_backend(self.backend):
-            result_has_state_seqs = self.store_state_seqs
+            result_has_state_seqs = store_state_seqs
             no_grad = not torch.is_grad_enabled() or (
                 not _value_requires_grad(inputs)
                 and not _value_requires_grad(state_values)
@@ -1483,7 +1473,7 @@ class FlexSN(base.MemoryModule):
             if self._inductor_handle is not None and all_cuda and same_device:
                 if no_grad:
                     if (
-                        not self.store_state_seqs
+                        not store_state_seqs
                         and self._inductor_inference_final_state_available
                     ):
                         result_seqs = flexsn_inductor_inference_final_state(
@@ -1493,7 +1483,7 @@ class FlexSN(base.MemoryModule):
                         state_values = list(result_seqs[self.num_outputs :])
                         updated_states = (
                             (state_sequences, state_values)
-                            if self.store_state_seqs
+                            if store_state_seqs
                             else (state_values,)
                         )
                         return tuple(output_seqs), updated_states
@@ -1505,7 +1495,7 @@ class FlexSN(base.MemoryModule):
                     else:
                         result_seqs = None
                 elif self._inductor_training_available:
-                    if not self.store_state_seqs:
+                    if not store_state_seqs:
                         result_seqs = flexsn_inductor_training_final_state(
                             self._inductor_handle, flat_args
                         )
@@ -1517,7 +1507,7 @@ class FlexSN(base.MemoryModule):
                         )
                         updated_states = (
                             (state_sequences, state_values)
-                            if self.store_state_seqs
+                            if store_state_seqs
                             else (state_values,)
                         )
                         return tuple(output_seqs), updated_states
@@ -1541,12 +1531,12 @@ class FlexSN(base.MemoryModule):
                     self.num_inputs,
                     self.num_states,
                     self.num_outputs,
-                    self.store_state_seqs,
+                    store_state_seqs,
                     *inputs,
                     *state_args,
                     output_template_specs=self._output_template_specs,
                 )
-                result_has_state_seqs = self.store_state_seqs
+                result_has_state_seqs = store_state_seqs
             output_seqs = list(result_seqs[: self.num_outputs])
             state_seqs = list(result_seqs[self.num_outputs :])
             if result_has_state_seqs:
@@ -1558,27 +1548,39 @@ class FlexSN(base.MemoryModule):
                     _last_state_or_current(v, state_values[i])
                     for i, v in enumerate(state_seqs)
                 ]
-                if self.store_state_seqs:
+                if store_state_seqs:
                     state_sequences = state_seqs
             else:
                 state_values = state_seqs
             updated_states = (
-                (state_sequences, state_values)
-                if self.store_state_seqs
-                else (state_values,)
+                (state_sequences, state_values) if store_state_seqs else (state_values,)
             )
             return tuple(output_seqs), updated_states
 
         else:
             raise ValueError(f"Unsupported backend: {self.backend}")
 
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        return self._multi_step(inputs, states[0], False)
+
     def single_step_forward(self, *args: torch.Tensor) -> tuple[torch.Tensor, ...]:
         outputs = super().single_step_forward(*args)
         return outputs if isinstance(outputs, tuple) else (outputs,)
 
     def multi_step_forward(self, *args: torch.Tensor) -> list[torch.Tensor]:
-        outputs = super().multi_step_forward(*args)
-        return list(outputs) if isinstance(outputs, tuple) else [outputs]
+        outputs, updated_states = self._multi_step(
+            tuple(args), self.states, self.store_state_seqs
+        )
+        if self.store_state_seqs:
+            self.state_seqs, self.states = updated_states
+        else:
+            (self.states,) = updated_states
+        return list(outputs)
 
     def forward(
         self, *args: torch.Tensor

--- a/spikingjelly/activation_based/neuron/ilif.py
+++ b/spikingjelly/activation_based/neuron/ilif.py
@@ -352,13 +352,12 @@ class ILIFNode(LIFNode):
         x = inputs[0]
         v = states[0]
 
-        charged = functional.lif_charge(x, v, self.tau, False, None)
-        spike = self.surrogate_function(charged / self.v_threshold)
-        v = functional.voltage_reset(
-            charged,
-            spike,
+        spike, v = functional.ilif_step(
+            x,
+            v,
+            self.tau,
             self.v_threshold,
-            None,
+            self.surrogate_function,
             self.detach_reset,
         )
         return (spike,), (v, *states[1:])

--- a/spikingjelly/activation_based/neuron/ilif.py
+++ b/spikingjelly/activation_based/neuron/ilif.py
@@ -334,23 +334,56 @@ class ILIFNode(LIFNode):
     def neuronal_fire(self) -> torch.Tensor:
         return self.surrogate_function(self.v / self.v_threshold)
 
-    def single_step_forward(self, x: torch.Tensor) -> torch.Tensor:
-        self.v_float_to_tensor(x)
-        self.neuronal_charge(x)
-        spike = self.neuronal_fire()
-        self.neuronal_reset(spike)
-        return spike
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        r"""Execute one I-LIF step with explicit state. / 使用显式状态执行一个 I-LIF 时间步。
 
-    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+        :param inputs: 仅包含 ``x`` 的元组 / Tuple containing only ``x``
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :type states: tuple
+        :return: ``((spike_count,), updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
+        """
+        x = inputs[0]
+        v = states[0]
+
+        charged = v * (1.0 - 1.0 / self.tau) + x
+        spike = self.surrogate_function(charged / self.v_threshold)
+        reset_spike = spike.detach() if self.detach_reset else spike
+        v = charged - reset_spike * self.v_threshold
+        return (spike,), (v, *states[1:])
+
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        r"""Execute I-LIF sequence forward with explicit state. / 使用显式状态执行 I-LIF 序列前向。
+
+        :param inputs: 仅包含 ``x_seq`` 的元组 / Tuple containing only ``x_seq``
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :type states: tuple
+        :return: ``((spike_count_seq,), updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
+        """
+        x_seq = inputs[0]
+        v = states[0]
+
         if self.backend == "triton":
             if triton_ilif_kernel is None:
                 raise ImportError(
                     "ILIFNode backend='triton' requires the optional Triton backend."
                 )
-            self.v_float_to_tensor(x_seq[0])
             spike_seq, v_out = triton_ilif_kernel._multistep_ilif(
                 x_seq,
-                self.v,
+                v,
                 1.0 - 1.0 / self.tau,
                 self.v_threshold,
                 self.surrogate_function.max_spike_count,
@@ -360,19 +393,26 @@ class ILIFNode(LIFNode):
                 self.store_v_seq,
             )
             if self.store_v_seq:
-                self.v_seq = v_out
-                self.v = v_out[-1].clone()
+                v_seq = v_out
+                v = v_out[-1].clone()
             else:
-                self.v = v_out
-            return spike_seq
+                v = v_out
+                v_seq = None
+        elif self.backend == "torch":
+            spikes = []
+            voltages = []
+            for t in range(x_seq.shape[0]):
+                x = x_seq[t]
+                (spike,), (v, *_) = self.single_step_functional_forward(
+                    (x,), (v, *states[1:])
+                )
+                spikes.append(spike)
+                if self.store_v_seq:
+                    voltages.append(v)
+            spike_seq = torch.stack(spikes)
+            v_seq = torch.stack(voltages) if self.store_v_seq else None
+        else:
+            raise ValueError(self.backend)
 
-        spike_seq = []
-        if self.store_v_seq:
-            v_seq = []
-        for x in x_seq:
-            spike_seq.append(self.single_step_forward(x))
-            if self.store_v_seq:
-                v_seq.append(self.v)
-        if self.store_v_seq:
-            self.v_seq = torch.stack(v_seq)
-        return torch.stack(spike_seq)
+        updated_states = (v, v_seq) if self.store_v_seq else (v,)
+        return (spike_seq,), updated_states

--- a/spikingjelly/activation_based/neuron/ilif.py
+++ b/spikingjelly/activation_based/neuron/ilif.py
@@ -2,7 +2,7 @@ from spikingjelly.logger import logger
 
 import torch
 
-from .. import surrogate
+from .. import functional, surrogate
 from .lif import LIFNode
 
 try:
@@ -344,7 +344,7 @@ class ILIFNode(LIFNode):
 
         :param inputs: 仅包含 ``x`` 的元组 / Tuple containing only ``x``
         :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :param states: ``(v,)``
         :type states: tuple
         :return: ``((spike_count,), updated_states)``
         :rtype: tuple[tuple[torch.Tensor, ...], tuple]
@@ -352,10 +352,15 @@ class ILIFNode(LIFNode):
         x = inputs[0]
         v = states[0]
 
-        charged = v * (1.0 - 1.0 / self.tau) + x
+        charged = functional.lif_charge(x, v, self.tau, False, None)
         spike = self.surrogate_function(charged / self.v_threshold)
-        reset_spike = spike.detach() if self.detach_reset else spike
-        v = charged - reset_spike * self.v_threshold
+        v = functional.voltage_reset(
+            charged,
+            spike,
+            self.v_threshold,
+            None,
+            self.detach_reset,
+        )
         return (spike,), (v, *states[1:])
 
     def multi_step_functional_forward(
@@ -368,7 +373,7 @@ class ILIFNode(LIFNode):
 
         :param inputs: 仅包含 ``x_seq`` 的元组 / Tuple containing only ``x_seq``
         :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :param states: ``(v,)``
         :type states: tuple
         :return: ``((spike_count_seq,), updated_states)``
         :rtype: tuple[tuple[torch.Tensor, ...], tuple]
@@ -390,29 +395,38 @@ class ILIFNode(LIFNode):
                 self.surrogate_function.grad_min,
                 self.surrogate_function.grad_max,
                 self.detach_reset,
-                self.store_v_seq,
+                False,
             )
-            if self.store_v_seq:
-                v_seq = v_out
-                v = v_out[-1].clone()
-            else:
-                v = v_out
-                v_seq = None
+            v = v_out
         elif self.backend == "torch":
-            spikes = []
-            voltages = []
-            for t in range(x_seq.shape[0]):
-                x = x_seq[t]
-                (spike,), (v, *_) = self.single_step_functional_forward(
-                    (x,), (v, *states[1:])
-                )
-                spikes.append(spike)
-                if self.store_v_seq:
-                    voltages.append(v)
-            spike_seq = torch.stack(spikes)
-            v_seq = torch.stack(voltages) if self.store_v_seq else None
+            return super().multi_step_functional_forward(inputs, states, **kwargs)
         else:
             raise ValueError(self.backend)
 
-        updated_states = (v, v_seq) if self.store_v_seq else (v,)
-        return (spike_seq,), updated_states
+        return (spike_seq,), (v,)
+
+    def multi_step_forward(self, x_seq: torch.Tensor, *args, **kwargs):
+        if not self.store_v_seq or self.backend == "torch":
+            return super().multi_step_forward(x_seq, *args, **kwargs)
+
+        states = self.materialize_states(
+            (x_seq, *args), tuple(self._memories.values()), "m"
+        )
+        if triton_ilif_kernel is None:
+            raise ImportError(
+                "ILIFNode backend='triton' requires the optional Triton backend."
+            )
+        spike_seq, v_seq = triton_ilif_kernel._multistep_ilif(
+            x_seq,
+            states[0],
+            1.0 - 1.0 / self.tau,
+            self.v_threshold,
+            self.surrogate_function.max_spike_count,
+            self.surrogate_function.grad_min,
+            self.surrogate_function.grad_max,
+            self.detach_reset,
+            True,
+        )
+        self.v = v_seq[-1].clone()
+        self.v_seq = v_seq
+        return spike_seq

--- a/spikingjelly/activation_based/neuron/ilif.py
+++ b/spikingjelly/activation_based/neuron/ilif.py
@@ -331,24 +331,12 @@ class ILIFNode(LIFNode):
     def supported_backends(self) -> tuple[str, ...]:
         return ("torch",) if self.step_mode == "s" else ("torch", "triton")
 
-    def neuronal_fire(self) -> torch.Tensor:
-        return self.surrogate_function(self.v / self.v_threshold)
-
     def single_step_functional_forward(
         self,
         inputs: tuple[torch.Tensor, ...],
         states: tuple[object, ...],
         **kwargs: object,
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
-        r"""Execute one I-LIF step with explicit state. / 使用显式状态执行一个 I-LIF 时间步。
-
-        :param inputs: 仅包含 ``x`` 的元组 / Tuple containing only ``x``
-        :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)``
-        :type states: tuple
-        :return: ``((spike_count,), updated_states)``
-        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
-        """
         x = inputs[0]
         v = states[0]
 
@@ -368,15 +356,6 @@ class ILIFNode(LIFNode):
         states: tuple[object, ...],
         **kwargs: object,
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
-        r"""Execute I-LIF sequence forward with explicit state. / 使用显式状态执行 I-LIF 序列前向。
-
-        :param inputs: 仅包含 ``x_seq`` 的元组 / Tuple containing only ``x_seq``
-        :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)``
-        :type states: tuple
-        :return: ``((spike_count_seq,), updated_states)``
-        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
-        """
         x_seq = inputs[0]
         v = states[0]
 

--- a/spikingjelly/activation_based/neuron/integrate_and_fire.py
+++ b/spikingjelly/activation_based/neuron/integrate_and_fire.py
@@ -8,13 +8,11 @@ from .. import base, functional, surrogate
 from .base_node import BaseNode, NonSpikingBaseNode, SimpleBaseNode
 
 try:
-    from .. import triton_kernel
     from ..triton_kernel.neuron_kernel import (
         activation_aware_if as activation_aware_if_triton_kernel,
     )
 except (ImportError, OSError) as e:
     logger.debug("spikingjelly.activation_based.neuron: %s", e)
-    triton_kernel = None
     activation_aware_if_triton_kernel = None
 
 
@@ -45,8 +43,7 @@ class SimpleIFNode(SimpleBaseNode):
 
         * **中文**
 
-        基于 :class:`SimpleBaseNode` 充电-放电-重置接口的纯 PyTorch IF 实现，
-        用于理解和修改神经元动力学。
+        基于 :class:`SimpleBaseNode` 充电-放电-重置接口的纯 PyTorch IF 实现。
 
         :param v_threshold: 神经元阈值电压
         :type v_threshold: float
@@ -66,7 +63,7 @@ class SimpleIFNode(SimpleBaseNode):
         * **English**
 
         A pure-PyTorch IF implementation built on the charge-fire-reset interface
-        of :class:`SimpleBaseNode` for understanding and modifying neuron dynamics.
+        of :class:`SimpleBaseNode`.
 
         :param v_threshold: Threshold voltage of the neuron
         :type v_threshold: float
@@ -233,49 +230,6 @@ class IFNode(BaseNode):
     def neuronal_charge(self, x: torch.Tensor):
         self.v = self.v + x
 
-    @staticmethod
-    def _eval_single_step_forward(
-        x: torch.Tensor, v: torch.Tensor, v_threshold: float, v_reset
-    ):
-        """Unified single-step eval (replaces jit_eval_single_step_forward_*)."""
-        v = v + x
-        spike = (v >= v_threshold).to(x)
-        v = (
-            (v - spike * v_threshold)
-            if v_reset is None
-            else (v_reset * spike + (1.0 - spike) * v)
-        )
-        return spike, v
-
-    @staticmethod
-    def _eval_multi_step_forward(
-        x_seq: torch.Tensor,
-        v: torch.Tensor,
-        v_threshold: float,
-        v_reset,
-        store_v_seq: bool = False,
-    ):
-        """Unified multi-step eval (replaces jit_eval_multi_step_forward_*)."""
-        T = x_seq.shape[0]
-        spike_seq = torch.zeros_like(x_seq)
-        v_seq = torch.zeros_like(x_seq) if store_v_seq else None
-        soft_reset = v_reset is None
-        _vr = 0.0 if soft_reset else v_reset
-        for t in range(T):
-            v = v + x_seq[t]
-            spike = (v >= v_threshold).to(x_seq)
-            v = (
-                (v - spike * v_threshold)
-                if soft_reset
-                else (_vr * spike + (1.0 - spike) * v)
-            )
-            spike_seq[t] = spike
-            if store_v_seq:
-                v_seq[t] = v
-        if store_v_seq:
-            return spike_seq, v, v_seq
-        return spike_seq, v
-
     # kept for subclass backward-compatibility
     @staticmethod
     def jit_eval_single_step_forward_hard_reset(
@@ -305,7 +259,7 @@ class IFNode(BaseNode):
 
         :param inputs: 仅包含 ``x`` 的元组 / Tuple containing only ``x``
         :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :param states: ``(v,)``
         :type states: tuple
         :return: ``((spike,), updated_states)``
         :rtype: tuple[tuple[torch.Tensor, ...], tuple]
@@ -313,31 +267,32 @@ class IFNode(BaseNode):
         x = inputs[0]
         v = states[0]
 
-        if self.training:
-            if self.backend == "torch":
-                spike, v = functional.if_step(
-                    x,
-                    v,
-                    self.v_threshold,
-                    self.v_reset,
-                    self.surrogate_function,
-                    self.detach_reset,
-                )
-            elif self.backend == "cupy":
-                spike, v = functional.if_step_cupy(
-                    x,
-                    v,
-                    self.v_threshold,
-                    self.v_reset,
-                    self.surrogate_function,
-                    self.detach_reset,
-                )
-            else:
-                raise ValueError(self.backend)
-        else:
-            spike, v = self._eval_single_step_forward(
-                x, v, self.v_threshold, self.v_reset
+        if self.backend == "torch":
+            surrogate_function = (
+                self.surrogate_function
+                if self.training
+                or not getattr(self.surrogate_function, "spiking", True)
+                else surrogate.heaviside
             )
+            spike, v = functional.if_step(
+                x,
+                v,
+                self.v_threshold,
+                self.v_reset,
+                surrogate_function,
+                self.detach_reset,
+            )
+        elif self.backend == "cupy":
+            spike, v = functional.if_step_cupy(
+                x,
+                v,
+                self.v_threshold,
+                self.v_reset,
+                self.surrogate_function,
+                self.detach_reset,
+            )
+        else:
+            raise ValueError(self.backend)
         return (spike,), (v, *states[1:])
 
     def multi_step_functional_forward(
@@ -350,7 +305,7 @@ class IFNode(BaseNode):
 
         :param inputs: 仅包含 ``x_seq`` 的元组 / Tuple containing only ``x_seq``
         :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :param states: ``(v,)``
         :type states: tuple
         :return: ``((spike_seq,), updated_states)``
         :rtype: tuple[tuple[torch.Tensor, ...], tuple]
@@ -358,26 +313,25 @@ class IFNode(BaseNode):
         x_seq = inputs[0]
         v = states[0]
 
-        v_seq = None
         if self.backend == "inductor":
-            spike_seq, v, v_seq = functional.if_multi_step_inductor(
+            spike_seq, v, _ = functional.if_multi_step_inductor(
                 x_seq,
                 v,
                 self.v_threshold,
                 self.v_reset,
                 self.surrogate_function,
                 self.detach_reset,
-                self.store_v_seq,
+                False,
             )
         elif self.backend == "cupy":
-            spike_seq, v, v_seq = functional.if_multi_step_cupy(
+            spike_seq, v, _ = functional.if_multi_step_cupy(
                 x_seq,
                 v,
                 self.v_threshold,
                 self.v_reset,
                 self.surrogate_function,
                 self.detach_reset,
-                self.store_v_seq,
+                False,
             )
         elif self.backend == "triton":
             if not self.training and not getattr(
@@ -387,56 +341,72 @@ class IFNode(BaseNode):
                     "Triton backend only supports spiking surrogate functions. "
                     "Use backend='torch' for non-spiking surrogate functions."
                 )
-            spike_seq, v_out = triton_kernel.multistep_if(
+            spike_seq, v, _ = functional.if_multi_step_triton(
                 x_seq,
                 v,
                 self.v_threshold,
                 self.v_reset,
-                self.detach_reset,
                 self.surrogate_function,
-                self.store_v_seq,
+                self.detach_reset,
+                False,
             )
-            if self.store_v_seq:
-                v_seq = v_out
-                v = v_out[-1].clone() if self.training else v_out[-1]
-            else:
-                v = v_out
-        elif self.backend == "torch" and not self.training:
-            out = self._eval_multi_step_forward(
-                x_seq,
-                v,
-                self.v_threshold,
-                self.v_reset,
-                store_v_seq=self.store_v_seq,
-            )
-            if self.store_v_seq:
-                spike_seq, v, v_seq = out
-            else:
-                spike_seq, v = out
         elif self.backend == "torch":
-            spike_seq = []
-            voltages = []
-            for t in range(x_seq.shape[0]):
-                x = x_seq[t]
-                spike, v = functional.if_step(
-                    x,
-                    v,
-                    self.v_threshold,
-                    self.v_reset,
-                    self.surrogate_function,
-                    self.detach_reset,
-                )
-                spike_seq.append(spike)
-                if self.store_v_seq:
-                    voltages.append(v)
-            spike_seq = torch.stack(spike_seq)
-            if self.store_v_seq:
-                v_seq = torch.stack(voltages)
+            return super().multi_step_functional_forward(inputs, states, **kwargs)
         else:
             raise ValueError(self.backend)
 
-        updated_states = (v, v_seq) if self.store_v_seq else (v,)
-        return (spike_seq,), updated_states
+        return (spike_seq,), (v,)
+
+    def multi_step_forward(self, x_seq: torch.Tensor, *args, **kwargs):
+        if not self.store_v_seq or self.backend == "torch":
+            return super().multi_step_forward(x_seq, *args, **kwargs)
+
+        states = self.materialize_states(
+            (x_seq, *args), tuple(self._memories.values()), "m"
+        )
+        v = states[0]
+        if self.backend == "inductor":
+            spike_seq, v, v_seq = functional.if_multi_step_inductor(
+                x_seq,
+                v,
+                self.v_threshold,
+                self.v_reset,
+                self.surrogate_function,
+                self.detach_reset,
+                True,
+            )
+        elif self.backend == "cupy":
+            spike_seq, v, v_seq = functional.if_multi_step_cupy(
+                x_seq,
+                v,
+                self.v_threshold,
+                self.v_reset,
+                self.surrogate_function,
+                self.detach_reset,
+                True,
+            )
+        elif self.backend == "triton":
+            if not self.training and not getattr(
+                self.surrogate_function, "spiking", True
+            ):
+                raise NotImplementedError(
+                    "Triton backend only supports spiking surrogate functions. "
+                    "Use backend='torch' for non-spiking surrogate functions."
+                )
+            spike_seq, v, v_seq = functional.if_multi_step_triton(
+                x_seq,
+                v,
+                self.v_threshold,
+                self.v_reset,
+                self.surrogate_function,
+                self.detach_reset,
+                True,
+            )
+        else:
+            raise ValueError(self.backend)
+        self.v = v
+        self.v_seq = v_seq
+        return spike_seq
 
 
 class HalfThresholdIFNode(BaseNode):
@@ -573,9 +543,7 @@ class HalfThresholdIFNode(BaseNode):
         states: tuple[object, ...],
         step_mode: str,
     ) -> tuple[object, ...]:
-        x = inputs[0]
-        if step_mode == "m" and x.dim() > 0 and x.shape[0] > 0:
-            x = x[0]
+        x = inputs[0][0] if step_mode == "m" else inputs[0]
         v = states[0]
         if isinstance(v, float):
             v = torch.full_like(x, v, requires_grad=False)
@@ -920,8 +888,6 @@ class ActivationAwareIFNode(base.MemoryModule):
 
         :param value: 是否保存完整膜电位序列。
         :type value: bool
-        :raises ValueError: 当 ``value`` 不是布尔值时抛出。
-
         ----
 
         .. _ActivationAwareIFNode.store_v_seq-setter-en:
@@ -934,15 +900,13 @@ class ActivationAwareIFNode(base.MemoryModule):
 
         :param value: Whether to store the full membrane-voltage sequence.
         :type value: bool
-        :raises ValueError: If ``value`` is not a boolean.
         """
-        if not isinstance(value, bool):
-            raise ValueError("store_v_seq must be bool.")
         self._store_v_seq = value
-        if value and not hasattr(self, "v_seq"):
-            self.register_memory("v_seq", None)
-        elif not value and hasattr(self, "v_seq"):
-            self.v_seq = None
+        self.v_seq = None
+
+    def reset(self):
+        super().reset()
+        self.v_seq = None
 
     def _canonical_channel_dim(self, x: torch.Tensor) -> int:
         channel_dim = self.channel_dim
@@ -979,9 +943,7 @@ class ActivationAwareIFNode(base.MemoryModule):
         states: tuple[object, ...],
         step_mode: str,
     ) -> tuple[object, ...]:
-        x = inputs[0]
-        if step_mode == "m" and x.dim() > 0 and x.shape[0] > 0:
-            x = x[0]
+        x = inputs[0][0] if step_mode == "m" else inputs[0]
         v = states[0]
         if isinstance(v, float):
             v = torch.full_like(x, v, requires_grad=False)
@@ -1013,7 +975,7 @@ class ActivationAwareIFNode(base.MemoryModule):
 
         :param inputs: 仅包含单步输入 ``x`` 的元组，``x`` 形状为 ``[N, *]``。
         :type inputs: tuple[torch.Tensor, ...]
-        :param states: 显式状态 ``(v,)`` 或 ``(v, v_seq)``。
+        :param states: 显式状态 ``(v,)``。
         :type states: tuple
         :return: ``((spike,), updated_states)``。
         :rtype: tuple[tuple[torch.Tensor, ...], tuple]
@@ -1031,7 +993,7 @@ class ActivationAwareIFNode(base.MemoryModule):
 
         :param inputs: Tuple containing only the single-step input ``x`` with shape ``[N, *]``.
         :type inputs: tuple[torch.Tensor, ...]
-        :param states: Explicit states ``(v,)`` or ``(v, v_seq)``.
+        :param states: Explicit state ``(v,)``.
         :type states: tuple
         :return: ``((spike,), updated_states)``.
         :rtype: tuple[tuple[torch.Tensor, ...], tuple]
@@ -1059,7 +1021,7 @@ class ActivationAwareIFNode(base.MemoryModule):
         return (spike,), (v, *states[1:])
 
     def _triton_multi_step_functional_forward(
-        self, x_seq: torch.Tensor, v
+        self, x_seq: torch.Tensor, v, store_v_seq: bool
     ) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
         if activation_aware_if_triton_kernel is None:
             raise RuntimeError(
@@ -1128,7 +1090,7 @@ class ActivationAwareIFNode(base.MemoryModule):
             channel_size,
             inner_size,
             self.v_reset,
-            self.store_v_seq,
+            store_v_seq,
         )
         return spike_seq, v, v_seq
 
@@ -1148,12 +1110,11 @@ class ActivationAwareIFNode(base.MemoryModule):
         * **中文**
 
         使用显式状态执行 activation-aware IF 多步前向。Torch 后端
-        默认逐步调用单步 functional 实现；``store_v_seq=True`` 时
-        同时返回完整膜电位序列。Triton 后端使用专用多步 kernel。
+        逐步调用单步 functional 实现，Triton 后端使用专用多步 kernel。
 
         :param inputs: 仅包含 ``x_seq`` 的元组，``x_seq`` 形状为 ``[T, N, *]``。
         :type inputs: tuple[torch.Tensor, ...]
-        :param states: 显式状态 ``(v,)`` 或 ``(v, v_seq)``。
+        :param states: 显式状态 ``(v,)``。
         :type states: tuple
         :return: ``((spike_seq,), updated_states)``。
         :rtype: tuple[tuple[torch.Tensor, ...], tuple]
@@ -1168,14 +1129,12 @@ class ActivationAwareIFNode(base.MemoryModule):
         * **English**
 
         Run the multi-step activation-aware IF forward pass with explicit state.
-        The Torch backend uses the single-step functional implementation by
-        default and also returns the full voltage sequence when
-        ``store_v_seq=True``. The Triton backend uses its specialized sequence
-        kernel.
+        The Torch backend uses the single-step functional implementation. The
+        Triton backend uses its specialized sequence kernel.
 
         :param inputs: Tuple containing only ``x_seq`` with shape ``[T, N, *]``.
         :type inputs: tuple[torch.Tensor, ...]
-        :param states: Explicit states ``(v,)`` or ``(v, v_seq)``.
+        :param states: Explicit state ``(v,)``.
         :type states: tuple
         :return: ``((spike_seq,), updated_states)``.
         :rtype: tuple[tuple[torch.Tensor, ...], tuple]
@@ -1185,30 +1144,43 @@ class ActivationAwareIFNode(base.MemoryModule):
             training or autograd, with a non-spiking surrogate, or with an
             input other than FP32/BF16.
         """
-        x_seq = inputs[0]
-        if x_seq.dim() < 2 or x_seq.shape[0] == 0 or x_seq[0].numel() == 0:
-            raise ValueError(
-                "ActivationAwareIFNode multi-step input must have a non-empty "
-                "shape [T, N, *] with T greater than zero."
+        if self.backend == "triton":
+            spike_seq, v, _ = self._triton_multi_step_functional_forward(
+                inputs[0], states[0], False
             )
+            return (spike_seq,), (v,)
+        if self.backend == "torch":
+            return super().multi_step_functional_forward(inputs, states, **kwargs)
+        raise ValueError(self.backend)
+
+    def multi_step_forward(self, x_seq: torch.Tensor, *args, **kwargs):
+        if not self.store_v_seq:
+            return super().multi_step_forward(x_seq, *args, **kwargs)
+
+        states = self.materialize_states(
+            (x_seq, *args), tuple(self._memories.values()), "m"
+        )
         if self.backend == "triton":
             spike_seq, v, v_seq = self._triton_multi_step_functional_forward(
-                x_seq, states[0]
+                x_seq, states[0], True
             )
-            updated_states = (v, v_seq) if self.store_v_seq else (v, *states[1:])
-            return (spike_seq,), updated_states
-        if not self.store_v_seq:
-            return super().multi_step_functional_forward(inputs, states, **kwargs)
-
-        spike_seq = []
-        v_seq = []
-        for t in range(x_seq.shape[0]):
-            outputs, states = self.single_step_functional_forward(
-                (x_seq[t],), states, **kwargs
-            )
-            spike_seq.append(outputs[0])
-            v_seq.append(states[0])
-        return (torch.stack(spike_seq),), (states[0], torch.stack(v_seq))
+        elif self.backend == "torch":
+            spike_steps = []
+            voltage_steps = []
+            for t in range(x_seq.shape[0]):
+                outputs, states = self.single_step_functional_forward(
+                    (x_seq[t],), states, **kwargs
+                )
+                spike_steps.append(outputs[0])
+                voltage_steps.append(states[0])
+            spike_seq = torch.stack(spike_steps)
+            v = states[0]
+            v_seq = torch.stack(voltage_steps)
+        else:
+            raise ValueError(self.backend)
+        self.v = v
+        self.v_seq = v_seq
+        return spike_seq
 
     def extra_repr(self):
         return (

--- a/spikingjelly/activation_based/neuron/integrate_and_fire.py
+++ b/spikingjelly/activation_based/neuron/integrate_and_fire.py
@@ -293,140 +293,148 @@ class IFNode(BaseNode):
         v = v - spike * v_threshold
         return spike, v
 
-    def _inductor_multi_step_forward(self, x_seq: torch.Tensor):
-        self.v_float_to_tensor(x_seq[0])
-        spike_seq, self.v, v_seq = functional.if_multi_step_inductor(
-            x_seq,
-            self.v,
-            self.v_threshold,
-            self.v_reset,
-            self.surrogate_function,
-            self.detach_reset,
-            self.store_v_seq,
-        )
-        if self.store_v_seq:
-            self.v_seq = v_seq
-        return spike_seq
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        r"""Execute one IF step with explicit state. / 使用显式状态执行一个 IF 时间步。
 
-    def multi_step_forward(self, x_seq: torch.Tensor):
-        if self.backend == "inductor":
-            return self._inductor_multi_step_forward(x_seq)
+        :param inputs: 仅包含 ``x`` 的元组 / Tuple containing only ``x``
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :type states: tuple
+        :return: ``((spike,), updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
+        """
+        x = inputs[0]
+        v = states[0]
+
         if self.training:
             if self.backend == "torch":
-                return super().multi_step_forward(x_seq)
+                spike, v = functional.if_step(
+                    x,
+                    v,
+                    self.v_threshold,
+                    self.v_reset,
+                    self.surrogate_function,
+                    self.detach_reset,
+                )
             elif self.backend == "cupy":
-                self.v_float_to_tensor(x_seq[0])
-                spike_seq, self.v, v_seq = functional.if_multi_step_cupy(
-                    x_seq,
-                    self.v,
+                spike, v = functional.if_step_cupy(
+                    x,
+                    v,
                     self.v_threshold,
                     self.v_reset,
                     self.surrogate_function,
                     self.detach_reset,
-                    self.store_v_seq,
                 )
-                if self.store_v_seq:
-                    self.v_seq = v_seq
-                return spike_seq
-            elif self.backend == "triton":
-                self.v_float_to_tensor(x_seq[0])
-                spike_seq, v_out = triton_kernel.multistep_if(
-                    x_seq,
-                    self.v,
-                    self.v_threshold,
-                    self.v_reset,
-                    self.detach_reset,
-                    self.surrogate_function,
-                    self.store_v_seq,
-                )
-                if self.store_v_seq:
-                    self.v_seq = v_out
-                    self.v = v_out[-1].clone()
-                else:
-                    self.v = v_out
-                return spike_seq
             else:
                 raise ValueError(self.backend)
-
         else:
-            self.v_float_to_tensor(x_seq[0])
+            spike, v = self._eval_single_step_forward(
+                x, v, self.v_threshold, self.v_reset
+            )
+        return (spike,), (v, *states[1:])
 
-            if self.backend == "triton":
-                if not getattr(self.surrogate_function, "spiking", True):
-                    raise NotImplementedError(
-                        "Triton backend only supports spiking surrogate functions. "
-                        "Use backend='torch' for non-spiking surrogate functions."
-                    )
-                spike_seq, v_out = triton_kernel.multistep_if(
-                    x_seq,
-                    self.v,
-                    self.v_threshold,
-                    self.v_reset,
-                    self.detach_reset,
-                    self.surrogate_function,
-                    self.store_v_seq,
-                )
-                if self.store_v_seq:
-                    self.v_seq = v_out
-                    self.v = v_out[-1]
-                else:
-                    self.v = v_out
-                return spike_seq
-            elif self.backend == "cupy":
-                spike_seq, self.v, v_seq = functional.if_multi_step_cupy(
-                    x_seq,
-                    self.v,
-                    self.v_threshold,
-                    self.v_reset,
-                    self.surrogate_function,
-                    self.detach_reset,
-                    self.store_v_seq,
-                )
-                if self.store_v_seq:
-                    self.v_seq = v_seq
-                return spike_seq
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        r"""Execute IF sequence forward with explicit state. / 使用显式状态执行 IF 序列前向。
 
-            # torch backend:
+        :param inputs: 仅包含 ``x_seq`` 的元组 / Tuple containing only ``x_seq``
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :type states: tuple
+        :return: ``((spike_seq,), updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
+        """
+        x_seq = inputs[0]
+        v = states[0]
+
+        v_seq = None
+        if self.backend == "inductor":
+            spike_seq, v, v_seq = functional.if_multi_step_inductor(
+                x_seq,
+                v,
+                self.v_threshold,
+                self.v_reset,
+                self.surrogate_function,
+                self.detach_reset,
+                self.store_v_seq,
+            )
+        elif self.backend == "cupy":
+            spike_seq, v, v_seq = functional.if_multi_step_cupy(
+                x_seq,
+                v,
+                self.v_threshold,
+                self.v_reset,
+                self.surrogate_function,
+                self.detach_reset,
+                self.store_v_seq,
+            )
+        elif self.backend == "triton":
+            if not self.training and not getattr(
+                self.surrogate_function, "spiking", True
+            ):
+                raise NotImplementedError(
+                    "Triton backend only supports spiking surrogate functions. "
+                    "Use backend='torch' for non-spiking surrogate functions."
+                )
+            spike_seq, v_out = triton_kernel.multistep_if(
+                x_seq,
+                v,
+                self.v_threshold,
+                self.v_reset,
+                self.detach_reset,
+                self.surrogate_function,
+                self.store_v_seq,
+            )
+            if self.store_v_seq:
+                v_seq = v_out
+                v = v_out[-1].clone() if self.training else v_out[-1]
+            else:
+                v = v_out
+        elif self.backend == "torch" and not self.training:
             out = self._eval_multi_step_forward(
                 x_seq,
-                self.v,
+                v,
                 self.v_threshold,
                 self.v_reset,
                 store_v_seq=self.store_v_seq,
             )
             if self.store_v_seq:
-                spike_seq, self.v, self.v_seq = out
+                spike_seq, v, v_seq = out
             else:
-                spike_seq, self.v = out
-            return spike_seq
-
-    def single_step_forward(self, x: torch.Tensor):
-        if self.training:
-            if self.backend == "torch":
-                return super().single_step_forward(x)
-            elif self.backend == "cupy":
-                self.v_float_to_tensor(x)
-                spike, self.v = functional.if_step_cupy(
+                spike_seq, v = out
+        elif self.backend == "torch":
+            spike_seq = []
+            voltages = []
+            for t in range(x_seq.shape[0]):
+                x = x_seq[t]
+                spike, v = functional.if_step(
                     x,
-                    self.v,
+                    v,
                     self.v_threshold,
                     self.v_reset,
                     self.surrogate_function,
                     self.detach_reset,
                 )
-                return spike
-            else:
-                raise ValueError(self.backend)
-
+                spike_seq.append(spike)
+                if self.store_v_seq:
+                    voltages.append(v)
+            spike_seq = torch.stack(spike_seq)
+            if self.store_v_seq:
+                v_seq = torch.stack(voltages)
         else:
-            self.v_float_to_tensor(x)
-            spike, self.v = self._eval_single_step_forward(
-                x,
-                self.v,
-                self.v_threshold,
-                self.v_reset,
-            )
-            return spike
+            raise ValueError(self.backend)
+
+        updated_states = (v, v_seq) if self.store_v_seq else (v,)
+        return (spike_seq,), updated_states
 
 
 class HalfThresholdIFNode(BaseNode):
@@ -557,18 +565,45 @@ class HalfThresholdIFNode(BaseNode):
     def supported_backends(self):
         return ("torch",)
 
-    def v_float_to_tensor(self, x: torch.Tensor):
-        half_threshold = self.v_threshold / 2.0
-        if isinstance(self.v, float):
-            self.v = torch.full_like(x, self.v, requires_grad=False)
-        elif isinstance(self.v, torch.Tensor):
-            if self.v.shape != x.shape:
-                self.v = torch.full_like(x, half_threshold, requires_grad=False)
-            elif self.v.dtype != x.dtype or self.v.device != x.device:
-                self.v = self.v.to(dtype=x.dtype, device=x.device)
+    def materialize_states(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        step_mode: str,
+    ) -> tuple[object, ...]:
+        x = inputs[0]
+        if step_mode == "m" and x.dim() > 0 and x.shape[0] > 0:
+            x = x[0]
+        v = states[0]
+        if isinstance(v, float):
+            v = torch.full_like(x, v, requires_grad=False)
+        elif isinstance(v, torch.Tensor):
+            if v.shape != x.shape:
+                v = torch.full_like(x, self.v_threshold / 2.0, requires_grad=False)
+            elif v.dtype != x.dtype or v.device != x.device:
+                v = v.to(dtype=x.dtype, device=x.device)
+        return (v, *states[1:])
 
     def neuronal_charge(self, x: torch.Tensor):
         self.v = self.v + x
+
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        v = states[0]
+        spike, v = functional.if_step(
+            x,
+            v,
+            self.v_threshold,
+            None,
+            self.surrogate_function,
+            self.detach_reset,
+        )
+        return (spike,), (v, *states[1:])
 
 
 class ActivationAwareIFNode(base.MemoryModule):
@@ -766,11 +801,11 @@ class ActivationAwareIFNode(base.MemoryModule):
         self.v_reset = v_reset
         self.detach_reset = detach_reset
         self.surrogate_function = surrogate_function
-        self.store_v_seq = store_v_seq
         if v_reset is None:
             self.register_memory("v", 0.0)
         else:
             self.register_memory("v", v_reset)
+        self.store_v_seq = store_v_seq
         self.step_mode = step_mode
         self.backend = backend
 
@@ -936,50 +971,68 @@ class ActivationAwareIFNode(base.MemoryModule):
         shape[channel_dim] = param.numel()
         return param.view(shape)
 
-    def v_float_to_tensor(self, x: torch.Tensor) -> None:
-        if isinstance(self.v, float):
-            self.v = torch.full_like(x, self.v, requires_grad=False)
-        elif isinstance(self.v, torch.Tensor):
-            if self.v.shape != x.shape:
+    def materialize_states(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        step_mode: str,
+    ) -> tuple[object, ...]:
+        x = inputs[0]
+        if step_mode == "m" and x.dim() > 0 and x.shape[0] > 0:
+            x = x[0]
+        v = states[0]
+        if isinstance(v, float):
+            v = torch.full_like(x, v, requires_grad=False)
+        elif isinstance(v, torch.Tensor):
+            if v.shape != x.shape:
                 fill_value = self.v_reset if self.v_reset is not None else 0.0
-                self.v = torch.full_like(x, fill_value, requires_grad=False)
-            elif self.v.dtype != x.dtype or self.v.device != x.device:
-                self.v = self.v.to(dtype=x.dtype, device=x.device)
+                v = torch.full_like(x, fill_value, requires_grad=False)
+            elif v.dtype != x.dtype or v.device != x.device:
+                v = v.to(dtype=x.dtype, device=x.device)
+        return (v, *states[1:])
 
-    def single_step_forward(self, x: torch.Tensor) -> torch.Tensor:
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         r"""
-        **API Language** - :ref:`中文 <ActivationAwareIFNode.single_step_forward-cn>` | :ref:`English <ActivationAwareIFNode.single_step_forward-en>`
+        **API Language** - :ref:`中文 <ActivationAwareIFNode.single_step_functional_forward-cn>` | :ref:`English <ActivationAwareIFNode.single_step_functional_forward-en>`
 
         ----
 
-        .. _ActivationAwareIFNode.single_step_forward-cn:
+        .. _ActivationAwareIFNode.single_step_functional_forward-cn:
 
         * **中文**
 
-        执行一个时间步的 activation-aware IF 前向，并将末步膜电位写回
-        ``self.v``。单步前向仅支持 ``backend="torch"``，不会从 Triton
-        隐式回退。
+        使用显式膜电位执行一个 activation-aware IF 时间步。
+        本方法不修改模块状态，且仅支持 ``backend="torch"``。
 
-        :param x: 单步输入，形状为 ``[N, *]``。
-        :type x: torch.Tensor
-        :return: 与 ``x`` 形状和 dtype 相同的脉冲张量。
-        :rtype: torch.Tensor
+        :param inputs: 仅包含单步输入 ``x`` 的元组，``x`` 形状为 ``[N, *]``。
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: 显式状态 ``(v,)`` 或 ``(v, v_seq)``。
+        :type states: tuple
+        :return: ``((spike,), updated_states)``。
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
         :raises RuntimeError: 当当前 backend 不是 ``"torch"`` 时抛出。
 
         ----
 
-        .. _ActivationAwareIFNode.single_step_forward-en:
+        .. _ActivationAwareIFNode.single_step_functional_forward-en:
 
         * **English**
 
-        Run one activation-aware IF time step and store the final membrane
-        voltage in ``self.v``. Single-step forward supports only
-        ``backend="torch"`` and never falls back implicitly from Triton.
+        Run one activation-aware IF time step with explicit membrane voltage.
+        This method does not mutate module state and supports only
+        ``backend="torch"``.
 
-        :param x: Single-step input with shape ``[N, *]``.
-        :type x: torch.Tensor
-        :return: Spike tensor with the same shape and dtype as ``x``.
-        :rtype: torch.Tensor
+        :param inputs: Tuple containing only the single-step input ``x`` with shape ``[N, *]``.
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: Explicit states ``(v,)`` or ``(v, v_seq)``.
+        :type states: tuple
+        :return: ``((spike,), updated_states)``.
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
         :raises RuntimeError: If the current backend is not ``"torch"``.
         """
         if self.backend != "torch":
@@ -987,21 +1040,25 @@ class ActivationAwareIFNode(base.MemoryModule):
                 "ActivationAwareIFNode single-step forward supports only "
                 "backend='torch'; refusing implicit backend fallback."
             )
-        self.v_float_to_tensor(x)
+        x = inputs[0]
+        v = states[0]
+
         threshold = self._broadcast_parameter(self.v_threshold, x, "v_threshold")
         offset = self._broadcast_parameter(self.v_offset, x, "v_offset")
-        spike, self.v = functional.activation_aware_if_step(
+        spike, v = functional.activation_aware_if_step(
             x,
-            self.v,
+            v,
             threshold,
             offset,
             self.v_reset,
             self.surrogate_function,
             self.detach_reset,
         )
-        return spike
+        return (spike,), (v, *states[1:])
 
-    def _triton_multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+    def _triton_multi_step_functional_forward(
+        self, x_seq: torch.Tensor, v
+    ) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
         if activation_aware_if_triton_kernel is None:
             raise RuntimeError(
                 "ActivationAwareIFNode Triton kernel is unavailable because its "
@@ -1027,8 +1084,7 @@ class ActivationAwareIFNode(base.MemoryModule):
                 "surrogate function."
             )
 
-        self.v_float_to_tensor(x_seq[0])
-        grad_tensors = (x_seq, self.v, self.v_threshold, self.v_offset)
+        grad_tensors = (x_seq, v, self.v_threshold, self.v_offset)
         if torch.is_grad_enabled() and any(
             value.requires_grad
             for value in grad_tensors
@@ -1062,9 +1118,9 @@ class ActivationAwareIFNode(base.MemoryModule):
             channel_size = 1
             inner_size = x_seq[0].numel()
 
-        spike_seq, self.v, v_seq = functional.activation_aware_if_multi_step_triton(
+        spike_seq, v, v_seq = functional.activation_aware_if_multi_step_triton(
             x_seq,
-            self.v,
+            v,
             threshold,
             offset,
             channel_size,
@@ -1072,75 +1128,85 @@ class ActivationAwareIFNode(base.MemoryModule):
             self.v_reset,
             self.store_v_seq,
         )
-        if self.store_v_seq:
-            self.v_seq = v_seq
-        return spike_seq
+        return spike_seq, v, v_seq
 
-    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         r"""
-        **API Language** - :ref:`中文 <ActivationAwareIFNode.multi_step_forward-cn>` | :ref:`English <ActivationAwareIFNode.multi_step_forward-en>`
+        **API Language** - :ref:`中文 <ActivationAwareIFNode.multi_step_functional_forward-cn>` | :ref:`English <ActivationAwareIFNode.multi_step_functional_forward-en>`
 
         ----
 
-        .. _ActivationAwareIFNode.multi_step_forward-cn:
+        .. _ActivationAwareIFNode.multi_step_functional_forward-cn:
 
         * **中文**
 
-        执行 activation-aware IF 神经元的多步前向。输入和输出形状均为
-        ``[T, N, *]``。每次调用从当前 ``self.v`` 开始并将末步膜电位写回
-        ``self.v``；当 ``store_v_seq=True`` 时还会把完整膜电位序列保存到
-        ``self.v_seq``。Triton 后端仅支持 ``eval`` 模式下的 FP32/BF16 CUDA
-        推理，不提供反向传播或隐式 Torch 回退。
+        使用显式状态执行 activation-aware IF 多步前向。Torch 后端
+        默认逐步调用单步 functional 实现；``store_v_seq=True`` 时
+        同时返回完整膜电位序列。Triton 后端使用专用多步 kernel。
 
-        :param x_seq: 多步输入，形状为 ``[T, N, *]``，且 ``T > 0``。
-        :type x_seq: torch.Tensor
-        :return: 与 ``x_seq`` 形状和 dtype 相同的脉冲序列。
-        :rtype: torch.Tensor
+        :param inputs: 仅包含 ``x_seq`` 的元组，``x_seq`` 形状为 ``[T, N, *]``。
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: 显式状态 ``(v,)`` 或 ``(v, v_seq)``。
+        :type states: tuple
+        :return: ``((spike_seq,), updated_states)``。
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
         :raises ValueError: 当输入形状、T 或逐通道参数长度非法时抛出。
         :raises RuntimeError: 当 Triton 后端用于 CPU、训练、求梯度、非脉冲
             surrogate 或非 FP32/BF16 输入时抛出。
 
         ----
 
-        .. _ActivationAwareIFNode.multi_step_forward-en:
+        .. _ActivationAwareIFNode.multi_step_functional_forward-en:
 
         * **English**
 
-        Run the multi-step activation-aware IF forward pass. Input and output
-        both have shape ``[T, N, *]``. Each call starts from the current
-        ``self.v`` and stores the final membrane voltage back in ``self.v``;
-        when ``store_v_seq=True``, it also stores the full voltage sequence in
-        ``self.v_seq``. The Triton backend supports only FP32/BF16 CUDA
-        inference in ``eval`` mode, with no backward path or implicit Torch
-        fallback.
+        Run the multi-step activation-aware IF forward pass with explicit state.
+        The Torch backend uses the single-step functional implementation by
+        default and also returns the full voltage sequence when
+        ``store_v_seq=True``. The Triton backend uses its specialized sequence
+        kernel.
 
-        :param x_seq: Multi-step input with shape ``[T, N, *]`` and ``T > 0``.
-        :type x_seq: torch.Tensor
-        :return: Spike sequence with the same shape and dtype as ``x_seq``.
-        :rtype: torch.Tensor
+        :param inputs: Tuple containing only ``x_seq`` with shape ``[T, N, *]``.
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: Explicit states ``(v,)`` or ``(v, v_seq)``.
+        :type states: tuple
+        :return: ``((spike_seq,), updated_states)``.
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
         :raises ValueError: If the input shape, T, or channel-wise parameter
             length is invalid.
         :raises RuntimeError: If the Triton backend is used on CPU, for
             training or autograd, with a non-spiking surrogate, or with an
             input other than FP32/BF16.
         """
+        x_seq = inputs[0]
         if x_seq.dim() < 2 or x_seq.shape[0] == 0 or x_seq[0].numel() == 0:
             raise ValueError(
                 "ActivationAwareIFNode multi-step input must have a non-empty "
                 "shape [T, N, *] with T greater than zero."
             )
         if self.backend == "triton":
-            return self._triton_multi_step_forward(x_seq)
+            spike_seq, v, v_seq = self._triton_multi_step_functional_forward(
+                x_seq, states[0]
+            )
+            updated_states = (v, v_seq) if self.store_v_seq else (v, *states[1:])
+            return (spike_seq,), updated_states
         if not self.store_v_seq:
-            return super().multi_step_forward(x_seq)
+            return super().multi_step_functional_forward(inputs, states, **kwargs)
 
         spike_seq = []
         v_seq = []
-        for x in x_seq:
-            spike_seq.append(self.single_step_forward(x))
-            v_seq.append(self.v)
-        self.v_seq = torch.stack(v_seq)
-        return torch.stack(spike_seq)
+        for t in range(x_seq.shape[0]):
+            outputs, states = self.single_step_functional_forward(
+                (x_seq[t],), states, **kwargs
+            )
+            spike_seq.append(outputs[0])
+            v_seq.append(states[0])
+        return (torch.stack(spike_seq),), (states[0], torch.stack(v_seq))
 
     def extra_repr(self):
         return (

--- a/spikingjelly/activation_based/neuron/integrate_and_fire.py
+++ b/spikingjelly/activation_based/neuron/integrate_and_fire.py
@@ -45,7 +45,8 @@ class SimpleIFNode(SimpleBaseNode):
 
         * **中文**
 
-        :class:`IFNode` 的简化版实现。
+        基于 :class:`SimpleBaseNode` 充电-放电-重置接口的纯 PyTorch IF 实现，
+        用于理解和修改神经元动力学。
 
         :param v_threshold: 神经元阈值电压
         :type v_threshold: float
@@ -64,7 +65,8 @@ class SimpleIFNode(SimpleBaseNode):
 
         * **English**
 
-        A simple version of :class:`IFNode`.
+        A pure-PyTorch IF implementation built on the charge-fire-reset interface
+        of :class:`SimpleBaseNode` for understanding and modifying neuron dynamics.
 
         :param v_threshold: Threshold voltage of the neuron
         :type v_threshold: float

--- a/spikingjelly/activation_based/neuron/integrate_and_fire.py
+++ b/spikingjelly/activation_based/neuron/integrate_and_fire.py
@@ -227,43 +227,12 @@ class IFNode(BaseNode):
         else:
             raise ValueError(self.step_mode)
 
-    def neuronal_charge(self, x: torch.Tensor):
-        self.v = self.v + x
-
-    # kept for subclass backward-compatibility
-    @staticmethod
-    def jit_eval_single_step_forward_hard_reset(
-        x: torch.Tensor, v: torch.Tensor, v_threshold: float, v_reset: float
-    ):
-        v = v + x
-        spike = (v >= v_threshold).to(x)
-        v = v_reset * spike + (1.0 - spike) * v
-        return spike, v
-
-    @staticmethod
-    def jit_eval_single_step_forward_soft_reset(
-        x: torch.Tensor, v: torch.Tensor, v_threshold: float
-    ):
-        v = v + x
-        spike = (v >= v_threshold).to(x)
-        v = v - spike * v_threshold
-        return spike, v
-
     def single_step_functional_forward(
         self,
         inputs: tuple[torch.Tensor, ...],
         states: tuple[object, ...],
         **kwargs: object,
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
-        r"""Execute one IF step with explicit state. / 使用显式状态执行一个 IF 时间步。
-
-        :param inputs: 仅包含 ``x`` 的元组 / Tuple containing only ``x``
-        :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)``
-        :type states: tuple
-        :return: ``((spike,), updated_states)``
-        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
-        """
         x = inputs[0]
         v = states[0]
 
@@ -301,15 +270,6 @@ class IFNode(BaseNode):
         states: tuple[object, ...],
         **kwargs: object,
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
-        r"""Execute IF sequence forward with explicit state. / 使用显式状态执行 IF 序列前向。
-
-        :param inputs: 仅包含 ``x_seq`` 的元组 / Tuple containing only ``x_seq``
-        :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)``
-        :type states: tuple
-        :return: ``((spike_seq,), updated_states)``
-        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
-        """
         x_seq = inputs[0]
         v = states[0]
 
@@ -553,9 +513,6 @@ class HalfThresholdIFNode(BaseNode):
             elif v.dtype != x.dtype or v.device != x.device:
                 v = v.to(dtype=x.dtype, device=x.device)
         return (v, *states[1:])
-
-    def neuronal_charge(self, x: torch.Tensor):
-        self.v = self.v + x
 
     def single_step_functional_forward(
         self,

--- a/spikingjelly/activation_based/neuron/lif.py
+++ b/spikingjelly/activation_based/neuron/lif.py
@@ -240,103 +240,12 @@ class LIFNode(BaseNode):
     def extra_repr(self):
         return super().extra_repr() + f", tau={self.tau}"
 
-    def neuronal_charge(self, x: torch.Tensor):
-        if self.decay_input:
-            if self.v_reset is None or self.v_reset == 0.0:
-                self.v = self.neuronal_charge_decay_input_reset0(x, self.v, self.tau)
-            else:
-                self.v = self.neuronal_charge_decay_input(
-                    x, self.v, self.v_reset, self.tau
-                )
-
-        else:
-            if self.v_reset is None or self.v_reset == 0.0:
-                self.v = self.neuronal_charge_no_decay_input_reset0(x, self.v, self.tau)
-            else:
-                self.v = self.neuronal_charge_no_decay_input(
-                    x, self.v, self.v_reset, self.tau
-                )
-
-    @staticmethod
-    def neuronal_charge_decay_input_reset0(
-        x: torch.Tensor, v: torch.Tensor, tau: float
-    ):
-        v = v + (x - v) / tau
-        return v
-
-    @staticmethod
-    def neuronal_charge_decay_input(
-        x: torch.Tensor, v: torch.Tensor, v_reset: float, tau: float
-    ):
-        v = v + (x - (v - v_reset)) / tau
-        return v
-
-    @staticmethod
-    def neuronal_charge_no_decay_input_reset0(
-        x: torch.Tensor, v: torch.Tensor, tau: float
-    ):
-        v = v * (1.0 - 1.0 / tau) + x
-        return v
-
-    @staticmethod
-    def neuronal_charge_no_decay_input(
-        x: torch.Tensor, v: torch.Tensor, v_reset: float, tau: float
-    ):
-        v = v - (v - v_reset) / tau + x
-        return v
-
-    # ---------- kept for subclass backward-compatibility ----------
-    @staticmethod
-    def jit_eval_single_step_forward_hard_reset_decay_input(
-        x: torch.Tensor, v: torch.Tensor, v_threshold: float, v_reset: float, tau: float
-    ):
-        v = v + (x - (v - v_reset)) / tau
-        spike = (v >= v_threshold).to(x)
-        v = v_reset * spike + (1.0 - spike) * v
-        return spike, v
-
-    @staticmethod
-    def jit_eval_single_step_forward_hard_reset_no_decay_input(
-        x: torch.Tensor, v: torch.Tensor, v_threshold: float, v_reset: float, tau: float
-    ):
-        v = v - (v - v_reset) / tau + x
-        spike = (v >= v_threshold).to(x)
-        v = v_reset * spike + (1.0 - spike) * v
-        return spike, v
-
-    @staticmethod
-    def jit_eval_single_step_forward_soft_reset_decay_input(
-        x: torch.Tensor, v: torch.Tensor, v_threshold: float, tau: float
-    ):
-        v = v + (x - v) / tau
-        spike = (v >= v_threshold).to(x)
-        v = v - spike * v_threshold
-        return spike, v
-
-    @staticmethod
-    def jit_eval_single_step_forward_soft_reset_no_decay_input(
-        x: torch.Tensor, v: torch.Tensor, v_threshold: float, tau: float
-    ):
-        v = v * (1.0 - 1.0 / tau) + x
-        spike = (v >= v_threshold).to(x)
-        v = v - spike * v_threshold
-        return spike, v
-
     def single_step_functional_forward(
         self,
         inputs: tuple[torch.Tensor, ...],
         states: tuple[object, ...],
         **kwargs: object,
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
-        r"""Execute one LIF step with explicit state. / 使用显式状态执行一个 LIF 时间步。
-
-        :param inputs: 仅包含 ``x`` 的元组 / Tuple containing only ``x``
-        :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)``
-        :type states: tuple
-        :return: ``((spike,), updated_states)``
-        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
-        """
         x = inputs[0]
         v = states[0]
 
@@ -378,15 +287,6 @@ class LIFNode(BaseNode):
         states: tuple[object, ...],
         **kwargs: object,
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
-        r"""Execute LIF sequence forward with explicit state. / 使用显式状态执行 LIF 序列前向。
-
-        :param inputs: 仅包含 ``x_seq`` 的元组 / Tuple containing only ``x_seq``
-        :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)``
-        :type states: tuple
-        :return: ``((spike_seq,), updated_states)``
-        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
-        """
         x_seq = inputs[0]
         v = states[0]
 

--- a/spikingjelly/activation_based/neuron/lif.py
+++ b/spikingjelly/activation_based/neuron/lif.py
@@ -36,7 +36,8 @@ class SimpleLIFNode(SimpleBaseNode):
 
         * **中文**
 
-        :class:`LIFNode` 的简化版实现。
+        基于 :class:`SimpleBaseNode` 充电-放电-重置接口的纯 PyTorch LIF 实现，
+        用于理解和修改神经元动力学。
 
         ----
 
@@ -44,7 +45,8 @@ class SimpleLIFNode(SimpleBaseNode):
 
         * **English**
 
-        A simple version of :class:`LIFNode`.
+        A pure-PyTorch LIF implementation built on the charge-fire-reset interface
+        of :class:`SimpleBaseNode` for understanding and modifying neuron dynamics.
 
         :param tau: 膜电位时间常数（详见父类 :class:`LIFNode`）
         :type tau: float

--- a/spikingjelly/activation_based/neuron/lif.py
+++ b/spikingjelly/activation_based/neuron/lif.py
@@ -395,15 +395,29 @@ class LIFNode(BaseNode):
             return spike_seq, v, v_seq
         return spike_seq, v
 
-    def single_step_forward(self, x: torch.Tensor):
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        r"""Execute one LIF step with explicit state. / 使用显式状态执行一个 LIF 时间步。
+
+        :param inputs: 仅包含 ``x`` 的元组 / Tuple containing only ``x``
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :type states: tuple
+        :return: ``((spike,), updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
+        """
+        x = inputs[0]
+        v = states[0]
+
         if self.training:
             if self.backend == "torch":
-                return super().single_step_forward(x)
-            elif self.backend == "cupy":
-                self.v_float_to_tensor(x)
-                spike, self.v = functional.lif_step_cupy(
+                spike, v = functional.lif_step(
                     x,
-                    self.v,
+                    v,
                     self.tau,
                     self.decay_input,
                     self.v_threshold,
@@ -411,146 +425,140 @@ class LIFNode(BaseNode):
                     self.surrogate_function,
                     self.detach_reset,
                 )
-                return spike
+            elif self.backend == "cupy":
+                spike, v = functional.lif_step_cupy(
+                    x,
+                    v,
+                    self.tau,
+                    self.decay_input,
+                    self.v_threshold,
+                    self.v_reset,
+                    self.surrogate_function,
+                    self.detach_reset,
+                )
             else:
                 raise ValueError(self.backend)
-
         else:
-            self.v_float_to_tensor(x)
-            spike, self.v = self._eval_single_step_forward(
+            spike, v = self._eval_single_step_forward(
                 x,
-                self.v,
+                v,
                 self.v_threshold,
                 self.v_reset,
                 self.tau,
                 self.decay_input,
             )
-            return spike
+        return (spike,), (v, *states[1:])
 
-    def multi_step_forward(self, x_seq: torch.Tensor):
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        r"""Execute LIF sequence forward with explicit state. / 使用显式状态执行 LIF 序列前向。
+
+        :param inputs: 仅包含 ``x_seq`` 的元组 / Tuple containing only ``x_seq``
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :type states: tuple
+        :return: ``((spike_seq,), updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
+        """
+        x_seq = inputs[0]
+        v = states[0]
+
+        v_seq = None
         if self.backend == "inductor":
-            return self._inductor_multi_step_forward(x_seq)
-        if self.training:
-            if self.backend == "torch":
-                return super().multi_step_forward(x_seq)
-            elif self.backend == "cupy":
-                self.v_float_to_tensor(x_seq[0])
-                spike_seq, self.v, v_seq = functional.lif_multi_step_cupy(
-                    x_seq,
-                    self.v,
-                    self.tau,
-                    self.decay_input,
-                    self.v_threshold,
-                    self.v_reset,
-                    self.surrogate_function,
-                    self.detach_reset,
-                    self.store_v_seq,
+            spike_seq, v, v_seq = functional.lif_multi_step_inductor(
+                x_seq,
+                v,
+                self.tau,
+                self.decay_input,
+                self.v_threshold,
+                self.v_reset,
+                self.surrogate_function,
+                self.detach_reset,
+                self.store_v_seq,
+            )
+        elif self.backend == "cupy":
+            spike_seq, v, v_seq = functional.lif_multi_step_cupy(
+                x_seq,
+                v,
+                self.tau,
+                self.decay_input,
+                self.v_threshold,
+                self.v_reset,
+                self.surrogate_function,
+                self.detach_reset,
+                self.store_v_seq,
+            )
+        elif self.backend == "triton":
+            if not self.training and not getattr(
+                self.surrogate_function, "spiking", True
+            ):
+                raise NotImplementedError(
+                    "Triton backend only supports spiking surrogate functions. "
+                    "Use backend='torch' for non-spiking surrogate functions."
                 )
-                if self.store_v_seq:
-                    self.v_seq = v_seq
-                return spike_seq
-            elif self.backend == "triton":
-                self.v_float_to_tensor(x_seq[0])
-                spike_seq, v_out = triton_kernel.multistep_lif(
-                    x_seq,
-                    self.v,
-                    self.decay_input,
-                    self.tau,
-                    self.v_threshold,
-                    self.v_reset,
-                    self.detach_reset,
-                    self.surrogate_function,
-                    self.store_v_seq,
-                )
-                if self.store_v_seq:
-                    self.v_seq = v_out
-                    self.v = v_out[-1].clone()
-                else:
-                    self.v = v_out
-                return spike_seq
+            spike_seq, v_out = triton_kernel.multistep_lif(
+                x_seq,
+                v,
+                self.decay_input,
+                self.tau,
+                self.v_threshold,
+                self.v_reset,
+                self.detach_reset,
+                self.surrogate_function,
+                self.store_v_seq,
+            )
+            if self.store_v_seq:
+                v_seq = v_out
+                v = v_out[-1].clone() if self.training else v_out[-1]
             else:
-                raise ValueError(self.backend)
-
-        else:
-            self.v_float_to_tensor(x_seq[0])
-
-            if self.backend == "triton":
-                if not getattr(self.surrogate_function, "spiking", True):
-                    raise NotImplementedError(
-                        "Triton backend only supports spiking surrogate functions. "
-                        "Use backend='torch' for non-spiking surrogate functions."
-                    )
-                spike_seq, v_out = triton_kernel.multistep_lif(
-                    x_seq,
-                    self.v,
-                    self.decay_input,
-                    self.tau,
-                    self.v_threshold,
-                    self.v_reset,
-                    self.detach_reset,
-                    self.surrogate_function,
-                    self.store_v_seq,
-                )
-                if self.store_v_seq:
-                    self.v_seq = v_out
-                    self.v = v_out[-1]
-                else:
-                    self.v = v_out
-                return spike_seq
-            elif self.backend == "cupy":
-                spike_seq, self.v, v_seq = functional.lif_multi_step_cupy(
-                    x_seq,
-                    self.v,
-                    self.tau,
-                    self.decay_input,
-                    self.v_threshold,
-                    self.v_reset,
-                    self.surrogate_function,
-                    self.detach_reset,
-                    self.store_v_seq,
-                )
-                if self.store_v_seq:
-                    self.v_seq = v_seq
-                return spike_seq
-
-            # torch backend:
-            # (replaces the 8 separate jit_eval_multi_step_forward_* methods)
-            _spiking = getattr(self.surrogate_function, "spiking", True)
+                v = v_out
+        elif self.backend == "torch" and not self.training:
+            spiking = getattr(self.surrogate_function, "spiking", True)
             out = self._eval_multi_step_forward(
                 x_seq,
-                self.v,
+                v,
                 self.v_threshold,
                 self.v_reset,
                 self.tau,
                 self.decay_input,
                 self.store_v_seq,
-                spiking=_spiking,
-                # When spiking=False, SurrogateFunctionBase.forward() returns the
-                # primitive (smooth) function, so we can call it directly.
-                surrogate_fn=self.surrogate_function if not _spiking else None,
+                spiking=spiking,
+                surrogate_fn=self.surrogate_function if not spiking else None,
             )
             if self.store_v_seq:
-                spike_seq, self.v, self.v_seq = out
+                spike_seq, v, v_seq = out
             else:
-                spike_seq, self.v = out
-            return spike_seq
+                spike_seq, v = out
+        elif self.backend == "torch":
+            spike_seq = []
+            voltages = []
+            for t in range(x_seq.shape[0]):
+                x = x_seq[t]
+                spike, v = functional.lif_step(
+                    x,
+                    v,
+                    self.tau,
+                    self.decay_input,
+                    self.v_threshold,
+                    self.v_reset,
+                    self.surrogate_function,
+                    self.detach_reset,
+                )
+                spike_seq.append(spike)
+                if self.store_v_seq:
+                    voltages.append(v)
+            spike_seq = torch.stack(spike_seq)
+            if self.store_v_seq:
+                v_seq = torch.stack(voltages)
+        else:
+            raise ValueError(self.backend)
 
-    def _inductor_multi_step_forward(self, x_seq: torch.Tensor):
-        self.v_float_to_tensor(x_seq[0])
-        spike_seq, self.v, v_seq = functional.lif_multi_step_inductor(
-            x_seq,
-            self.v,
-            self.tau,
-            self.decay_input,
-            self.v_threshold,
-            self.v_reset,
-            self.surrogate_function,
-            self.detach_reset,
-            self.store_v_seq,
-        )
-        if self.store_v_seq:
-            self.v_seq = v_seq
-        return spike_seq
+        updated_states = (v, v_seq) if self.store_v_seq else (v,)
+        return (spike_seq,), updated_states
 
 
 class NonSpikingLIFNode(NonSpikingBaseNode):

--- a/spikingjelly/activation_based/neuron/lif.py
+++ b/spikingjelly/activation_based/neuron/lif.py
@@ -1,16 +1,9 @@
-from spikingjelly.logger import logger
 from typing import Optional
 
 import torch
 
 from .. import functional, surrogate
 from .base_node import BaseNode, NonSpikingBaseNode, SimpleBaseNode
-
-try:
-    from .. import triton_kernel
-except (ImportError, OSError) as e:
-    logger.debug("spikingjelly.activation_based.neuron: %s", e)
-    triton_kernel = None
 
 
 __all__ = ["SimpleLIFNode", "LIFNode", "NonSpikingLIFNode"]
@@ -36,8 +29,7 @@ class SimpleLIFNode(SimpleBaseNode):
 
         * **中文**
 
-        基于 :class:`SimpleBaseNode` 充电-放电-重置接口的纯 PyTorch LIF 实现，
-        用于理解和修改神经元动力学。
+        基于 :class:`SimpleBaseNode` 充电-放电-重置接口的纯 PyTorch LIF 实现。
 
         ----
 
@@ -46,7 +38,7 @@ class SimpleLIFNode(SimpleBaseNode):
         * **English**
 
         A pure-PyTorch LIF implementation built on the charge-fire-reset interface
-        of :class:`SimpleBaseNode` for understanding and modifying neuron dynamics.
+        of :class:`SimpleBaseNode`.
 
         :param tau: 膜电位时间常数（详见父类 :class:`LIFNode`）
         :type tau: float
@@ -293,30 +285,6 @@ class LIFNode(BaseNode):
         v = v - (v - v_reset) / tau + x
         return v
 
-    @staticmethod
-    def _eval_single_step_forward(
-        x: torch.Tensor,
-        v: torch.Tensor,
-        v_threshold: float,
-        v_reset,
-        tau: float,
-        decay_input: bool,
-    ):
-        """Unified single-step eval forward (replaces the 4 jit_eval_single_step_* methods)."""
-        soft_reset = v_reset is None
-        _vr = 0.0 if soft_reset else v_reset
-        if decay_input:
-            v = v + (x - (v - _vr)) / tau
-        else:
-            v = v - (v - _vr) / tau + x
-        spike = (v >= v_threshold).to(x)
-        v = (
-            (v - spike * v_threshold)
-            if soft_reset
-            else (_vr * spike + (1.0 - spike) * v)
-        )
-        return spike, v
-
     # ---------- kept for subclass backward-compatibility ----------
     @staticmethod
     def jit_eval_single_step_forward_hard_reset_decay_input(
@@ -354,49 +322,6 @@ class LIFNode(BaseNode):
         v = v - spike * v_threshold
         return spike, v
 
-    @staticmethod
-    def _eval_multi_step_forward(
-        x_seq: torch.Tensor,
-        v: torch.Tensor,
-        v_threshold: float,
-        v_reset,
-        tau: float,
-        decay_input: bool,
-        store_v_seq: bool,
-        spiking: bool = True,
-        surrogate_fn=None,
-    ):
-        """Unified fallback for all 4 LIF variants (CPU or unsupported surrogate).
-        When *spiking* is False the surrogate primitive function is used to
-        compute a continuous spike value instead of the hard Heaviside threshold,
-        matching the behaviour of ``single_step_forward`` with ``spiking=False``.
-        """
-        T = x_seq.shape[0]
-        spike_seq = torch.zeros_like(x_seq)
-        v_seq = torch.zeros_like(x_seq) if store_v_seq else None
-        soft_reset = v_reset is None
-        _vr = 0.0 if soft_reset else v_reset
-        for t in range(T):
-            if decay_input:
-                v = v + (x_seq[t] - (v - _vr)) / tau
-            else:
-                v = v - (v - _vr) / tau + x_seq[t]
-            if spiking:
-                spike = (v >= v_threshold).to(x_seq)
-            else:
-                spike = surrogate_fn(v - v_threshold)
-            v = (
-                (v - spike * v_threshold)
-                if soft_reset
-                else (_vr * spike + (1.0 - spike) * v)
-            )
-            spike_seq[t] = spike
-            if store_v_seq:
-                v_seq[t] = v
-        if store_v_seq:
-            return spike_seq, v, v_seq
-        return spike_seq, v
-
     def single_step_functional_forward(
         self,
         inputs: tuple[torch.Tensor, ...],
@@ -407,7 +332,7 @@ class LIFNode(BaseNode):
 
         :param inputs: 仅包含 ``x`` 的元组 / Tuple containing only ``x``
         :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :param states: ``(v,)``
         :type states: tuple
         :return: ``((spike,), updated_states)``
         :rtype: tuple[tuple[torch.Tensor, ...], tuple]
@@ -415,40 +340,36 @@ class LIFNode(BaseNode):
         x = inputs[0]
         v = states[0]
 
-        if self.training:
-            if self.backend == "torch":
-                spike, v = functional.lif_step(
-                    x,
-                    v,
-                    self.tau,
-                    self.decay_input,
-                    self.v_threshold,
-                    self.v_reset,
-                    self.surrogate_function,
-                    self.detach_reset,
-                )
-            elif self.backend == "cupy":
-                spike, v = functional.lif_step_cupy(
-                    x,
-                    v,
-                    self.tau,
-                    self.decay_input,
-                    self.v_threshold,
-                    self.v_reset,
-                    self.surrogate_function,
-                    self.detach_reset,
-                )
-            else:
-                raise ValueError(self.backend)
-        else:
-            spike, v = self._eval_single_step_forward(
+        if self.backend == "torch":
+            surrogate_function = (
+                self.surrogate_function
+                if self.training
+                or not getattr(self.surrogate_function, "spiking", True)
+                else surrogate.heaviside
+            )
+            spike, v = functional.lif_step(
                 x,
                 v,
-                self.v_threshold,
-                self.v_reset,
                 self.tau,
                 self.decay_input,
+                self.v_threshold,
+                self.v_reset,
+                surrogate_function,
+                self.detach_reset,
             )
+        elif self.backend == "cupy":
+            spike, v = functional.lif_step_cupy(
+                x,
+                v,
+                self.tau,
+                self.decay_input,
+                self.v_threshold,
+                self.v_reset,
+                self.surrogate_function,
+                self.detach_reset,
+            )
+        else:
+            raise ValueError(self.backend)
         return (spike,), (v, *states[1:])
 
     def multi_step_functional_forward(
@@ -461,7 +382,7 @@ class LIFNode(BaseNode):
 
         :param inputs: 仅包含 ``x_seq`` 的元组 / Tuple containing only ``x_seq``
         :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :param states: ``(v,)``
         :type states: tuple
         :return: ``((spike_seq,), updated_states)``
         :rtype: tuple[tuple[torch.Tensor, ...], tuple]
@@ -469,7 +390,64 @@ class LIFNode(BaseNode):
         x_seq = inputs[0]
         v = states[0]
 
-        v_seq = None
+        if self.backend == "inductor":
+            spike_seq, v, _ = functional.lif_multi_step_inductor(
+                x_seq,
+                v,
+                self.tau,
+                self.decay_input,
+                self.v_threshold,
+                self.v_reset,
+                self.surrogate_function,
+                self.detach_reset,
+                False,
+            )
+        elif self.backend == "cupy":
+            spike_seq, v, _ = functional.lif_multi_step_cupy(
+                x_seq,
+                v,
+                self.tau,
+                self.decay_input,
+                self.v_threshold,
+                self.v_reset,
+                self.surrogate_function,
+                self.detach_reset,
+                False,
+            )
+        elif self.backend == "triton":
+            if not self.training and not getattr(
+                self.surrogate_function, "spiking", True
+            ):
+                raise NotImplementedError(
+                    "Triton backend only supports spiking surrogate functions. "
+                    "Use backend='torch' for non-spiking surrogate functions."
+                )
+            spike_seq, v, _ = functional.lif_multi_step_triton(
+                x_seq,
+                v,
+                self.tau,
+                self.decay_input,
+                self.v_threshold,
+                self.v_reset,
+                self.surrogate_function,
+                self.detach_reset,
+                False,
+            )
+        elif self.backend == "torch":
+            return super().multi_step_functional_forward(inputs, states, **kwargs)
+        else:
+            raise ValueError(self.backend)
+
+        return (spike_seq,), (v,)
+
+    def multi_step_forward(self, x_seq: torch.Tensor, *args, **kwargs):
+        if not self.store_v_seq or self.backend == "torch":
+            return super().multi_step_forward(x_seq, *args, **kwargs)
+
+        states = self.materialize_states(
+            (x_seq, *args), tuple(self._memories.values()), "m"
+        )
+        v = states[0]
         if self.backend == "inductor":
             spike_seq, v, v_seq = functional.lif_multi_step_inductor(
                 x_seq,
@@ -480,7 +458,7 @@ class LIFNode(BaseNode):
                 self.v_reset,
                 self.surrogate_function,
                 self.detach_reset,
-                self.store_v_seq,
+                True,
             )
         elif self.backend == "cupy":
             spike_seq, v, v_seq = functional.lif_multi_step_cupy(
@@ -492,7 +470,7 @@ class LIFNode(BaseNode):
                 self.v_reset,
                 self.surrogate_function,
                 self.detach_reset,
-                self.store_v_seq,
+                True,
             )
         elif self.backend == "triton":
             if not self.training and not getattr(
@@ -502,65 +480,22 @@ class LIFNode(BaseNode):
                     "Triton backend only supports spiking surrogate functions. "
                     "Use backend='torch' for non-spiking surrogate functions."
                 )
-            spike_seq, v_out = triton_kernel.multistep_lif(
+            spike_seq, v, v_seq = functional.lif_multi_step_triton(
                 x_seq,
                 v,
-                self.decay_input,
                 self.tau,
+                self.decay_input,
                 self.v_threshold,
                 self.v_reset,
-                self.detach_reset,
                 self.surrogate_function,
-                self.store_v_seq,
+                self.detach_reset,
+                True,
             )
-            if self.store_v_seq:
-                v_seq = v_out
-                v = v_out[-1].clone() if self.training else v_out[-1]
-            else:
-                v = v_out
-        elif self.backend == "torch" and not self.training:
-            spiking = getattr(self.surrogate_function, "spiking", True)
-            out = self._eval_multi_step_forward(
-                x_seq,
-                v,
-                self.v_threshold,
-                self.v_reset,
-                self.tau,
-                self.decay_input,
-                self.store_v_seq,
-                spiking=spiking,
-                surrogate_fn=self.surrogate_function if not spiking else None,
-            )
-            if self.store_v_seq:
-                spike_seq, v, v_seq = out
-            else:
-                spike_seq, v = out
-        elif self.backend == "torch":
-            spike_seq = []
-            voltages = []
-            for t in range(x_seq.shape[0]):
-                x = x_seq[t]
-                spike, v = functional.lif_step(
-                    x,
-                    v,
-                    self.tau,
-                    self.decay_input,
-                    self.v_threshold,
-                    self.v_reset,
-                    self.surrogate_function,
-                    self.detach_reset,
-                )
-                spike_seq.append(spike)
-                if self.store_v_seq:
-                    voltages.append(v)
-            spike_seq = torch.stack(spike_seq)
-            if self.store_v_seq:
-                v_seq = torch.stack(voltages)
         else:
             raise ValueError(self.backend)
-
-        updated_states = (v, v_seq) if self.store_v_seq else (v,)
-        return (spike_seq,), updated_states
+        self.v = v
+        self.v_seq = v_seq
+        return spike_seq
 
 
 class NonSpikingLIFNode(NonSpikingBaseNode):

--- a/spikingjelly/activation_based/neuron/lif_variants.py
+++ b/spikingjelly/activation_based/neuron/lif_variants.py
@@ -201,30 +201,6 @@ class GatedLIFNode(base.MemoryModule):
             + f", conduct={self.conduct}"
         )
 
-    def neuronal_charge(
-        self, x: torch.Tensor, alpha: torch.Tensor, beta: torch.Tensor, t
-    ):
-        input = x * (1 - beta * (1 - self.conduct[t].view(1, -1, 1, 1).sigmoid()))
-        self.u = (
-            (1 - alpha * (1 - self.tau.view(1, -1, 1, 1).sigmoid())) * self.v
-            - (1 - alpha) * self.linear_decay.view(1, -1, 1, 1).sigmoid()
-        ) + input
-
-    def neuronal_reset(self, spike, alpha: torch.Tensor, gamma: torch.Tensor):
-        self.u = (
-            self.u
-            - (1 - alpha * (1 - self.tau.view(1, -1, 1, 1).sigmoid()))
-            * self.v
-            * gamma
-            * spike
-            - (1 - gamma) * self.v_subreset.view(1, -1, 1, 1).sigmoid() * spike
-        )
-
-    def neuronal_fire(self):
-        return self.surrogate_function(
-            self.u - self.v_threshold.view(1, -1, 1, 1).sigmoid()
-        )
-
     def materialize_states(
         self,
         inputs: tuple[torch.Tensor, ...],
@@ -344,7 +320,7 @@ class KLIFNode(BaseNode):
                 \frac{1}{k}(F[t] - S[t]V_{th}), & \text{soft reset}
             \end{cases}
 
-        :param scale_reset: 是否在 ``neuronal_reset`` 阶段对膜电位 ``v`` 进行缩放
+        :param scale_reset: 是否在重置阶段对膜电位 ``v`` 进行缩放
         :type scale_reset: bool
 
         :param tau: 膜电位的时间常数
@@ -434,7 +410,7 @@ class KLIFNode(BaseNode):
                 \frac{1}{k}(F[t] - S[t]V_{th}), & \text{soft reset}
             \end{cases}
 
-        :param scale_reset: whether to scale the membrane potential ``v`` during ``neuronal_reset``
+        :param scale_reset: whether to scale the membrane potential ``v`` during reset
         :type scale_reset: bool
 
         :param tau: membrane time constant
@@ -490,55 +466,6 @@ class KLIFNode(BaseNode):
     @property
     def supported_backends(self):
         return ("torch",)
-
-    @staticmethod
-    def neuronal_charge_decay_input(
-        x: torch.Tensor, v: torch.Tensor, v_reset: float, tau: float, k: torch.Tensor
-    ):
-        v = v + (x - (v - v_reset)) / tau
-        v = torch.relu_(k * v)
-        return v
-
-    @staticmethod
-    def neuronal_charge_no_decay_input(
-        x: torch.Tensor, v: torch.Tensor, v_reset: float, tau: float, k: torch.Tensor
-    ):
-        v = v - (v - v_reset) / tau + x
-        v = torch.relu_(k * v)
-        return v
-
-    def neuronal_charge(self, x: torch.Tensor):
-        if self.v_reset is None:
-            v_reset = 0.0
-        else:
-            v_reset = self.v_reset
-        if self.decay_input:
-            self.v = self.neuronal_charge_decay_input(
-                x, self.v, v_reset, self.tau, self.k
-            )
-
-        else:
-            self.v = self.neuronal_charge_no_decay_input(
-                x, self.v, v_reset, self.tau, self.k
-            )
-
-    def neuronal_reset(self, spike):
-        if self.detach_reset:
-            spike_d = spike.detach()
-        else:
-            spike_d = spike
-
-        if self.scale_reset:
-            v = self.v / self.k
-            v_threshold = self.v_threshold / self.k
-        else:
-            v = self.v
-            v_threshold = self.v_threshold
-
-        if self.v_reset is None:
-            self.v = self.apply_soft_reset(v, spike_d, v_threshold)
-        else:
-            self.v = self.apply_hard_reset(v, spike_d, self.v_reset)
 
     def single_step_functional_forward(
         self,
@@ -601,10 +528,6 @@ class CUBALIFNode(BaseNode):
 
         self.c_decay = c_decay
         self.v_decay = v_decay
-
-    def neuronal_charge(self, x: torch.Tensor):
-        self.c = self.c * self.c_decay + x
-        self.v = self.v * self.v_decay + self.c
 
     def materialize_states(
         self,
@@ -719,15 +642,6 @@ class LIAFNode(LIFNode):
         states: tuple[object, ...],
         **kwargs: object,
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
-        r"""Execute one LIAF step with explicit state. / 使用显式状态执行一个 LIAF 时间步。
-
-        :param inputs: 仅包含 ``x`` 的元组 / Tuple containing only ``x``
-        :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)``
-        :type states: tuple
-        :return: ``((analog_output,), updated_states)``
-        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
-        """
         x = inputs[0]
         v = states[0]
 

--- a/spikingjelly/activation_based/neuron/lif_variants.py
+++ b/spikingjelly/activation_based/neuron/lif_variants.py
@@ -548,22 +548,18 @@ class KLIFNode(BaseNode):
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         x = inputs[0]
         v = states[0]
-        v_reset = 0.0 if self.v_reset is None else self.v_reset
-        if self.decay_input:
-            v = self.neuronal_charge_decay_input(x, v, v_reset, self.tau, self.k)
-        else:
-            v = self.neuronal_charge_no_decay_input(x, v, v_reset, self.tau, self.k)
-        spike = self.surrogate_function(v - self.v_threshold)
-        reset_spike = spike.detach() if self.detach_reset else spike
-        if self.scale_reset:
-            v = v / self.k
-            v_threshold = self.v_threshold / self.k
-        else:
-            v_threshold = self.v_threshold
-        if self.v_reset is None:
-            v = self.apply_soft_reset(v, reset_spike, v_threshold)
-        else:
-            v = self.apply_hard_reset(v, reset_spike, self.v_reset)
+        spike, v = functional.klif_step(
+            x,
+            v,
+            self.k,
+            self.tau,
+            self.decay_input,
+            self.scale_reset,
+            self.v_threshold,
+            self.v_reset,
+            self.surrogate_function,
+            self.detach_reset,
+        )
         return (spike,), (v, *states[1:])
 
 
@@ -636,14 +632,17 @@ class CUBALIFNode(BaseNode):
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         x = inputs[0]
         v, c = states
-        c = c * self.c_decay + x
-        v = v * self.v_decay + c
-        spike = self.surrogate_function(v - self.v_threshold)
-        reset_spike = spike.detach() if self.detach_reset else spike
-        if self.v_reset is None:
-            v = self.apply_soft_reset(v, reset_spike, self.v_threshold)
-        else:
-            v = self.apply_hard_reset(v, reset_spike, self.v_reset)
+        spike, c, v = functional.cuba_lif_step(
+            x,
+            c,
+            v,
+            self.c_decay,
+            self.v_decay,
+            self.v_threshold,
+            self.v_reset,
+            self.surrogate_function,
+            self.detach_reset,
+        )
         return (spike,), (v, c)
 
 
@@ -724,7 +723,7 @@ class LIAFNode(LIFNode):
 
         :param inputs: 仅包含 ``x`` 的元组 / Tuple containing only ``x``
         :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :param states: ``(v,)``
         :type states: tuple
         :return: ``((analog_output,), updated_states)``
         :rtype: tuple[tuple[torch.Tensor, ...], tuple]
@@ -732,50 +731,14 @@ class LIAFNode(LIFNode):
         x = inputs[0]
         v = states[0]
 
-        if self.decay_input:
-            if self.v_reset is None or self.v_reset == 0.0:
-                charged = v + (x - v) / self.tau
-            else:
-                charged = v + (x - (v - self.v_reset)) / self.tau
-        else:
-            if self.v_reset is None or self.v_reset == 0.0:
-                charged = v * (1.0 - 1.0 / self.tau) + x
-            else:
-                charged = v - (v - self.v_reset) / self.tau + x
+        charged = functional.lif_charge(x, v, self.tau, self.decay_input, self.v_reset)
         y = self.act(charged - self.v_threshold if self.threshold_related else charged)
         spike = self.surrogate_function(charged - self.v_threshold)
-        reset_spike = spike.detach() if self.detach_reset else spike
-        if self.v_reset is None:
-            v = charged - reset_spike * self.v_threshold
-        else:
-            v = reset_spike * self.v_reset + (1.0 - reset_spike) * charged
+        v = functional.voltage_reset(
+            charged,
+            spike,
+            self.v_threshold,
+            self.v_reset,
+            self.detach_reset,
+        )
         return (y,), (v, *states[1:])
-
-    def multi_step_functional_forward(
-        self,
-        inputs: tuple[torch.Tensor, ...],
-        states: tuple[object, ...],
-        **kwargs: object,
-    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
-        r"""Execute LIAF sequence forward with explicit state. / 使用显式状态执行 LIAF 序列前向。
-
-        :param inputs: 仅包含 ``x_seq`` 的元组 / Tuple containing only ``x_seq``
-        :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)`` 或 ``(v, v_seq)``
-        :type states: tuple
-        :return: ``((analog_output_seq,), updated_states)``
-        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
-        """
-        outputs = []
-        voltages = []
-        v = states[0]
-        x_seq = inputs[0]
-        for t in range(x_seq.shape[0]):
-            x = x_seq[t]
-            (y,), (v, *_) = self.single_step_functional_forward((x,), (v, *states[1:]))
-            outputs.append(y)
-            if self.store_v_seq:
-                voltages.append(v)
-        v_seq = torch.stack(voltages) if self.store_v_seq else None
-        updated_states = (v, v_seq) if self.store_v_seq else (v,)
-        return (torch.stack(outputs),), updated_states

--- a/spikingjelly/activation_based/neuron/lif_variants.py
+++ b/spikingjelly/activation_based/neuron/lif_variants.py
@@ -225,9 +225,25 @@ class GatedLIFNode(base.MemoryModule):
             self.u - self.v_threshold.view(1, -1, 1, 1).sigmoid()
         )
 
-    def multi_step_forward(self, x_seq: torch.Tensor):
-        if not isinstance(self.v, torch.Tensor):
-            self.v = torch.full_like(x_seq[0], self.v)
+    def materialize_states(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        step_mode: str,
+    ) -> tuple[object, ...]:
+        v = states[0]
+        if not isinstance(v, torch.Tensor):
+            v = torch.full_like(inputs[0][0], v)
+        return v, states[1]
+
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x_seq = inputs[0]
+        v = states[0]
         alpha = self.alpha.view(1, -1, 1, 1).sigmoid()
         beta = self.beta.view(1, -1, 1, 1).sigmoid()
         gamma = self.gamma.view(1, -1, 1, 1).sigmoid()
@@ -238,7 +254,6 @@ class GatedLIFNode(base.MemoryModule):
 
         spike = torch.zeros(x_seq.shape[1:], device=x_seq.device)
         spike_seq = []
-        v = self.v
         for t in range(self.T):
             spike, v = functional.gated_lif_step(
                 x_seq[t],
@@ -255,8 +270,7 @@ class GatedLIFNode(base.MemoryModule):
                 self.surrogate_function,
             )
             spike_seq.append(spike)
-        self.u = self.v = v
-        return torch.stack(spike_seq)
+        return (torch.stack(spike_seq),), (v, v)
 
 
 class KLIFNode(BaseNode):
@@ -526,6 +540,32 @@ class KLIFNode(BaseNode):
         else:
             self.v = self.apply_hard_reset(v, spike_d, self.v_reset)
 
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        v = states[0]
+        v_reset = 0.0 if self.v_reset is None else self.v_reset
+        if self.decay_input:
+            v = self.neuronal_charge_decay_input(x, v, v_reset, self.tau, self.k)
+        else:
+            v = self.neuronal_charge_no_decay_input(x, v, v_reset, self.tau, self.k)
+        spike = self.surrogate_function(v - self.v_threshold)
+        reset_spike = spike.detach() if self.detach_reset else spike
+        if self.scale_reset:
+            v = v / self.k
+            v_threshold = self.v_threshold / self.k
+        else:
+            v_threshold = self.v_threshold
+        if self.v_reset is None:
+            v = self.apply_soft_reset(v, reset_spike, v_threshold)
+        else:
+            v = self.apply_hard_reset(v, reset_spike, self.v_reset)
+        return (spike,), (v, *states[1:])
+
 
 class CUBALIFNode(BaseNode):
     def __init__(
@@ -570,18 +610,41 @@ class CUBALIFNode(BaseNode):
         self.c = self.c * self.c_decay + x
         self.v = self.v * self.v_decay + self.c
 
-    def single_step_forward(self, x: torch.Tensor):
-        self.v_float_to_tensor(x)
-        self.c_float_to_tensor(x)
-        self.neuronal_charge(x)
-        spike = self.neuronal_fire()
-        self.neuronal_reset(spike)
-        return spike
+    def materialize_states(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        step_mode: str,
+    ) -> tuple[object, ...]:
+        states = super().materialize_states(inputs, states, step_mode)
+        x = states[0]
+        c = states[1]
+        if isinstance(c, float):
+            c = torch.full_like(x, c, requires_grad=False)
+        elif isinstance(c, torch.Tensor):
+            if c.shape != x.shape:
+                c = torch.zeros_like(x, requires_grad=False)
+            elif c.dtype != x.dtype or c.device != x.device:
+                c = c.to(dtype=x.dtype, device=x.device)
+        return (states[0], c, *states[2:])
 
-    def c_float_to_tensor(self, c: torch.Tensor):
-        if isinstance(self.c, float):
-            c_init = self.c
-            self.c = torch.full_like(c, fill_value=c_init)
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        v, c = states
+        c = c * self.c_decay + x
+        v = v * self.v_decay + c
+        spike = self.surrogate_function(v - self.v_threshold)
+        reset_spike = spike.detach() if self.detach_reset else spike
+        if self.v_reset is None:
+            v = self.apply_soft_reset(v, reset_spike, self.v_threshold)
+        else:
+            v = self.apply_hard_reset(v, reset_spike, self.v_reset)
+        return (spike,), (v, c)
 
 
 class LIAFNode(LIFNode):
@@ -651,9 +714,68 @@ class LIAFNode(LIFNode):
     def supported_backends(self):
         return ("torch",)
 
-    def single_step_forward(self, x: torch.Tensor):
-        self.neuronal_charge(x)
-        y = self.act(self.v - self.v_threshold if self.threshold_related else self.v)
-        spike = self.neuronal_fire()
-        self.neuronal_reset(spike)
-        return y
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        r"""Execute one LIAF step with explicit state. / 使用显式状态执行一个 LIAF 时间步。
+
+        :param inputs: 仅包含 ``x`` 的元组 / Tuple containing only ``x``
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :type states: tuple
+        :return: ``((analog_output,), updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
+        """
+        x = inputs[0]
+        v = states[0]
+
+        if self.decay_input:
+            if self.v_reset is None or self.v_reset == 0.0:
+                charged = v + (x - v) / self.tau
+            else:
+                charged = v + (x - (v - self.v_reset)) / self.tau
+        else:
+            if self.v_reset is None or self.v_reset == 0.0:
+                charged = v * (1.0 - 1.0 / self.tau) + x
+            else:
+                charged = v - (v - self.v_reset) / self.tau + x
+        y = self.act(charged - self.v_threshold if self.threshold_related else charged)
+        spike = self.surrogate_function(charged - self.v_threshold)
+        reset_spike = spike.detach() if self.detach_reset else spike
+        if self.v_reset is None:
+            v = charged - reset_spike * self.v_threshold
+        else:
+            v = reset_spike * self.v_reset + (1.0 - reset_spike) * charged
+        return (y,), (v, *states[1:])
+
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        r"""Execute LIAF sequence forward with explicit state. / 使用显式状态执行 LIAF 序列前向。
+
+        :param inputs: 仅包含 ``x_seq`` 的元组 / Tuple containing only ``x_seq``
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :type states: tuple
+        :return: ``((analog_output_seq,), updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
+        """
+        outputs = []
+        voltages = []
+        v = states[0]
+        x_seq = inputs[0]
+        for t in range(x_seq.shape[0]):
+            x = x_seq[t]
+            (y,), (v, *_) = self.single_step_functional_forward((x,), (v, *states[1:]))
+            outputs.append(y)
+            if self.store_v_seq:
+                voltages.append(v)
+        v_seq = torch.stack(voltages) if self.store_v_seq else None
+        updated_states = (v, v_seq) if self.store_v_seq else (v,)
+        return (torch.stack(outputs),), updated_states

--- a/spikingjelly/activation_based/neuron/lif_variants.py
+++ b/spikingjelly/activation_based/neuron/lif_variants.py
@@ -731,14 +731,16 @@ class LIAFNode(LIFNode):
         x = inputs[0]
         v = states[0]
 
-        charged = functional.lif_charge(x, v, self.tau, self.decay_input, self.v_reset)
-        y = self.act(charged - self.v_threshold if self.threshold_related else charged)
-        spike = self.surrogate_function(charged - self.v_threshold)
-        v = functional.voltage_reset(
-            charged,
-            spike,
+        y, v = functional.liaf_step(
+            x,
+            v,
+            self.tau,
+            self.decay_input,
             self.v_threshold,
             self.v_reset,
+            self.act,
+            self.threshold_related,
+            self.surrogate_function,
             self.detach_reset,
         )
         return (y,), (v, *states[1:])

--- a/spikingjelly/activation_based/neuron/mpbn.py
+++ b/spikingjelly/activation_based/neuron/mpbn.py
@@ -298,7 +298,6 @@ class MPBNLIFNode(MPBNBaseNode):
         }
 
     def forward(self, *args, **kwargs):
-        r"""Run the regular forward path and commit MPBN running statistics. / 执行常规前向并提交 MPBN 运行统计量。"""
         stats = self._normalization_state()
         kwargs["_mpbn_stats"] = stats
         output = super().forward(*args, **kwargs)
@@ -319,7 +318,6 @@ class MPBNLIFNode(MPBNBaseNode):
         states: tuple[object, ...],
         **kwargs: object,
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
-        r"""Run a pure MPBN sequence transition. / 执行纯 MPBN 序列状态转移。"""
         if "_mpbn_stats" not in kwargs:
             kwargs["_mpbn_stats"] = self._normalization_state()
         return super().multi_step_functional_forward(inputs, states, **kwargs)
@@ -330,7 +328,6 @@ class MPBNLIFNode(MPBNBaseNode):
         states: tuple[object, ...],
         **kwargs: object,
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
-        r"""Run a pure MPBN single-step transition. / 执行纯 MPBN 单步状态转移。"""
         x = inputs[0]
         v = states[0]
         stats = kwargs.get("_mpbn_stats")

--- a/spikingjelly/activation_based/neuron/mpbn.py
+++ b/spikingjelly/activation_based/neuron/mpbn.py
@@ -224,40 +224,6 @@ class MPBNBaseNode(BaseNode):
             self.v = self.v.masked_scatter(mask, normalized_residual)
         return spike
 
-    def single_step_forward(self, x: torch.Tensor):
-        """
-        **API Language** - :ref:`中文 <MPBNBaseNode.single_step_forward-cn>` | :ref:`English <MPBNBaseNode.single_step_forward-en>`
-
-        ----
-
-        .. _MPBNBaseNode.single_step_forward-cn:
-
-        * **中文**
-
-        :param x: 当前时间步输入张量（2D 或 4D）
-        :type x: torch.Tensor
-        :return: 当前时间步输出脉冲
-        :rtype: torch.Tensor
-        :raises NotImplementedError: 当输入维度不是 2D 或 4D 时，内部放电逻辑会抛出异常
-
-        ----
-
-        .. _MPBNBaseNode.single_step_forward-en:
-
-        * **English**
-
-        :param x: Input tensor at current time step (2D or 4D)
-        :type x: torch.Tensor
-        :return: Output spike at current time step
-        :rtype: torch.Tensor
-        :raises NotImplementedError: Raised by internal firing logic when input rank is neither 2D nor 4D
-        """
-        self.v_float_to_tensor(x)
-        self.neuronal_charge(x)
-        spike = self.neuronal_fire()
-        self.neuronal_reset(spike)
-        return spike
-
     def re_parameterize_v_threshold(
         self, normalize_residual: bool = False, running_stats: bool = False
     ):
@@ -397,3 +363,58 @@ class MPBNLIFNode(MPBNBaseNode):
                 self.v = LIFNode.neuronal_charge_no_decay_input(
                     x, self.v, self.v_reset, self.tau
                 )
+
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        v = states[0]
+        if self.decay_input:
+            if self.v_reset is None or self.v_reset == 0.0:
+                v = LIFNode.neuronal_charge_decay_input_reset0(x, v, self.tau)
+            else:
+                v = LIFNode.neuronal_charge_decay_input(x, v, self.v_reset, self.tau)
+        elif self.v_reset is None or self.v_reset == 0.0:
+            v = LIFNode.neuronal_charge_no_decay_input_reset0(x, v, self.tau)
+        else:
+            v = LIFNode.neuronal_charge_no_decay_input(x, v, self.v_reset, self.tau)
+        v = self.vbn(v)
+        if self.fold_bn and not self.learnable_vth and self.training:
+            self.compute_running_stats(v)
+
+        feature_shape = (1, -1) if v.ndim == 2 else (1, -1, 1, 1)
+        if self.fold_bn and not self.learnable_vth:
+            threshold = (self.v_threshold - self.beta) * torch.sqrt(
+                self.sigma2 + self.eps
+            ) / self.gamma + self.mu
+        elif self.learnable_vth:
+            threshold = torch.exp(self.a)
+        else:
+            threshold = self.v_threshold
+        if self.fold_bn or self.learnable_vth:
+            threshold = threshold.view(feature_shape)
+        diff = v - threshold
+        spike = self.surrogate_function(diff)
+
+        if self.normalize_residual:
+            mask = diff <= 0
+            gamma = self.gamma.view(feature_shape).expand_as(mask)
+            mu = self.mu.view(feature_shape).expand_as(mask)
+            beta = self.beta.view(feature_shape).expand_as(mask)
+            sigma = (
+                torch.sqrt(self.sigma2 + self.eps).view(feature_shape).expand_as(mask)
+            )
+            normalized_residual = (v[mask] - mu[mask]) / sigma[mask] * gamma[
+                mask
+            ] + beta[mask]
+            v = v.masked_scatter(mask, normalized_residual)
+
+        reset_spike = spike.detach() if self.detach_reset else spike
+        if self.v_reset is None:
+            v = self.apply_soft_reset(v, reset_spike, self.v_threshold)
+        else:
+            v = self.apply_hard_reset(v, reset_spike, self.v_reset)
+        return (spike,), (v, *states[1:])

--- a/spikingjelly/activation_based/neuron/mpbn.py
+++ b/spikingjelly/activation_based/neuron/mpbn.py
@@ -2,10 +2,10 @@ from typing import Optional
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
-from .. import surrogate
+from .. import functional, surrogate
 from .base_node import BaseNode
-from .lif import LIFNode
 
 __all__ = ["MPBNBaseNode", "MPBNLIFNode"]
 
@@ -128,9 +128,9 @@ class MPBNBaseNode(BaseNode):
         feature_count = out_channels if out_channels is not None else out_features
         if mpbn:
             self.vbn = (
-                nn.LazyBatchNorm2d()
+                nn.BatchNorm2d(feature_count)
                 if out_channels is not None
-                else nn.LazyBatchNorm1d()
+                else nn.BatchNorm1d(feature_count)
             )
         else:
             self.vbn = nn.Identity()
@@ -152,77 +152,6 @@ class MPBNBaseNode(BaseNode):
         self.learnable_vth = learnable_vth
         if learnable_vth:  # force the threshold to be positive
             self.a = nn.Parameter(torch.zeros(feature_count))
-
-    def compute_running_stats(
-        self, v: torch.Tensor
-    ):  # you can disable this completely by overiding it in subclasses
-        if v.ndim not in (2, 4):
-            raise NotImplementedError(
-                f"Only 2D and 4D tensor are supported, but got {v.ndim}D tensor."
-            )
-        if v.ndim == 2 and v.shape[0] == 1:
-            return
-
-        reduce_dims = 0 if v.ndim == 2 else (0, 2, 3)
-        mu = torch.mean(v, dim=reduce_dims).detach()
-        sigma2 = torch.var(v, dim=reduce_dims, unbiased=True).detach()
-        if self.running_stats and self.mu is not None:
-            self.mu = self.mu.detach() * (1 - self.bn_momentum) + mu * self.bn_momentum
-            self.sigma2 = (
-                self.sigma2.detach() * (1 - self.bn_momentum)
-                + sigma2 * self.bn_momentum
-            )
-            self.bn_momentum = max(
-                self.bn_momentum * self.bn_decay_momentum, self.bn_min_momentum
-            )
-        else:
-            self.mu = mu
-            self.sigma2 = sigma2
-
-    def pre_charge(self, x: torch.Tensor):
-        raise NotImplementedError(
-            "This method should be implemented in subclasses, e.g. the charging function of LIF neuron."
-        )
-
-    def neuronal_charge(self, x: torch.Tensor):
-        self.pre_charge(x)
-        self.v = self.vbn(self.v)
-        if self.fold_bn and not self.learnable_vth and self.training:
-            self.compute_running_stats(self.v)
-
-    def neuronal_fire(self):
-        if self.v.ndim not in (2, 4):
-            raise NotImplementedError(
-                f"Only 2D and 4D tensors are supported, but got {self.v.ndim}D tensors."
-            )
-
-        feature_shape = (1, -1) if self.v.ndim == 2 else (1, -1, 1, 1)
-        if self.fold_bn and not self.learnable_vth:
-            threshold = (self.v_threshold - self.beta) * torch.sqrt(
-                self.sigma2 + self.eps
-            ) / self.gamma + self.mu
-        elif self.learnable_vth:
-            threshold = torch.exp(self.a)
-        else:
-            threshold = self.v_threshold
-        if self.fold_bn or self.learnable_vth:
-            threshold = threshold.view(feature_shape)
-        diff = self.v - threshold
-        spike = self.surrogate_function(diff)
-
-        if self.normalize_residual:
-            mask = diff <= 0
-            gamma = self.gamma.view(feature_shape).expand_as(mask)
-            mu = self.mu.view(feature_shape).expand_as(mask)
-            beta = self.beta.view(feature_shape).expand_as(mask)
-            sigma = (
-                torch.sqrt(self.sigma2 + self.eps).view(feature_shape).expand_as(mask)
-            )
-            normalized_residual = (self.v[mask] - mu[mask]) / sigma[mask] * gamma[
-                mask
-            ] + beta[mask]
-            self.v = self.v.masked_scatter(mask, normalized_residual)
-        return spike
 
     def re_parameterize_v_threshold(
         self, normalize_residual: bool = False, running_stats: bool = False
@@ -346,23 +275,54 @@ class MPBNLIFNode(MPBNBaseNode):
     def supported_backends(self):
         return "torch"
 
-    def pre_charge(self, x: torch.Tensor):
-        if self.decay_input:
-            if self.v_reset is None or self.v_reset == 0.0:
-                self.v = LIFNode.neuronal_charge_decay_input_reset0(x, self.v, self.tau)
-            else:
-                self.v = LIFNode.neuronal_charge_decay_input(
-                    x, self.v, self.v_reset, self.tau
-                )
-        else:
-            if self.v_reset is None or self.v_reset == 0.0:
-                self.v = LIFNode.neuronal_charge_no_decay_input_reset0(
-                    x, self.v, self.tau
-                )
-            else:
-                self.v = LIFNode.neuronal_charge_no_decay_input(
-                    x, self.v, self.v_reset, self.tau
-                )
+    def _normalization_state(self):
+        return {
+            "running_mean": (
+                self.vbn.running_mean.clone()
+                if not isinstance(self.vbn, nn.Identity)
+                else None
+            ),
+            "running_var": (
+                self.vbn.running_var.clone()
+                if not isinstance(self.vbn, nn.Identity)
+                else None
+            ),
+            "num_batches_tracked": (
+                self.vbn.num_batches_tracked.clone()
+                if not isinstance(self.vbn, nn.Identity)
+                else None
+            ),
+            "mu": self.mu,
+            "sigma2": self.sigma2,
+            "bn_momentum": self.bn_momentum,
+        }
+
+    def forward(self, *args, **kwargs):
+        r"""Run the regular forward path and commit MPBN running statistics. / 执行常规前向并提交 MPBN 运行统计量。"""
+        stats = self._normalization_state()
+        kwargs["_mpbn_stats"] = stats
+        output = super().forward(*args, **kwargs)
+        if self.training:
+            if not isinstance(self.vbn, nn.Identity):
+                self.vbn.running_mean.copy_(stats["running_mean"])
+                self.vbn.running_var.copy_(stats["running_var"])
+                self.vbn.num_batches_tracked.copy_(stats["num_batches_tracked"])
+            elif self.fold_bn and not self.learnable_vth:
+                self.mu = stats["mu"]
+                self.sigma2 = stats["sigma2"]
+                self.bn_momentum = stats["bn_momentum"]
+        return output
+
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        r"""Run a pure MPBN sequence transition. / 执行纯 MPBN 序列状态转移。"""
+        if "_mpbn_stats" not in kwargs:
+            kwargs["_mpbn_stats"] = self._normalization_state()
+        return super().multi_step_functional_forward(inputs, states, **kwargs)
 
     def single_step_functional_forward(
         self,
@@ -370,26 +330,69 @@ class MPBNLIFNode(MPBNBaseNode):
         states: tuple[object, ...],
         **kwargs: object,
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        r"""Run a pure MPBN single-step transition. / 执行纯 MPBN 单步状态转移。"""
         x = inputs[0]
         v = states[0]
-        if self.decay_input:
-            if self.v_reset is None or self.v_reset == 0.0:
-                v = LIFNode.neuronal_charge_decay_input_reset0(x, v, self.tau)
+        stats = kwargs.get("_mpbn_stats")
+        if stats is None:
+            stats = self._normalization_state()
+        v = functional.lif_charge(x, v, self.tau, self.decay_input, self.v_reset)
+
+        if not isinstance(self.vbn, nn.Identity):
+            running_mean = stats["running_mean"]
+            running_var = stats["running_var"]
+            batches_tracked = stats["num_batches_tracked"]
+            exponential_average_factor = (
+                0.0 if self.vbn.momentum is None else self.vbn.momentum
+            )
+            if self.training:
+                batches_tracked.add_(1)
+                if self.vbn.momentum is None:
+                    exponential_average_factor = 1.0 / float(batches_tracked)
+            v = F.batch_norm(
+                v,
+                running_mean,
+                running_var,
+                self.vbn.weight,
+                self.vbn.bias,
+                self.training,
+                exponential_average_factor,
+                self.vbn.eps,
+            )
+
+        mu = stats["mu"]
+        sigma2 = stats["sigma2"]
+        bn_momentum = stats["bn_momentum"]
+        if (
+            self.fold_bn
+            and not self.learnable_vth
+            and self.training
+            and not (v.ndim == 2 and v.shape[0] == 1)
+        ):
+            reduce_dims = 0 if v.ndim == 2 else (0, 2, 3)
+            batch_mu = torch.mean(v, dim=reduce_dims).detach()
+            batch_sigma2 = torch.var(v, dim=reduce_dims, unbiased=True).detach()
+            if self.running_stats:
+                mu = mu.detach() * (1 - bn_momentum) + batch_mu * bn_momentum
+                sigma2 = (
+                    sigma2.detach() * (1 - bn_momentum) + batch_sigma2 * bn_momentum
+                )
+                bn_momentum = max(
+                    bn_momentum * self.bn_decay_momentum,
+                    self.bn_min_momentum,
+                )
             else:
-                v = LIFNode.neuronal_charge_decay_input(x, v, self.v_reset, self.tau)
-        elif self.v_reset is None or self.v_reset == 0.0:
-            v = LIFNode.neuronal_charge_no_decay_input_reset0(x, v, self.tau)
-        else:
-            v = LIFNode.neuronal_charge_no_decay_input(x, v, self.v_reset, self.tau)
-        v = self.vbn(v)
-        if self.fold_bn and not self.learnable_vth and self.training:
-            self.compute_running_stats(v)
+                mu = batch_mu
+                sigma2 = batch_sigma2
+            stats["mu"] = mu
+            stats["sigma2"] = sigma2
+            stats["bn_momentum"] = bn_momentum
 
         feature_shape = (1, -1) if v.ndim == 2 else (1, -1, 1, 1)
         if self.fold_bn and not self.learnable_vth:
             threshold = (self.v_threshold - self.beta) * torch.sqrt(
-                self.sigma2 + self.eps
-            ) / self.gamma + self.mu
+                sigma2 + self.eps
+            ) / self.gamma + mu
         elif self.learnable_vth:
             threshold = torch.exp(self.a)
         else:
@@ -402,19 +405,15 @@ class MPBNLIFNode(MPBNBaseNode):
         if self.normalize_residual:
             mask = diff <= 0
             gamma = self.gamma.view(feature_shape).expand_as(mask)
-            mu = self.mu.view(feature_shape).expand_as(mask)
+            mu = mu.view(feature_shape).expand_as(mask)
             beta = self.beta.view(feature_shape).expand_as(mask)
-            sigma = (
-                torch.sqrt(self.sigma2 + self.eps).view(feature_shape).expand_as(mask)
-            )
+            sigma = torch.sqrt(sigma2 + self.eps).view(feature_shape).expand_as(mask)
             normalized_residual = (v[mask] - mu[mask]) / sigma[mask] * gamma[
                 mask
             ] + beta[mask]
             v = v.masked_scatter(mask, normalized_residual)
 
-        reset_spike = spike.detach() if self.detach_reset else spike
-        if self.v_reset is None:
-            v = self.apply_soft_reset(v, reset_spike, self.v_threshold)
-        else:
-            v = self.apply_hard_reset(v, reset_spike, self.v_reset)
+        v = functional.voltage_reset(
+            v, spike, self.v_threshold, self.v_reset, self.detach_reset
+        )
         return (spike,), (v, *states[1:])

--- a/spikingjelly/activation_based/neuron/nonlinear_if.py
+++ b/spikingjelly/activation_based/neuron/nonlinear_if.py
@@ -164,6 +164,23 @@ class QIFNode(BaseNode):
             + (x + self.a0 * (self.v - self.v_rest) * (self.v - self.v_c)) / self.tau
         )
 
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        v = states[0]
+        v = v + (x + self.a0 * (v - self.v_rest) * (v - self.v_c)) / self.tau
+        spike = self.surrogate_function(v - self.v_threshold)
+        reset_spike = spike.detach() if self.detach_reset else spike
+        if self.v_reset is None:
+            v = self.apply_soft_reset(v, reset_spike, self.v_threshold)
+        else:
+            v = self.apply_hard_reset(v, reset_spike, self.v_reset)
+        return (spike,), (v, *states[1:])
+
     @property
     def supported_backends(self):
         if self.step_mode == "s":
@@ -173,14 +190,20 @@ class QIFNode(BaseNode):
         else:
             raise ValueError(self.step_mode)
 
-    def multi_step_forward(self, x_seq: torch.Tensor):
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         if self.backend == "torch":
-            return super().multi_step_forward(x_seq)
+            return super().multi_step_functional_forward(inputs, states, **kwargs)
         elif self.backend == "cupy":
-            self.v_float_to_tensor(x_seq[0])
-            spike_seq, self.v, v_seq = functional.qif_multi_step_cupy(
+            x_seq = inputs[0]
+            v = states[0]
+            spike_seq, v, v_seq = functional.qif_multi_step_cupy(
                 x_seq,
-                self.v,
+                v,
                 self.tau,
                 self.v_threshold,
                 self.v_reset,
@@ -191,9 +214,8 @@ class QIFNode(BaseNode):
                 self.surrogate_function,
                 self.store_v_seq,
             )
-            if self.store_v_seq:
-                self.v_seq = v_seq
-            return spike_seq
+            updated_states = (v, v_seq) if self.store_v_seq else (v,)
+            return (spike_seq,), updated_states
         else:
             raise ValueError(self.backend)
 
@@ -365,6 +387,32 @@ class EIFNode(BaseNode):
             / self.tau
         )
 
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        v = states[0]
+        v = (
+            v
+            + (
+                x
+                + self.v_rest
+                - v
+                + self.delta_T * torch.exp((v - self.theta_rh) / self.delta_T)
+            )
+            / self.tau
+        )
+        spike = self.surrogate_function(v - self.v_threshold)
+        reset_spike = spike.detach() if self.detach_reset else spike
+        if self.v_reset is None:
+            v = self.apply_soft_reset(v, reset_spike, self.v_threshold)
+        else:
+            v = self.apply_hard_reset(v, reset_spike, self.v_reset)
+        return (spike,), (v, *states[1:])
+
     @property
     def supported_backends(self):
         if self.step_mode == "s":
@@ -374,14 +422,20 @@ class EIFNode(BaseNode):
         else:
             raise ValueError(self.step_mode)
 
-    def multi_step_forward(self, x_seq: torch.Tensor):
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         if self.backend == "torch":
-            return super().multi_step_forward(x_seq)
+            return super().multi_step_functional_forward(inputs, states, **kwargs)
         elif self.backend == "cupy":
-            self.v_float_to_tensor(x_seq[0])
-            spike_seq, self.v, v_seq = functional.eif_multi_step_cupy(
+            x_seq = inputs[0]
+            v = states[0]
+            spike_seq, v, v_seq = functional.eif_multi_step_cupy(
                 x_seq,
-                self.v,
+                v,
                 self.tau,
                 self.v_threshold,
                 self.v_reset,
@@ -392,8 +446,7 @@ class EIFNode(BaseNode):
                 self.surrogate_function,
                 self.store_v_seq,
             )
-            if self.store_v_seq:
-                self.v_seq = v_seq
-            return spike_seq
+            updated_states = (v, v_seq) if self.store_v_seq else (v,)
+            return (spike_seq,), updated_states
         else:
             raise ValueError(self.backend)

--- a/spikingjelly/activation_based/neuron/nonlinear_if.py
+++ b/spikingjelly/activation_based/neuron/nonlinear_if.py
@@ -158,12 +158,6 @@ class QIFNode(BaseNode):
             + f", tau={self.tau}, v_c={self.v_c}, a0={self.a0}, v_rest={self.v_rest}"
         )
 
-    def neuronal_charge(self, x: torch.Tensor):
-        self.v = (
-            self.v
-            + (x + self.a0 * (self.v - self.v_rest) * (self.v - self.v_c)) / self.tau
-        )
-
     def single_step_functional_forward(
         self,
         inputs: tuple[torch.Tensor, ...],
@@ -395,22 +389,6 @@ class EIFNode(BaseNode):
         return (
             super().extra_repr()
             + f", tau={self.tau}, delta_T={self.delta_T}, theta_rh={self.theta_rh}"
-        )
-
-    def neuronal_charge(self, x: torch.Tensor):
-        with torch.no_grad():
-            if not isinstance(self.v, torch.Tensor):
-                self.v = torch.as_tensor(self.v, device=x.device)
-
-        self.v = (
-            self.v
-            + (
-                x
-                + self.v_rest
-                - self.v
-                + self.delta_T * torch.exp((self.v - self.theta_rh) / self.delta_T)
-            )
-            / self.tau
         )
 
     def single_step_functional_forward(

--- a/spikingjelly/activation_based/neuron/nonlinear_if.py
+++ b/spikingjelly/activation_based/neuron/nonlinear_if.py
@@ -172,13 +172,18 @@ class QIFNode(BaseNode):
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         x = inputs[0]
         v = states[0]
-        v = v + (x + self.a0 * (v - self.v_rest) * (v - self.v_c)) / self.tau
-        spike = self.surrogate_function(v - self.v_threshold)
-        reset_spike = spike.detach() if self.detach_reset else spike
-        if self.v_reset is None:
-            v = self.apply_soft_reset(v, reset_spike, self.v_threshold)
-        else:
-            v = self.apply_hard_reset(v, reset_spike, self.v_reset)
+        spike, v = functional.qif_step(
+            x,
+            v,
+            self.tau,
+            self.a0,
+            self.v_rest,
+            self.v_c,
+            self.v_threshold,
+            self.v_reset,
+            self.surrogate_function,
+            self.detach_reset,
+        )
         return (spike,), (v, *states[1:])
 
     @property
@@ -201,7 +206,7 @@ class QIFNode(BaseNode):
         elif self.backend == "cupy":
             x_seq = inputs[0]
             v = states[0]
-            spike_seq, v, v_seq = functional.qif_multi_step_cupy(
+            spike_seq, v, _ = functional.qif_multi_step_cupy(
                 x_seq,
                 v,
                 self.tau,
@@ -212,12 +217,33 @@ class QIFNode(BaseNode):
                 self.a0,
                 self.detach_reset,
                 self.surrogate_function,
-                self.store_v_seq,
+                False,
             )
-            updated_states = (v, v_seq) if self.store_v_seq else (v,)
-            return (spike_seq,), updated_states
+            return (spike_seq,), (v,)
         else:
             raise ValueError(self.backend)
+
+    def multi_step_forward(self, x_seq: torch.Tensor, *args, **kwargs):
+        if not self.store_v_seq or self.backend != "cupy":
+            return super().multi_step_forward(x_seq, *args, **kwargs)
+
+        states = self.materialize_states(
+            (x_seq, *args), tuple(self._memories.values()), "m"
+        )
+        spike_seq, self.v, self.v_seq = functional.qif_multi_step_cupy(
+            x_seq,
+            states[0],
+            self.tau,
+            self.v_threshold,
+            self.v_reset,
+            self.v_rest,
+            self.v_c,
+            self.a0,
+            self.detach_reset,
+            self.surrogate_function,
+            True,
+        )
+        return spike_seq
 
 
 class EIFNode(BaseNode):
@@ -395,22 +421,18 @@ class EIFNode(BaseNode):
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         x = inputs[0]
         v = states[0]
-        v = (
-            v
-            + (
-                x
-                + self.v_rest
-                - v
-                + self.delta_T * torch.exp((v - self.theta_rh) / self.delta_T)
-            )
-            / self.tau
+        spike, v = functional.eif_step(
+            x,
+            v,
+            self.tau,
+            self.delta_T,
+            self.theta_rh,
+            self.v_rest,
+            self.v_threshold,
+            self.v_reset,
+            self.surrogate_function,
+            self.detach_reset,
         )
-        spike = self.surrogate_function(v - self.v_threshold)
-        reset_spike = spike.detach() if self.detach_reset else spike
-        if self.v_reset is None:
-            v = self.apply_soft_reset(v, reset_spike, self.v_threshold)
-        else:
-            v = self.apply_hard_reset(v, reset_spike, self.v_reset)
         return (spike,), (v, *states[1:])
 
     @property
@@ -433,7 +455,7 @@ class EIFNode(BaseNode):
         elif self.backend == "cupy":
             x_seq = inputs[0]
             v = states[0]
-            spike_seq, v, v_seq = functional.eif_multi_step_cupy(
+            spike_seq, v, _ = functional.eif_multi_step_cupy(
                 x_seq,
                 v,
                 self.tau,
@@ -444,9 +466,30 @@ class EIFNode(BaseNode):
                 self.delta_T,
                 self.detach_reset,
                 self.surrogate_function,
-                self.store_v_seq,
+                False,
             )
-            updated_states = (v, v_seq) if self.store_v_seq else (v,)
-            return (spike_seq,), updated_states
+            return (spike_seq,), (v,)
         else:
             raise ValueError(self.backend)
+
+    def multi_step_forward(self, x_seq: torch.Tensor, *args, **kwargs):
+        if not self.store_v_seq or self.backend != "cupy":
+            return super().multi_step_forward(x_seq, *args, **kwargs)
+
+        states = self.materialize_states(
+            (x_seq, *args), tuple(self._memories.values()), "m"
+        )
+        spike_seq, self.v, self.v_seq = functional.eif_multi_step_cupy(
+            x_seq,
+            states[0],
+            self.tau,
+            self.v_threshold,
+            self.v_reset,
+            self.v_rest,
+            self.theta_rh,
+            self.delta_T,
+            self.detach_reset,
+            self.surrogate_function,
+            True,
+        )
+        return spike_seq

--- a/spikingjelly/activation_based/neuron/online_learning.py
+++ b/spikingjelly/activation_based/neuron/online_learning.py
@@ -21,25 +21,14 @@ class _OnlineLIFNode(LIFNode):
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         x = inputs[0]
         v = states[0]
-        if not self.training:
-            spike, v = self._eval_single_step_forward(
-                x,
-                v,
-                self.v_threshold,
-                self.v_reset,
-                self.tau,
-                self.decay_input,
-            )
-            return (spike,), (v, *states[1:])
-
         spike, v = functional.lif_step(
             x,
-            v.detach(),
+            v.detach() if self.training else v,
             self.tau,
             self.decay_input,
             self.v_threshold,
             self.v_reset,
-            self.surrogate_function,
+            self.surrogate_function if self.training else surrogate.heaviside,
             self.detach_reset,
         )
         return (spike,), (v, *states[1:])

--- a/spikingjelly/activation_based/neuron/online_learning.py
+++ b/spikingjelly/activation_based/neuron/online_learning.py
@@ -2,97 +2,47 @@ from typing import Optional
 
 import torch
 
-from .. import surrogate
+from .. import functional, surrogate
 from .lif import LIFNode
 
 __all__ = ["OTTTLIFNode", "SLTTLIFNode"]
 
 
 class _OnlineLIFNode(LIFNode):
-    def reset(self):
-        super().reset()
-        if hasattr(self, "v"):
-            del self.v
-        if hasattr(self, "trace"):
-            del self.trace
-
     @property
     def supported_backends(self):
         return "torch"
 
-    def neuronal_charge(self, x: torch.Tensor):
-        self.v = self.v.detach()
-        reset0 = self.v_reset is None or self.v_reset == 0.0
-        if self.decay_input:
-            if reset0:
-                self.v = self.neuronal_charge_decay_input_reset0(x, self.v, self.tau)
-            else:
-                self.v = self.neuronal_charge_decay_input(
-                    x, self.v, self.v_reset, self.tau
-                )
-        elif reset0:
-            self.v = self.neuronal_charge_no_decay_input_reset0(x, self.v, self.tau)
-        else:
-            self.v = self.neuronal_charge_no_decay_input(
-                x, self.v, self.v_reset, self.tau
-            )
-
-    def _training_output(self, spike: torch.Tensor):
-        return spike
-
-    def single_step_forward(self, x: torch.Tensor):
-        r"""
-        **API Language** - :ref:`中文 <OnlineLIFNode.single_step_forward-cn>` | :ref:`English <OnlineLIFNode.single_step_forward-en>`
-
-        ----
-
-        .. _OnlineLIFNode.single_step_forward-cn:
-
-        * **中文**
-
-        执行一个时间步。训练模式下，SLTT 返回脉冲，OTTT 返回
-        ``[spike, trace]``；推理模式下二者均返回脉冲。
-
-        :param x: 当前时间步的输入
-        :type x: torch.Tensor
-        :return: 当前脉冲，或 OTTT 训练使用的 ``[spike, trace]``
-        :rtype: Union[torch.Tensor, list[torch.Tensor]]
-
-        ----
-
-        .. _OnlineLIFNode.single_step_forward-en:
-
-        * **English**
-
-        Run one time step. In training mode SLTT returns the spike and
-        OTTT returns ``[spike, trace]``; both return the spike in evaluation mode.
-
-        :param x: input at the current time step
-        :type x: torch.Tensor
-        :return: current spike, or ``[spike, trace]`` for OTTT training
-        :rtype: Union[torch.Tensor, list[torch.Tensor]]
-        """
-        if not hasattr(self, "v"):
-            self.register_buffer(
-                "v",
-                torch.full_like(x, 0.0 if self.v_reset is None else self.v_reset),
-            )
-
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        v = states[0]
         if not self.training:
-            spike, self.v = self._eval_single_step_forward(
+            spike, v = self._eval_single_step_forward(
                 x,
-                self.v,
+                v,
                 self.v_threshold,
                 self.v_reset,
                 self.tau,
                 self.decay_input,
             )
-            return spike
+            return (spike,), (v, *states[1:])
 
-        self.neuronal_charge(x)
-        spike = self.neuronal_fire()
-        self.neuronal_reset(spike)
-        return self._training_output(spike)
+        spike, v = functional.lif_step(
+            x,
+            v.detach(),
+            self.tau,
+            self.decay_input,
+            self.v_threshold,
+            self.v_reset,
+            self.surrogate_function,
+            self.detach_reset,
+        )
+        return (spike,), (v, *states[1:])
 
 
 class OTTTLIFNode(_OnlineLIFNode):
@@ -228,13 +178,19 @@ class OTTTLIFNode(_OnlineLIFNode):
         assert step_mode == "s", (
             "Please use single-step mode to enable memory-efficient training."
         )
-        """
-        膜电位将在前向传播过程中重新登记为缓存，以支持多卡分布式训练的情况下保留信息在各时刻进行多次反向传播
+        self.register_memory("trace", None)
 
-        membrane potential will be registered as buffer during forward, to support multiple backpropagation for all time steps with
-        reserved informtion under distributed training on multiple GPUs
-        """
-        self._memories.pop("v")
+    def materialize_states(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        step_mode: str,
+    ) -> tuple[object, ...]:
+        states = super().materialize_states(inputs, states, step_mode)
+        trace = states[1]
+        if self.training and trace is None:
+            trace = torch.zeros_like(states[0])
+        return states[0], trace
 
     @staticmethod
     def track_trace(spike: torch.Tensor, trace: torch.Tensor, tau: float):
@@ -242,11 +198,23 @@ class OTTTLIFNode(_OnlineLIFNode):
             trace = trace * (1.0 - 1.0 / tau) + spike
         return trace
 
-    def _training_output(self, spike: torch.Tensor):
-        if not hasattr(self, "trace"):
-            self.register_buffer("trace", torch.zeros_like(spike))
-        self.trace = self.track_trace(spike, self.trace, self.tau)
-        return [spike, self.trace]
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        (spike,), (v, trace) = super().single_step_functional_forward(
+            inputs, states, **kwargs
+        )
+        if not self.training:
+            return (spike,), (v, trace)
+        trace = self.track_trace(spike, trace, self.tau)
+        return (spike, trace), (v, trace)
+
+    def single_step_forward(self, x: torch.Tensor) -> torch.Tensor | list[torch.Tensor]:
+        outputs = super().single_step_forward(x)
+        return list(outputs) if isinstance(outputs, tuple) else outputs
 
 
 class SLTTLIFNode(_OnlineLIFNode):
@@ -382,4 +350,3 @@ class SLTTLIFNode(_OnlineLIFNode):
         assert step_mode == "s", (
             "Please use single-step mode to enable memory-efficient training."
         )
-        self._memories.pop("v")

--- a/spikingjelly/activation_based/neuron/plif.py
+++ b/spikingjelly/activation_based/neuron/plif.py
@@ -183,7 +183,7 @@ class ParametricLIFNode(BaseNode):
 
         :param inputs: 仅包含 ``x`` 的元组 / Tuple containing only ``x``
         :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :param states: ``(v,)``
         :type states: tuple
         :return: ``((spike,), updated_states)``
         :rtype: tuple[tuple[torch.Tensor, ...], tuple]
@@ -212,7 +212,7 @@ class ParametricLIFNode(BaseNode):
 
         :param inputs: 仅包含 ``x_seq`` 的元组 / Tuple containing only ``x_seq``
         :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :param states: ``(v,)``
         :type states: tuple
         :return: ``((spike_seq,), updated_states)``
         :rtype: tuple[tuple[torch.Tensor, ...], tuple]
@@ -221,7 +221,7 @@ class ParametricLIFNode(BaseNode):
         v = states[0]
 
         if self.backend == "inductor":
-            spike_seq, v, v_seq = functional.plif_multi_step_inductor(
+            spike_seq, v, _ = functional.plif_multi_step_inductor(
                 x_seq,
                 v,
                 self.w,
@@ -230,10 +230,10 @@ class ParametricLIFNode(BaseNode):
                 self.v_reset,
                 self.surrogate_function,
                 self.detach_reset,
-                self.store_v_seq,
+                False,
             )
         elif self.backend == "cupy":
-            spike_seq, v, v_seq = functional.plif_multi_step_cupy(
+            spike_seq, v, _ = functional.plif_multi_step_cupy(
                 x_seq,
                 v,
                 self.w,
@@ -242,10 +242,10 @@ class ParametricLIFNode(BaseNode):
                 self.v_reset,
                 self.surrogate_function,
                 self.detach_reset,
-                self.store_v_seq,
+                False,
             )
         elif self.backend == "triton":
-            spike_seq, v, v_seq = functional.plif_multi_step_triton(
+            spike_seq, v, _ = functional.plif_multi_step_triton(
                 x_seq,
                 v,
                 self.w,
@@ -254,30 +254,38 @@ class ParametricLIFNode(BaseNode):
                 self.v_reset,
                 self.surrogate_function,
                 self.detach_reset,
-                self.store_v_seq,
+                False,
             )
         elif self.backend == "torch":
-            spikes = []
-            voltages = []
-            for t in range(x_seq.shape[0]):
-                x = x_seq[t]
-                spike, v = functional.plif_step(
-                    x,
-                    v,
-                    self.w,
-                    self.decay_input,
-                    self.v_threshold,
-                    self.v_reset,
-                    self.surrogate_function,
-                    self.detach_reset,
-                )
-                spikes.append(spike)
-                if self.store_v_seq:
-                    voltages.append(v)
-            spike_seq = torch.stack(spikes)
-            v_seq = torch.stack(voltages) if self.store_v_seq else None
+            return super().multi_step_functional_forward(inputs, states, **kwargs)
         else:
             raise ValueError(self.backend)
 
-        updated_states = (v, v_seq) if self.store_v_seq else (v,)
-        return (spike_seq,), updated_states
+        return (spike_seq,), (v,)
+
+    def multi_step_forward(self, x_seq: torch.Tensor, *args, **kwargs):
+        if not self.store_v_seq or self.backend == "torch":
+            return super().multi_step_forward(x_seq, *args, **kwargs)
+
+        states = self.materialize_states(
+            (x_seq, *args), tuple(self._memories.values()), "m"
+        )
+        function = {
+            "inductor": functional.plif_multi_step_inductor,
+            "cupy": functional.plif_multi_step_cupy,
+            "triton": functional.plif_multi_step_triton,
+        }[self.backend]
+        spike_seq, v, v_seq = function(
+            x_seq,
+            states[0],
+            self.w,
+            self.decay_input,
+            self.v_threshold,
+            self.v_reset,
+            self.surrogate_function,
+            self.detach_reset,
+            True,
+        )
+        self.v = v
+        self.v_seq = v_seq
+        return spike_seq

--- a/spikingjelly/activation_based/neuron/plif.py
+++ b/spikingjelly/activation_based/neuron/plif.py
@@ -1,4 +1,3 @@
-from spikingjelly.logger import logger
 import math
 from typing import Optional
 
@@ -7,12 +6,6 @@ import torch.nn as nn
 
 from .. import functional, surrogate
 from .base_node import BaseNode
-
-try:
-    from .. import triton_kernel
-except (ImportError, OSError) as e:
-    logger.debug("spikingjelly.activation_based.neuron: %s", e)
-    triton_kernel = None
 
 
 __all__ = ["ParametricLIFNode"]
@@ -180,33 +173,57 @@ class ParametricLIFNode(BaseNode):
             else:
                 self.v = self.v - (self.v - self.v_reset) * self.w.sigmoid() + x
 
-    def _inductor_multi_step_forward(self, x_seq: torch.Tensor):
-        self.v_float_to_tensor(x_seq[0])
-        spike_seq, self.v, v_seq = functional.plif_multi_step_inductor(
-            x_seq,
-            self.v,
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        r"""Execute one PLIF step with explicit state. / 使用显式状态执行一个 PLIF 时间步。
+
+        :param inputs: 仅包含 ``x`` 的元组 / Tuple containing only ``x``
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :type states: tuple
+        :return: ``((spike,), updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
+        """
+        x = inputs[0]
+        v = states[0]
+        spike, v = functional.plif_step(
+            x,
+            v,
             self.w,
             self.decay_input,
             self.v_threshold,
             self.v_reset,
             self.surrogate_function,
             self.detach_reset,
-            self.store_v_seq,
         )
-        if self.store_v_seq:
-            self.v_seq = v_seq
-        return spike_seq
+        return (spike,), (v, *states[1:])
 
-    def multi_step_forward(self, x_seq: torch.Tensor):
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        r"""Execute PLIF sequence forward with explicit state. / 使用显式状态执行 PLIF 序列前向。
+
+        :param inputs: 仅包含 ``x_seq`` 的元组 / Tuple containing only ``x_seq``
+        :type inputs: tuple[torch.Tensor, ...]
+        :param states: ``(v,)`` 或 ``(v, v_seq)``
+        :type states: tuple
+        :return: ``((spike_seq,), updated_states)``
+        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
+        """
+        x_seq = inputs[0]
+        v = states[0]
+
         if self.backend == "inductor":
-            return self._inductor_multi_step_forward(x_seq)
-        elif self.backend == "torch":
-            return super().multi_step_forward(x_seq)
-        elif self.backend == "cupy":
-            self.v_float_to_tensor(x_seq[0])
-            spike_seq, self.v, v_seq = functional.plif_multi_step_cupy(
+            spike_seq, v, v_seq = functional.plif_multi_step_inductor(
                 x_seq,
-                self.v,
+                v,
                 self.w,
                 self.decay_input,
                 self.v_threshold,
@@ -215,24 +232,52 @@ class ParametricLIFNode(BaseNode):
                 self.detach_reset,
                 self.store_v_seq,
             )
-            if self.store_v_seq:
-                self.v_seq = v_seq
-            return spike_seq
-        elif self.backend == "triton":
-            self.v_float_to_tensor(x_seq[0])
-            spike_seq, v_seq = triton_kernel.multistep_plif(
+        elif self.backend == "cupy":
+            spike_seq, v, v_seq = functional.plif_multi_step_cupy(
                 x_seq,
-                self.v,
-                self.w.sigmoid().to(x_seq),
+                v,
+                self.w,
                 self.decay_input,
                 self.v_threshold,
                 self.v_reset,
-                self.detach_reset,
                 self.surrogate_function,
+                self.detach_reset,
+                self.store_v_seq,
             )
-            if self.store_v_seq:
-                self.v_seq = v_seq
-            self.v = v_seq[-1].clone()
-            return spike_seq
+        elif self.backend == "triton":
+            spike_seq, v, v_seq = functional.plif_multi_step_triton(
+                x_seq,
+                v,
+                self.w,
+                self.decay_input,
+                self.v_threshold,
+                self.v_reset,
+                self.surrogate_function,
+                self.detach_reset,
+                self.store_v_seq,
+            )
+        elif self.backend == "torch":
+            spikes = []
+            voltages = []
+            for t in range(x_seq.shape[0]):
+                x = x_seq[t]
+                spike, v = functional.plif_step(
+                    x,
+                    v,
+                    self.w,
+                    self.decay_input,
+                    self.v_threshold,
+                    self.v_reset,
+                    self.surrogate_function,
+                    self.detach_reset,
+                )
+                spikes.append(spike)
+                if self.store_v_seq:
+                    voltages.append(v)
+            spike_seq = torch.stack(spikes)
+            v_seq = torch.stack(voltages) if self.store_v_seq else None
         else:
             raise ValueError(self.backend)
+
+        updated_states = (v, v_seq) if self.store_v_seq else (v,)
+        return (spike_seq,), updated_states

--- a/spikingjelly/activation_based/neuron/plif.py
+++ b/spikingjelly/activation_based/neuron/plif.py
@@ -161,33 +161,12 @@ class ParametricLIFNode(BaseNode):
             tau = 1.0 / self.w.sigmoid()
         return super().extra_repr() + f", tau={tau}"
 
-    def neuronal_charge(self, x: torch.Tensor):
-        if self.decay_input:
-            if self.v_reset is None or self.v_reset == 0.0:
-                self.v = self.v + (x - self.v) * self.w.sigmoid()
-            else:
-                self.v = self.v + (x - (self.v - self.v_reset)) * self.w.sigmoid()
-        else:
-            if self.v_reset is None or self.v_reset == 0.0:
-                self.v = self.v * (1.0 - self.w.sigmoid()) + x
-            else:
-                self.v = self.v - (self.v - self.v_reset) * self.w.sigmoid() + x
-
     def single_step_functional_forward(
         self,
         inputs: tuple[torch.Tensor, ...],
         states: tuple[object, ...],
         **kwargs: object,
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
-        r"""Execute one PLIF step with explicit state. / 使用显式状态执行一个 PLIF 时间步。
-
-        :param inputs: 仅包含 ``x`` 的元组 / Tuple containing only ``x``
-        :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)``
-        :type states: tuple
-        :return: ``((spike,), updated_states)``
-        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
-        """
         x = inputs[0]
         v = states[0]
         spike, v = functional.plif_step(
@@ -208,15 +187,6 @@ class ParametricLIFNode(BaseNode):
         states: tuple[object, ...],
         **kwargs: object,
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
-        r"""Execute PLIF sequence forward with explicit state. / 使用显式状态执行 PLIF 序列前向。
-
-        :param inputs: 仅包含 ``x_seq`` 的元组 / Tuple containing only ``x_seq``
-        :type inputs: tuple[torch.Tensor, ...]
-        :param states: ``(v,)``
-        :type states: tuple
-        :return: ``((spike_seq,), updated_states)``
-        :rtype: tuple[tuple[torch.Tensor, ...], tuple]
-        """
         x_seq = inputs[0]
         v = states[0]
 

--- a/spikingjelly/activation_based/neuron/psn.py
+++ b/spikingjelly/activation_based/neuron/psn.py
@@ -260,33 +260,26 @@ class MaskedPSN(base.MemoryModule):
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         x = inputs[0]
         time_step = states[0]
-        queue = [*states[1], x.flatten()]
         if self.lambda_ < 1.0:
             raise ValueError(
                 "The masked PSN can not work in single-step mode when k < 1!"
             )
-
-        if len(queue) > self.k:
-            queue.pop(0)
 
         if time_step + 1 > self.T:
             raise OverflowError(
                 f"The MaskedPSN(T={self.T}) has run {time_step + 1} time-steps!"
             )
 
-        weight = self.masked_weight()[
+        spike, time_step, queue = functional.masked_psn_step(
+            x,
             time_step,
-            time_step + 1 - len(queue) : time_step + 1,
-        ]
-        x_seq = torch.stack(queue)
-
-        for i in range(x.dim()):
-            weight = weight.unsqueeze(-1)
-
-        h = torch.sum(weight * x_seq, 0)
-        spike = self.surrogate_function(h + self.bias[time_step])
-
-        return (spike.view(x.shape),), (time_step + 1, queue)
+            tuple(states[1]),
+            self.masked_weight(),
+            self.bias,
+            self.k,
+            self.surrogate_function,
+        )
+        return (spike,), (time_step, list(queue))
 
     def multi_step_functional_forward(
         self,

--- a/spikingjelly/activation_based/neuron/psn.py
+++ b/spikingjelly/activation_based/neuron/psn.py
@@ -252,42 +252,54 @@ class MaskedPSN(base.MemoryModule):
                 self.lambda_, self.mask0, self.mask1, self.weight
             )
 
-    def single_step_forward(self, x: torch.Tensor):
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        time_step = states[0]
+        queue = [*states[1], x.flatten()]
         if self.lambda_ < 1.0:
             raise ValueError(
                 "The masked PSN can not work in single-step mode when k < 1!"
             )
 
-        self.queue.append(x.flatten())
-        if self.queue.__len__() > self.k:
-            self.queue.pop(0)
+        if len(queue) > self.k:
+            queue.pop(0)
 
-        if self.time_step + 1 > self.T:
+        if time_step + 1 > self.T:
             raise OverflowError(
-                f"The MaskedPSN(T={self.T}) has run {self.time_step + 1} time-steps!"
+                f"The MaskedPSN(T={self.T}) has run {time_step + 1} time-steps!"
             )
 
         weight = self.masked_weight()[
-            self.time_step,
-            self.time_step + 1 - self.queue.__len__() : self.time_step + 1,
+            time_step,
+            time_step + 1 - len(queue) : time_step + 1,
         ]
-        x_seq = torch.stack(self.queue)
+        x_seq = torch.stack(queue)
 
         for i in range(x.dim()):
             weight = weight.unsqueeze(-1)
 
         h = torch.sum(weight * x_seq, 0)
-        spike = self.surrogate_function(h + self.bias[self.time_step])
+        spike = self.surrogate_function(h + self.bias[time_step])
 
-        self.time_step += 1
-        return spike.view(x.shape)
+        return (spike.view(x.shape),), (time_step + 1, queue)
 
-    def multi_step_forward(self, x_seq: torch.Tensor):
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x_seq = inputs[0]
         # x_seq.shape = [T, N, *]
         assert x_seq.shape[0] == self.T
         h_seq = torch.addmm(self.bias, self.masked_weight(), x_seq.flatten(1))
         spike_seq = self.surrogate_function(h_seq).view(x_seq.shape)
-        return spike_seq
+        return (spike_seq,), states
 
     @property
     def lambda_(self):
@@ -423,18 +435,32 @@ class SlidingPSN(base.MemoryModule):
 
         return weight
 
-    def single_step_forward(self, x: torch.Tensor):
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         spike, queue = functional.sliding_psn_step(
-            x, tuple(self.queue), self.weight, self.bias, self.surrogate_function
+            inputs[0],
+            tuple(states[0]),
+            self.weight,
+            self.bias,
+            self.surrogate_function,
         )
-        self.queue[:] = queue
-        return spike
+        return (spike,), (list(queue),)
 
-    def multi_step_forward(self, x_seq: torch.Tensor):
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x_seq = inputs[0]
         if self.backend == "gemm":
             weight = self.gen_gemm_weight(x_seq.shape[0])
             h_seq = torch.addmm(self.bias, weight, x_seq.flatten(1)).view(x_seq.shape)
-            return self.surrogate_function(h_seq)
+            output = self.surrogate_function(h_seq)
         elif self.backend == "conv":
             # x_seq.shape = [T, N, *]
             x_seq_shape = x_seq.shape
@@ -445,10 +471,11 @@ class SlidingPSN(base.MemoryModule):
             x_seq = F.conv1d(x_seq, self.weight.view(1, 1, -1), stride=1)
 
             x_seq = x_seq.squeeze(1).t().view(x_seq_shape)
-            return self.surrogate_function(x_seq + self.bias)
+            output = self.surrogate_function(x_seq + self.bias)
 
         else:
             raise NotImplementedError(self.backend)
+        return (output,), states
 
     def extra_repr(self):
         return super().extra_repr() + f", order={self.k}"

--- a/spikingjelly/activation_based/neuron/spikezip.py
+++ b/spikingjelly/activation_based/neuron/spikezip.py
@@ -149,6 +149,10 @@ class STBIFNeuron(base.MemoryModule):
             q = torch.full_like(x, 0.5)
             acc_q = torch.zeros_like(x)
             cur_output = torch.zeros_like(x)
+        else:
+            q = q.to(x)
+            acc_q = acc_q.to(x)
+            cur_output = cur_output.to(x)
         return q, acc_q, cur_output, is_work
 
     def single_step_functional_forward(
@@ -189,7 +193,9 @@ class STBIFNeuron(base.MemoryModule):
     ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
         x_seq = inputs[0]
         q, acc_q, cur_output, is_work = states
-        if x_seq.device.type == "cuda" and self.backend == "triton":
+        if self.backend == "triton" and x_seq.device.type != "cuda":
+            raise RuntimeError("STBIFNeuron backend='triton' requires a CUDA tensor.")
+        if self.backend == "triton":
             from spikingjelly.activation_based.triton_kernel.neuron_kernel import stbif
 
             out_seq, q, acc_q, cur_output, work_flag = stbif.multi_step_stbif(

--- a/spikingjelly/activation_based/neuron/spikezip.py
+++ b/spikingjelly/activation_based/neuron/spikezip.py
@@ -137,81 +137,83 @@ class STBIFNeuron(base.MemoryModule):
     def supported_backends(self) -> tuple[str, ...]:
         return ("torch", "triton")
 
-    def _init_state(self, x: torch.Tensor) -> None:
-        if self.q is None or self.q.shape != x.shape:
-            self.cur_output = torch.zeros_like(x)
-            self.acc_q = torch.zeros_like(x)
-            self.q = torch.full_like(x, 0.5)
+    def materialize_states(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        step_mode: str,
+    ) -> tuple[object, ...]:
+        x = inputs[0] if step_mode == "s" else inputs[0][0]
+        q, acc_q, cur_output, is_work = states
+        if q is None or q.shape != x.shape:
+            q = torch.full_like(x, 0.5)
+            acc_q = torch.zeros_like(x)
+            cur_output = torch.zeros_like(x)
+        return q, acc_q, cur_output, is_work
 
-    def single_step_forward(self, x: torch.Tensor) -> torch.Tensor:
-        self._init_state(x)
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        q, acc_q, cur_output, is_work = states
         if self.backend == "triton":
-            out, self.q, self.acc_q, cur_output, work_flag = (
-                functional.stbif_single_step_triton(
-                    x,
-                    self.q,
-                    self.acc_q,
-                    self.q_threshold,
-                    self.pos_max,
-                    self.neg_min,
-                )
-            )
-            self.cur_output.copy_(cur_output)
-            self.is_work = bool(work_flag.item())
-            return out
-        out, self.q, self.acc_q, cur_output = functional.stbif_step(
-            x,
-            self.q,
-            self.acc_q,
-            self.q_threshold,
-            self.pos_max,
-            self.neg_min,
-        )
-        self.cur_output.copy_(cur_output)
-        self.is_work = bool((x != 0).any() | (out != 0).any())
-        return out
-
-    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
-        if x_seq.device.type == "cuda" and self.backend == "triton":
-            return self._multi_step_forward_triton(x_seq)
-        return self._multi_step_forward_torch(x_seq)
-
-    def _multi_step_forward_torch(self, x_seq: torch.Tensor) -> torch.Tensor:
-        self._init_state(x_seq[0])
-        out_seq = torch.empty_like(x_seq)
-        for t in range(x_seq.shape[0]):
-            out_seq[t], self.q, self.acc_q, cur_output = functional.stbif_step(
-                x_seq[t],
-                self.q,
-                self.acc_q,
+            out, q, acc_q, cur_output, work_flag = functional.stbif_single_step_triton(
+                x,
+                q,
+                acc_q,
                 self.q_threshold,
                 self.pos_max,
                 self.neg_min,
             )
-        self.cur_output.copy_(cur_output)
-        self.is_work = bool((x_seq != 0).any() | (out_seq != 0).any())
-        return out_seq
-
-    def _multi_step_forward_triton(self, x_seq: torch.Tensor) -> torch.Tensor:
-        from spikingjelly.activation_based.triton_kernel.neuron_kernel import stbif
-
-        q_threshold = self.q_threshold.to(dtype=x_seq.dtype)
-        pos_max = self.pos_max.to(dtype=x_seq.dtype)
-        neg_min = self.neg_min.to(dtype=x_seq.dtype)
-        self._init_state(x_seq[0])
-        out_seq, q, acc_q, cur_output, work_flag = stbif.multi_step_stbif(
-            x_seq,
-            self.q,
-            self.acc_q,
-            q_threshold,
-            pos_max,
-            neg_min,
+            is_work = bool(work_flag.item())
+            return (out,), (q, acc_q, cur_output, is_work)
+        out, q, acc_q, cur_output = functional.stbif_step(
+            x,
+            q,
+            acc_q,
+            self.q_threshold,
+            self.pos_max,
+            self.neg_min,
         )
-        self.q = q
-        self.acc_q = acc_q
-        self.cur_output = cur_output
-        self.is_work = bool(work_flag.item())
-        return out_seq
+        is_work = bool((x != 0).any() | (out != 0).any())
+        return (out,), (q, acc_q, cur_output, is_work)
+
+    def multi_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x_seq = inputs[0]
+        q, acc_q, cur_output, is_work = states
+        if x_seq.device.type == "cuda" and self.backend == "triton":
+            from spikingjelly.activation_based.triton_kernel.neuron_kernel import stbif
+
+            out_seq, q, acc_q, cur_output, work_flag = stbif.multi_step_stbif(
+                x_seq,
+                q,
+                acc_q,
+                self.q_threshold.to(dtype=x_seq.dtype),
+                self.pos_max.to(dtype=x_seq.dtype),
+                self.neg_min.to(dtype=x_seq.dtype),
+            )
+            is_work = bool(work_flag.item())
+        else:
+            out_seq = torch.empty_like(x_seq)
+            for t in range(x_seq.shape[0]):
+                out_seq[t], q, acc_q, cur_output = functional.stbif_step(
+                    x_seq[t],
+                    q,
+                    acc_q,
+                    self.q_threshold,
+                    self.pos_max,
+                    self.neg_min,
+                )
+            is_work = bool((x_seq != 0).any() | (out_seq != 0).any())
+        return (out_seq,), (q, acc_q, cur_output, is_work)
 
     @property
     def accumulated(self) -> torch.Tensor:

--- a/spikingjelly/activation_based/op_counter/neuron_state.py
+++ b/spikingjelly/activation_based/op_counter/neuron_state.py
@@ -104,6 +104,11 @@ _STATE_COPY_OPS = {
     aten._to_copy.default,
 }
 
+_STATE_MATERIALIZATION_OPS = {
+    aten.full_like.default,
+    aten.zeros_like.default,
+}
+
 
 def _storage_key(x: torch.Tensor) -> tuple[Any, ...]:
     if x.is_meta:
@@ -330,13 +335,20 @@ class NeuronStateCounter(BaseCounter):
                 if torch.is_tensor(value):
                     state_tensor_keys.add(_storage_key(value))
 
-        live_states = [
-            tensor
-            for ref in self._functional_state_refs
-            if (tensor := ref()) is not None
-        ]
-        self._functional_state_refs = [weakref.ref(tensor) for tensor in live_states]
+        live_refs = []
+        live_states = []
+        for state_ref in self._functional_state_refs:
+            tensor = state_ref()
+            if tensor is not None:
+                live_refs.append(state_ref)
+                live_states.append(tensor)
+        self._functional_state_refs = live_refs
         state_tensor_keys.update(_storage_key(tensor) for tensor in live_states)
+
+        if not state_tensor_keys and func in _STATE_MATERIALIZATION_OPS:
+            materialized_state = _collect_tensors(out)[0]
+            self._functional_state_refs.append(weakref.ref(materialized_state))
+            state_tensor_keys.add(_storage_key(materialized_state))
 
         if not state_tensor_keys:
             self._pending_metrics = None

--- a/spikingjelly/activation_based/op_counter/neuron_state.py
+++ b/spikingjelly/activation_based/op_counter/neuron_state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+import weakref
 from collections import defaultdict
 from typing import Any, Callable
 
@@ -216,6 +217,7 @@ class NeuronStateCounter(BaseCounter):
         self._warned_modules: set[int] = set()
         self._pending_metrics: dict[str, int] | None = None
         self._pending_projection: dict[str, int] | None = None
+        self._functional_state_refs: list[weakref.ReferenceType[torch.Tensor]] = []
 
     def has_rule(self, func) -> bool:
         return True
@@ -327,6 +329,14 @@ class NeuronStateCounter(BaseCounter):
             for value in module._memories.values():
                 if torch.is_tensor(value):
                     state_tensor_keys.add(_storage_key(value))
+
+        live_states = [
+            tensor
+            for ref in self._functional_state_refs
+            if (tensor := ref()) is not None
+        ]
+        self._functional_state_refs = [weakref.ref(tensor) for tensor in live_states]
+        state_tensor_keys.update(_storage_key(tensor) for tensor in live_states)
 
         if not state_tensor_keys:
             self._pending_metrics = None
@@ -444,6 +454,9 @@ class NeuronStateCounter(BaseCounter):
 
         if writes_state and output_tensors:
             metrics["state_writes"] += out_bytes
+            self._functional_state_refs.extend(
+                weakref.ref(tensor) for tensor in output_tensors
+            )
             has_spike_gate = sparse_state_access
             if has_spike_gate:
                 metrics["state_reset_ops"] += out_numel
@@ -582,3 +595,4 @@ class NeuronStateCounter(BaseCounter):
         self._warned_modules = set()
         self._pending_metrics = None
         self._pending_projection = None
+        self._functional_state_refs = []

--- a/test/activation_based/test_activation_aware_ifnode.py
+++ b/test/activation_based/test_activation_aware_ifnode.py
@@ -186,7 +186,7 @@ class TestActivationAwareIFNode:
                 candidate.v_seq.untyped_storage().data_ptr()
             )
         else:
-            assert not hasattr(candidate, "v_seq")
+            assert candidate.v_seq is None
             assert candidate.v.untyped_storage().nbytes() == (
                 candidate.v.numel() * candidate.v.element_size()
             )
@@ -479,20 +479,6 @@ class TestActivationAwareIFNode:
 
         with pytest.raises(RuntimeError, match="kernel is unavailable"):
             neuron.ActivationAwareIFNode(step_mode="m", backend="triton")
-
-    @pytest.mark.parametrize(
-        "x_seq",
-        (
-            torch.tensor(1.0),
-            torch.empty(0, 2, 3),
-            torch.empty(2, 0, 3),
-        ),
-    )
-    def test_multistep_rejects_invalid_sequence_shapes(self, x_seq):
-        node = neuron.ActivationAwareIFNode(step_mode="m")
-
-        with pytest.raises(ValueError, match="non-empty shape.*T"):
-            node(x_seq)
 
     @pytest.mark.parametrize("bad_backend", ["cupy", "inductor"])
     def test_rejects_non_torch_backend(self, bad_backend):

--- a/test/activation_based/test_ann2snn_operators.py
+++ b/test/activation_based/test_ann2snn_operators.py
@@ -133,13 +133,16 @@ def test_td_modules_support_step_mode_switching():
             module.step_mode = "bogus"
 
 
-def test_td_module_requires_explicit_multistep_forward():
+def test_td_module_uses_default_functional_multistep_forward():
     class DummyTDModule(TDModule):
         def ann_forward(self, x):
             return x
 
-    with pytest.raises(NotImplementedError, match="multi_step_forward"):
-        DummyTDModule()(torch.zeros(2, 3))
+    module = DummyTDModule()
+    x_seq = torch.randn(2, 3)
+
+    torch.testing.assert_close(module(x_seq), x_seq)
+    torch.testing.assert_close(module.x_cum, x_seq.sum(0))
 
 
 def test_td_multistep_state_owns_only_final_step_storage():

--- a/test/activation_based/test_ann2snn_transformer.py
+++ b/test/activation_based/test_ann2snn_transformer.py
@@ -1492,15 +1492,6 @@ def test_sta_sequence_spike_encoder_clamps_zero_threshold():
     assert torch.count_nonzero(y_seq) == 0
 
 
-def test_sta_sequence_spike_encoder_rejects_invalid_multistep_input():
-    encoder = _STASpikeEncoder(torch.ones(3), channel_dim=-1, step_mode="m")
-
-    with pytest.raises(ValueError, match="at least one data dimension"):
-        encoder(torch.zeros(4))
-    with pytest.raises(ValueError, match="non-empty time dimension"):
-        encoder(torch.zeros(0, 2, 3))
-
-
 class TinyUnsupportedSequenceOpClassifier(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return x.permute(1, 0, 2)

--- a/test/activation_based/test_cupy_backend_comprehensive.py
+++ b/test/activation_based/test_cupy_backend_comprehensive.py
@@ -398,7 +398,7 @@ def test_cupy_batch_size_change_reconciles_v_state(kind, dtype):
     node_cupy(x_first)
     node_cupy.reset()
 
-    # Pass 2: change batch size to 7; v_float_to_tensor should reconcile state.
+    # Pass 2: change batch size to 7; materialize_states should reconcile state.
     s_torch_second = node_torch(x_second)
     v_torch_second = node_torch.v_seq
 

--- a/test/activation_based/test_functional_layer.py
+++ b/test/activation_based/test_functional_layer.py
@@ -105,6 +105,38 @@ def test_synapse_filter_step_does_not_mutate_state():
     assert torch.equal(state, state_before)
 
 
+def test_neunorm_step_matches_module():
+    in_spikes = torch.randn(2, 3, 4, 5)
+    state = torch.randn(2, 1, 4, 5)
+    module = layer.NeuNorm(3, 4, 5)
+    module.x = state.clone()
+
+    output, state_next = functional.neunorm_step(
+        in_spikes,
+        state,
+        module.w,
+        module.k0,
+        module.k1,
+    )
+    module_output = module(in_spikes)
+    expected_state = module.k0 * state + module.k1 * in_spikes.sum(dim=1, keepdim=True)
+
+    torch.testing.assert_close(output, module_output)
+    torch.testing.assert_close(state_next, module.x)
+    torch.testing.assert_close(state_next, expected_state)
+    torch.testing.assert_close(output, in_spikes - module.w * expected_state)
+
+
+@pytest.mark.parametrize("step_mode", ["s", "m"])
+def test_neunorm_materializes_channel_shared_state(step_mode):
+    module = layer.NeuNorm(3, 4, 5, step_mode=step_mode)
+    x = torch.randn(2, 3, 4, 5)
+    output = module(x if step_mode == "s" else x.unsqueeze(0))
+
+    assert output.shape == (x.shape if step_mode == "s" else (1, *x.shape))
+    assert module.x.shape == (2, 1, 4, 5)
+
+
 def test_functional_layer_exports():
     for name in functional_layer.__all__:
         assert getattr(functional, name) is getattr(functional_layer, name)

--- a/test/activation_based/test_functional_neuron.py
+++ b/test/activation_based/test_functional_neuron.py
@@ -267,7 +267,7 @@ def test_store_v_seq_does_not_change_functional_state_layout(node):
     assert node.v_seq is None
 
 
-def test_save_v_lif_functional_forward_tracks_observed_voltage_as_memory():
+def test_save_v_lif_keeps_observed_voltage_out_of_functional_state():
     from spikingjelly.activation_based.model.spike_dhs import save_v_LIFNode
 
     node = save_v_LIFNode(
@@ -283,9 +283,29 @@ def test_save_v_lif_functional_forward_tracks_observed_voltage_as_memory():
     outputs, updated_states = node.functional_forward((x_seq,), states)
 
     assert tuple(node._memories.values()) == states
+    assert tuple(node._memories) == ("v",)
+    assert node.v_before_spike is None
     torch.testing.assert_close(node(x_seq), outputs[0])
     for actual, expected in zip(node._memories.values(), updated_states):
         torch.testing.assert_close(actual, expected)
+    assert node.v_seq.shape == (x_seq.shape[0],)
+
+    reference_v = states[0]
+    expected_observations = []
+    for x in x_seq:
+        charged = functional.lif_charge(
+            x, reference_v, node.tau, node.decay_input, node.v_reset
+        )
+        expected_observations.append((charged - node.v_threshold).mean())
+        spike = node.surrogate_function(charged - node.v_threshold)
+        reference_v = functional.voltage_reset(
+            charged,
+            spike,
+            node.v_threshold,
+            node.v_reset,
+            node.detach_reset,
+        )
+    torch.testing.assert_close(node.v_seq, torch.stack(expected_observations))
 
 
 @pytest.mark.parametrize(

--- a/test/activation_based/test_functional_neuron.py
+++ b/test/activation_based/test_functional_neuron.py
@@ -71,6 +71,30 @@ def test_lif_step_matches_module(decay_input):
     _assert_close(v_next, module.v)
 
 
+@pytest.mark.parametrize("decay_input", [False, True])
+@pytest.mark.parametrize("v_reset", [0.0, None])
+def test_lif_step_is_composed_from_charge_and_voltage_reset(decay_input, v_reset):
+    x = torch.randn(2, 3)
+    v = torch.randn(2, 3)
+    surrogate_function = _surrogate()
+
+    charged = functional.lif_charge(x, v, 2.5, decay_input, v_reset)
+    spike = surrogate_function(charged - 0.8)
+    v_next = functional.voltage_reset(charged, spike, 0.8, v_reset, False)
+    expected_spike, expected_v = functional.lif_step(
+        x,
+        v,
+        2.5,
+        decay_input,
+        0.8,
+        v_reset,
+        surrogate_function,
+    )
+
+    _assert_close(spike, expected_spike)
+    _assert_close(v_next, expected_v)
+
+
 def test_materialize_states_is_pure():
     module = neuron.IFNode()
     x = torch.randn(2, 3)
@@ -173,14 +197,22 @@ def test_neuron_functional_forward_is_pure_and_backs_regular_forward(
 
 
 @pytest.mark.parametrize("node", [neuron.IFNode(), neuron.LIFNode()])
-def test_store_v_seq_updates_functional_state_layout(node):
+def test_store_v_seq_does_not_change_functional_state_layout(node):
     node.step_mode = "m"
     node.store_v_seq = True
-    assert tuple(name for name, _ in node.named_memories()) == ("v", "v_seq")
+    assert tuple(name for name, _ in node.named_memories()) == ("v",)
+
+    x_seq = torch.randn(3, 2)
+    states = tuple(node._memories.values())
+    node.functional_forward((x_seq,), states)
+    assert node.v_seq is None
+
+    node(x_seq)
+    assert node.v_seq.shape == x_seq.shape
 
     node.store_v_seq = False
     assert tuple(name for name, _ in node.named_memories()) == ("v",)
-    node(torch.randn(3, 2))
+    assert node.v_seq is None
 
 
 def test_save_v_lif_functional_forward_tracks_observed_voltage_as_memory():
@@ -381,6 +413,57 @@ def test_lava_cuba_lif_step_matches_norm_free_module():
     _assert_close(spike, module_spike)
     _assert_close(current_next, module.current_state)
     _assert_close(voltage_next, module.voltage_state)
+
+
+def test_cuba_sequence_caches_are_not_functional_states():
+    module = lava_exchange.CubaLIFNode(
+        current_decay=0.25,
+        voltage_decay=0.5,
+        step_mode="m",
+        store_v_seq=True,
+        store_i_seq=True,
+    )
+    x_seq = torch.randn(3, 2, 4)
+    states = tuple(module._memories.values())
+
+    outputs, updated_states = module.functional_forward((x_seq,), states)
+
+    assert module.v_seq is None
+    assert module.i_seq is None
+    assert tuple(module._memories.values()) == states
+    torch.testing.assert_close(module(x_seq), outputs[0])
+    assert module.v_seq.shape == x_seq.shape
+    assert module.i_seq.shape == x_seq.shape
+    for actual, expected in zip(module._memories.values(), updated_states):
+        if isinstance(actual, torch.Tensor):
+            torch.testing.assert_close(actual, expected)
+
+
+def test_flexsn_sequence_cache_is_not_a_functional_state():
+    from spikingjelly.activation_based.neuron.flexsn import FlexSN
+
+    def core(x, state):
+        state = state + x
+        return state, state
+
+    module = FlexSN(
+        core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        step_mode="m",
+        backend="torch",
+        store_state_seqs=True,
+    )
+    x_seq = torch.randn(3, 2, 4)
+
+    outputs, updated_states = module.functional_forward((x_seq,), (module.states,))
+
+    assert module.states is None
+    assert module.state_seqs is None
+    torch.testing.assert_close(module(x_seq), outputs[0])
+    assert len(module.state_seqs) == 1
+    torch.testing.assert_close(module.states[0], updated_states[0][0])
 
 
 def test_activation_aware_if_step_matches_module():

--- a/test/activation_based/test_functional_neuron.py
+++ b/test/activation_based/test_functional_neuron.py
@@ -95,6 +95,58 @@ def test_lif_step_is_composed_from_charge_and_voltage_reset(decay_input, v_reset
     _assert_close(v_next, expected_v)
 
 
+@pytest.mark.parametrize("threshold_related", [False, True])
+def test_liaf_step_matches_module(threshold_related):
+    x = torch.randn(2, 3)
+    v = torch.randn(2, 3)
+    module = neuron.LIAFNode(
+        torch.tanh,
+        threshold_related,
+        tau=2.5,
+        decay_input=True,
+        v_threshold=0.8,
+        v_reset=None,
+        surrogate_function=_surrogate(),
+    )
+    module.v = v.clone()
+
+    output, v_next = functional.liaf_step(
+        x,
+        v,
+        2.5,
+        True,
+        0.8,
+        None,
+        torch.tanh,
+        threshold_related,
+        _surrogate(),
+    )
+    module_output = module(x)
+
+    _assert_close(output, module_output)
+    _assert_close(v_next, module.v)
+
+
+def test_ilif_step_matches_module():
+    x = torch.randn(2, 3)
+    v = torch.randn(2, 3)
+    module = neuron.ILIFNode(tau=1.5, v_threshold=0.8)
+    module.v = v.clone()
+
+    spike, v_next = functional.ilif_step(
+        x,
+        v,
+        1.5,
+        0.8,
+        module.surrogate_function,
+        module.detach_reset,
+    )
+    module_spike = module(x)
+
+    _assert_close(spike, module_spike)
+    _assert_close(v_next, module.v)
+
+
 def test_materialize_states_is_pure():
     module = neuron.IFNode()
     x = torch.randn(2, 3)
@@ -515,6 +567,35 @@ def test_sliding_psn_step_matches_module():
     assert len(module.queue) == len(queue)
     for actual_state, expected_state in zip(module.queue, queue):
         _assert_close(actual_state, expected_state)
+
+
+def test_masked_psn_step_matches_module_sequence():
+    x_seq = torch.randn(4, 2, 3)
+    module = neuron.MaskedPSN(k=3, T=4, lambda_init=1.0)
+    time_step = 0
+    queue = ()
+    expected = []
+
+    for x in x_seq:
+        spike, time_step, queue = functional.masked_psn_step(
+            x,
+            time_step,
+            queue,
+            module.masked_weight(),
+            module.bias,
+            module.k,
+            module.surrogate_function,
+        )
+        expected.append(spike)
+    actual = torch.stack([module(x) for x in x_seq])
+    module.reset()
+    module.step_mode = "m"
+    multi_step = module(x_seq)
+
+    _assert_close(actual, torch.stack(expected))
+    _assert_close(actual, multi_step)
+    assert time_step == x_seq.shape[0]
+    assert len(queue) == module.k
 
 
 def test_gated_lif_step_matches_module_sequence():

--- a/test/activation_based/test_functional_neuron.py
+++ b/test/activation_based/test_functional_neuron.py
@@ -71,6 +71,16 @@ def test_lif_step_matches_module(decay_input):
     _assert_close(v_next, module.v)
 
 
+def test_materialize_states_is_pure():
+    module = neuron.IFNode()
+    x = torch.randn(2, 3)
+
+    states = module.materialize_states((x,), (module.v,), "s")
+
+    assert module.v == 0.0
+    assert torch.equal(states[0], torch.zeros_like(x))
+
+
 def test_plif_step_matches_module_and_parameter_gradient():
     x = torch.randn(2, 3)
     v = torch.randn(2, 3)
@@ -100,6 +110,98 @@ def test_plif_step_matches_module_and_parameter_gradient():
     _assert_close(spike, module_spike)
     _assert_close(v_next, module.v)
     _assert_close(w.grad, module.w.grad)
+
+
+@pytest.mark.parametrize(
+    "module_factory",
+    [
+        lambda: neuron.IFNode(v_reset=None, surrogate_function=_surrogate()),
+        lambda: neuron.LIFNode(
+            tau=2.5, decay_input=False, v_reset=0.0, surrogate_function=_surrogate()
+        ),
+        lambda: neuron.ParametricLIFNode(
+            init_tau=2.5,
+            decay_input=True,
+            v_reset=None,
+            surrogate_function=_surrogate(),
+        ),
+        lambda: neuron.LIAFNode(
+            torch.relu,
+            True,
+            tau=2.5,
+            decay_input=True,
+            v_reset=0.0,
+            surrogate_function=_surrogate(),
+        ),
+        lambda: neuron.ActivationAwareIFNode(
+            v_threshold=0.8,
+            v_offset=0.1,
+            v_reset=None,
+            surrogate_function=_surrogate(),
+        ),
+    ],
+)
+@pytest.mark.parametrize("step_mode", ["s", "m"])
+def test_neuron_functional_forward_is_pure_and_backs_regular_forward(
+    module_factory, step_mode
+):
+    module = module_factory()
+    module.step_mode = step_mode
+    module.store_v_seq = step_mode == "m"
+    x = torch.randn(4, 2, 3) if step_mode == "m" else torch.randn(2, 3)
+    v = torch.randn_like(x[0] if step_mode == "m" else x, requires_grad=True)
+    module.v = v
+    if step_mode == "m":
+        module.v_seq = None
+
+    original_states = tuple(module._memories.values())
+    outputs, updated_states = module.functional_forward((x,), original_states)
+
+    assert all(
+        actual is expected
+        for actual, expected in zip(module._memories.values(), original_states)
+    )
+    actual = module(x)
+    _assert_close(actual, outputs[0])
+    for actual_state, expected_state in zip(module._memories.values(), updated_states):
+        if actual_state is not None:
+            _assert_close(actual_state, expected_state)
+
+    loss = outputs[0].sum() + updated_states[0].sum()
+    loss.backward()
+    assert v.grad is not None
+
+
+@pytest.mark.parametrize("node", [neuron.IFNode(), neuron.LIFNode()])
+def test_store_v_seq_updates_functional_state_layout(node):
+    node.step_mode = "m"
+    node.store_v_seq = True
+    assert tuple(name for name, _ in node.named_memories()) == ("v", "v_seq")
+
+    node.store_v_seq = False
+    assert tuple(name for name, _ in node.named_memories()) == ("v",)
+    node(torch.randn(3, 2))
+
+
+def test_save_v_lif_functional_forward_tracks_observed_voltage_as_memory():
+    from spikingjelly.activation_based.model.spike_dhs import save_v_LIFNode
+
+    node = save_v_LIFNode(
+        tau=2.5,
+        decay_input=False,
+        store_v_seq=True,
+        step_mode="m",
+        surrogate_function=_surrogate(),
+    )
+    x_seq = torch.randn(3, 2, 4)
+    states = tuple(node._memories.values())
+
+    outputs, updated_states = node.functional_forward((x_seq,), states)
+
+    assert tuple(node._memories.values()) == states
+    torch.testing.assert_close(node(x_seq), outputs[0])
+    for actual, expected in zip(node._memories.values(), updated_states):
+        torch.testing.assert_close(actual, expected)
 
 
 @pytest.mark.parametrize(

--- a/test/activation_based/test_ilif_node.py
+++ b/test/activation_based/test_ilif_node.py
@@ -620,3 +620,24 @@ def test_multi_level_spike_count_rejects_invalid_parameters():
             surrogate.MultiLevelSpikeCount(value)
     with pytest.raises(ValueError):
         surrogate.MultiLevelSpikeCount(4, grad_window=(1.0, 0.0))
+
+
+@pytest.mark.parametrize("step_mode", ["s", "m"])
+def test_ilif_functional_forward_is_pure_and_backs_regular_forward(step_mode):
+    node = neuron.ILIFNode(step_mode=step_mode, store_v_seq=step_mode == "m")
+    x = torch.randn(4, 2, 3) if step_mode == "m" else torch.randn(2, 3)
+    v = torch.randn_like(x[0] if step_mode == "m" else x)
+    node.v = v
+    if step_mode == "m":
+        node.v_seq = None
+    original_states = tuple(node._memories.values())
+
+    outputs, updated_states = node.functional_forward((x,), original_states)
+
+    assert all(
+        actual is expected
+        for actual, expected in zip(node._memories.values(), original_states)
+    )
+    torch.testing.assert_close(node(x), outputs[0])
+    for actual, expected in zip(node._memories.values(), updated_states):
+        torch.testing.assert_close(actual, expected)

--- a/test/activation_based/test_memory.py
+++ b/test/activation_based/test_memory.py
@@ -166,9 +166,10 @@ def test_to_functional_forward_stateless():
     module = StatelessModule()
     func_forward = base.to_functional_forward(module)
     x = torch.randn(3, 10)
-    result1 = func_forward(x)
+    outputs, states = func_forward((x,), ())
     result2 = module(x)
-    assert torch.equal(result1, result2)
+    assert states == ()
+    assert torch.equal(outputs[0], result2)
 
 
 def test_to_functional_forward_stateful():
@@ -187,15 +188,14 @@ def test_to_functional_forward_stateful():
     module = StatefulModule()
     func_forward = base.to_functional_forward(module)
 
-    # Test functional interface: (input, state) -> (output, new_state)
     x = torch.randn(3, 10)
     initial_state = torch.tensor(0.0)
-    output, new_state = func_forward(x, initial_state)
+    outputs, new_states = func_forward((x,), (initial_state,))
     expected_output = module.linear(x)
     expected_state = initial_state + 1.0
 
-    assert torch.equal(output, expected_output)
-    assert torch.equal(new_state, expected_state)
+    assert torch.equal(outputs[0], expected_output)
+    assert torch.equal(new_states[0], expected_state)
 
 
 def test_to_functional_forward_nested_stateful():
@@ -226,11 +226,11 @@ def test_to_functional_forward_nested_stateful():
     x = torch.randn(3, 10)
     outer_state = torch.tensor(5.0)
     inner_state = 3
-    output, new_outer_state, new_inner_state = func_forward(x, outer_state, inner_state)
+    outputs, new_states = func_forward((x,), (outer_state, inner_state))
 
-    assert torch.equal(output, x)
-    assert torch.equal(new_outer_state, outer_state + 2.0)
-    assert new_inner_state == inner_state + 1
+    assert torch.equal(outputs[0], x)
+    assert torch.equal(new_states[0], outer_state + 2.0)
+    assert new_states[1] == inner_state + 1
 
 
 def test_to_functional_forward_state_restoration():
@@ -249,7 +249,7 @@ def test_to_functional_forward_state_restoration():
     original_state = module.state.clone()
     func_forward = base.to_functional_forward(module)
     x = torch.randn(3, 10)
-    func_forward(x, torch.tensor(5.0))
+    func_forward((x,), (torch.tensor(5.0),))
 
     assert torch.equal(module.state, original_state)
 
@@ -275,10 +275,255 @@ def test_to_functional_forward_custom_fn():
     func_forward = base.to_functional_forward(module, module.custom_forward)
     x = torch.randn(3, 10)
     initial_state = torch.tensor(0.0)
-    output, new_state = func_forward(x, initial_state)
+    outputs, new_states = func_forward((x,), (initial_state,))
 
-    assert torch.equal(output, module.linear(x) * 2)
-    assert torch.equal(new_state, initial_state + 2.0)
+    assert torch.equal(outputs[0], module.linear(x) * 2)
+    assert torch.equal(new_states[0], initial_state + 2.0)
+
+
+def test_memory_module_functional_forward_is_pure_and_backs_regular_forward():
+    x = torch.tensor(1.0)
+    node = neuron.IFNode()
+    initial_v = torch.zeros_like(x)
+    outputs, updated_states = node.functional_forward((x,), (initial_v,))
+    assert node.v == 0.0
+    torch.testing.assert_close(node(x), outputs[0])
+    torch.testing.assert_close(node.v, updated_states[0])
+
+
+def test_memory_module_step_forwards_are_functional_backed():
+    class FunctionalOnlyModule(base.MemoryModule):
+        def __init__(self):
+            super().__init__()
+            self.register_memory("left", torch.tensor(2.0))
+            self.register_memory("right", torch.tensor(5.0))
+
+        def single_step_functional_forward(self, inputs, states, **kwargs):
+            x, y = inputs
+            increment = kwargs.get("increment", 1.0)
+            left = states[0] + increment
+            right = states[1] + increment
+            return (x + y + left, x - y + right), (left, right)
+
+    module = FunctionalOnlyModule()
+    outputs = module.single_step_forward(
+        torch.tensor(1.0), torch.tensor(3.0), increment=2.0
+    )
+    torch.testing.assert_close(outputs[0], torch.tensor(8.0))
+    torch.testing.assert_close(outputs[1], torch.tensor(5.0))
+    torch.testing.assert_close(module.left, torch.tensor(4.0))
+    torch.testing.assert_close(module.right, torch.tensor(7.0))
+
+    outputs = module.multi_step_forward(
+        torch.tensor([1.0, 2.0]),
+        torch.tensor([3.0, 4.0]),
+        increment=3.0,
+    )
+    torch.testing.assert_close(outputs[0], torch.tensor([11.0, 16.0]))
+    torch.testing.assert_close(outputs[1], torch.tensor([8.0, 11.0]))
+    torch.testing.assert_close(module.left, torch.tensor(10.0))
+    torch.testing.assert_close(module.right, torch.tensor(13.0))
+
+
+def test_materialize_states_uses_single_step_shape_for_multistep_forward():
+    class MaterializedStateModule(base.MemoryModule):
+        def __init__(self):
+            super().__init__()
+            self.register_memory("state", None)
+            self.step_mode = "m"
+
+        def materialize_states(self, inputs, states, step_mode):
+            x = inputs[0][0] if step_mode == "m" else inputs[0]
+            return (torch.zeros_like(x),)
+
+        def single_step_functional_forward(self, inputs, states, **kwargs):
+            state = states[0] + inputs[0]
+            return (state,), (state,)
+
+    module = MaterializedStateModule()
+    x_seq = torch.randn(4, 2, 3)
+
+    module(x_seq)
+
+    assert module.state.shape == x_seq.shape[1:]
+
+
+def test_simple_base_node_forward_uses_charge_fire_reset_hooks():
+    class SquareIFNode(neuron.SimpleBaseNode):
+        def neuronal_charge(self, x):
+            self.v = self.v + x.square()
+
+    node = SquareIFNode(v_threshold=10.0)
+    x_seq = torch.tensor([[1.0], [2.0], [1.0]])
+
+    node.step_mode = "s"
+    spike_steps = torch.stack([node(x) for x in x_seq])
+    torch.testing.assert_close(spike_steps, torch.zeros_like(x_seq))
+    torch.testing.assert_close(node.v, torch.tensor([6.0]))
+
+    node.reset()
+    node.step_mode = "m"
+    spike_seq = node(x_seq)
+    torch.testing.assert_close(spike_seq, torch.zeros_like(x_seq))
+    torch.testing.assert_close(node.v, torch.tensor([6.0]))
+
+
+@pytest.mark.parametrize(
+    ("simple_factory", "production_factory"),
+    [
+        (neuron.SimpleIFNode, neuron.IFNode),
+        (
+            lambda **kwargs: neuron.SimpleLIFNode(tau=2.5, decay_input=False, **kwargs),
+            lambda **kwargs: neuron.LIFNode(tau=2.5, decay_input=False, **kwargs),
+        ),
+    ],
+)
+@pytest.mark.parametrize("step_mode", ["s", "m"])
+def test_simple_nodes_match_production_nodes(
+    simple_factory, production_factory, step_mode
+):
+    simple = simple_factory(v_threshold=0.8, v_reset=0.0, step_mode=step_mode)
+    production = production_factory(v_threshold=0.8, v_reset=0.0, step_mode=step_mode)
+    x = torch.randn(4, 2, 3) if step_mode == "m" else torch.randn(2, 3)
+    v = torch.randn_like(x[0] if step_mode == "m" else x)
+    simple.v = v.clone()
+    production.v = v.clone()
+
+    torch.testing.assert_close(simple(x), production(x))
+    torch.testing.assert_close(simple.v, production.v)
+
+
+def test_to_functional_forward_converts_simple_node_without_mutating_it():
+    class SquareIFNode(neuron.SimpleBaseNode):
+        def neuronal_charge(self, x):
+            self.v = self.v + x.square()
+
+    node = SquareIFNode(v_threshold=2.0, v_reset=None, step_mode="m")
+    node.v = torch.tensor([7.0])
+    x_seq = torch.tensor([[0.5], [1.0], [0.5]])
+    initial_v = torch.tensor([0.25])
+
+    with pytest.raises(NotImplementedError):
+        node.functional_forward((x_seq,), (initial_v,))
+
+    functional_forward = base.to_functional_forward(node)
+    outputs, updated_states = functional_forward((x_seq,), (initial_v,))
+
+    torch.testing.assert_close(node.v, torch.tensor([7.0]))
+    reference = SquareIFNode(v_threshold=2.0, v_reset=None, step_mode="m")
+    reference.v = initial_v
+    torch.testing.assert_close(outputs[0], reference(x_seq))
+    torch.testing.assert_close(updated_states[0], reference.v)
+
+
+def test_to_functional_forward_preserves_overridden_simple_forward():
+    class NonSpikingLIFNode(neuron.SimpleLIFNode):
+        def single_step_forward(self, x):
+            self.neuronal_charge(x)
+            return self.v
+
+    node = NonSpikingLIFNode(tau=2.0, decay_input=True, step_mode="m")
+    node.v = torch.tensor([4.0])
+    x_seq = torch.tensor([[1.0], [2.0], [3.0]])
+    initial_v = torch.tensor([0.0])
+
+    outputs, states = base.to_functional_forward(node)((x_seq,), (initial_v,))
+
+    reference = NonSpikingLIFNode(tau=2.0, decay_input=True, step_mode="m")
+    reference.v = initial_v
+    torch.testing.assert_close(outputs[0], reference(x_seq))
+    torch.testing.assert_close(states[0], reference.v)
+    torch.testing.assert_close(node.v, torch.tensor([4.0]))
+
+
+def test_to_functional_forward_uses_default_multi_step_functional_forward():
+    class FunctionalOnlyModule(base.MemoryModule):
+        def __init__(self):
+            super().__init__()
+            self.register_memory("state", torch.tensor(0.0))
+            self.step_mode = "m"
+
+        def single_step_functional_forward(self, inputs, states, **kwargs):
+            state = states[0] + inputs[0]
+            return (state,), (state,)
+
+        def forward(self, *args, **kwargs):
+            raise AssertionError("to_functional_forward used the stateful path")
+
+    module = FunctionalOnlyModule()
+    functional_forward = base.to_functional_forward(module)
+    outputs, states = functional_forward(
+        (torch.tensor([1.0, 2.0, 3.0]),), (torch.tensor(4.0),)
+    )
+
+    torch.testing.assert_close(outputs[0], torch.tensor([5.0, 7.0, 10.0]))
+    torch.testing.assert_close(states[0], torch.tensor(10.0))
+
+
+def test_to_functional_forward_sequential_multiple_inputs_outputs_and_kwargs():
+    class Add(nn.Module):
+        def forward(self, x, y, *, scale=1.0):
+            return (x + y) * scale, x - y
+
+    class Combine(nn.Module):
+        def forward(self, total, difference):
+            return total + difference
+
+    module = nn.Sequential(Add(), Combine())
+    functional_forward = base.to_functional_forward(module)
+    x = torch.tensor(3.0)
+    y = torch.tensor(2.0)
+    outputs, states = functional_forward((x, y), (), scale=2.0)
+
+    assert states == ()
+    torch.testing.assert_close(outputs[0], torch.tensor(11.0))
+
+
+def test_to_functional_forward_fallback_multiple_inputs_states_outputs_and_kwargs():
+    class Accumulator(base.MemoryModule):
+        def __init__(self):
+            super().__init__()
+            self.register_memory("left", torch.tensor(10.0))
+            self.register_memory("right", torch.tensor(20.0))
+
+        def single_step_forward(self, x, y, *, scale=1.0):
+            self.left = self.left + x * scale
+            self.right = self.right + y * scale
+            return self.left, self.right
+
+    module = Accumulator()
+    functional_forward = base.to_functional_forward(module)
+    outputs, states = functional_forward(
+        (torch.tensor(2.0), torch.tensor(3.0)),
+        (torch.tensor(1.0), torch.tensor(4.0)),
+        scale=2.0,
+    )
+
+    torch.testing.assert_close(outputs[0], torch.tensor(5.0))
+    torch.testing.assert_close(outputs[1], torch.tensor(10.0))
+    torch.testing.assert_close(states[0], torch.tensor(5.0))
+    torch.testing.assert_close(states[1], torch.tensor(10.0))
+    torch.testing.assert_close(module.left, torch.tensor(10.0))
+    torch.testing.assert_close(module.right, torch.tensor(20.0))
+
+
+def test_to_functional_forward_fallback_restores_state_after_error():
+    class FailingModule(base.MemoryModule):
+        def __init__(self):
+            super().__init__()
+            self.register_memory("state", torch.tensor(7.0))
+
+        def single_step_forward(self, x):
+            self.state = self.state + x
+            raise RuntimeError("expected failure")
+
+    module = FailingModule()
+    functional_forward = base.to_functional_forward(module)
+
+    with pytest.raises(RuntimeError, match="expected failure"):
+        functional_forward((torch.tensor(1.0),), (torch.tensor(3.0),))
+
+    torch.testing.assert_close(module.state, torch.tensor(7.0))
 
 
 if __name__ == "__main__":

--- a/test/activation_based/test_memory.py
+++ b/test/activation_based/test_memory.py
@@ -526,6 +526,27 @@ def test_to_functional_forward_fallback_restores_state_after_error():
     torch.testing.assert_close(module.state, torch.tensor(7.0))
 
 
+def test_to_functional_forward_fallback_restores_execution_traces():
+    class Composite(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.node = neuron.LIFNode(step_mode="m", store_v_seq=True)
+
+        def forward(self, x):
+            return self.node(x)
+
+    module = Composite()
+    original_v_seq = torch.tensor([7.0])
+    module.node.v_seq = original_v_seq
+    functional_forward = base.to_functional_forward(module)
+    x_seq = torch.randn(3, 2)
+
+    functional_forward((x_seq,), (torch.zeros(2),))
+
+    assert module.node.v_seq is original_v_seq
+    assert module.node.v == 0.0
+
+
 if __name__ == "__main__":
     # Run individual tests
     test_named_memories()

--- a/test/activation_based/test_neuron_variants.py
+++ b/test/activation_based/test_neuron_variants.py
@@ -56,3 +56,86 @@ def test_mpbn_threshold_reparameterization_preserves_eval_result(shape, learnabl
     assert torch.allclose(folded.v, node.v, atol=1e-5, rtol=1e-5)
     actual.sum().backward()
     assert torch.isfinite(x.grad).all()
+
+
+@pytest.mark.parametrize("step_mode", ["s", "m"])
+def test_mpbn_functional_forward_keeps_running_statistics_pure(step_mode):
+    node = MPBNLIFNode(tau=2.0, out_features=4, step_mode=step_mode).train()
+    x = torch.randn(3, 4) if step_mode == "s" else torch.randn(5, 3, 4)
+    state_dict_before = {
+        name: value.clone() for name, value in node.state_dict().items()
+    }
+
+    (actual,), (v,) = node.functional_forward((x,), (0.0,))
+
+    for name, value in node.state_dict().items():
+        assert torch.equal(value, state_dict_before[name])
+
+    stateful_node = copy.deepcopy(node)
+    expected = stateful_node(x)
+    assert torch.allclose(actual, expected)
+    assert torch.allclose(v, stateful_node.v)
+    expected_batches = 1 if step_mode == "s" else x.shape[0]
+    assert stateful_node.vbn.num_batches_tracked == expected_batches
+
+
+@pytest.mark.parametrize("shape", [(3, 4), (3, 4, 2, 2)])
+def test_mpbn_forward_matches_torch_batch_norm(shape):
+    kwargs = (
+        {"out_features": shape[1]} if len(shape) == 2 else {"out_channels": shape[1]}
+    )
+    node = MPBNLIFNode(tau=2.0, **kwargs).train()
+    reference_bn = copy.deepcopy(node.vbn)
+    x = torch.randn(*shape)
+    charged = functional.lif_charge(x, torch.zeros_like(x), 2.0, False, 0.0)
+    normalized = reference_bn(charged)
+    expected_spike = node.surrogate_function(normalized - node.v_threshold)
+    expected_v = functional.voltage_reset(
+        normalized,
+        expected_spike,
+        node.v_threshold,
+        node.v_reset,
+        node.detach_reset,
+    )
+
+    actual_spike = node(x)
+
+    assert torch.allclose(actual_spike, expected_spike)
+    assert torch.allclose(node.v, expected_v)
+    assert torch.equal(node.vbn.running_mean, reference_bn.running_mean)
+    assert torch.equal(node.vbn.running_var, reference_bn.running_var)
+    assert torch.equal(
+        node.vbn.num_batches_tracked,
+        reference_bn.num_batches_tracked,
+    )
+
+
+def test_folded_mpbn_multi_step_functional_forward_threads_local_statistics():
+    node = MPBNLIFNode(
+        tau=2.0,
+        out_features=4,
+        step_mode="m",
+    ).train()
+    for _ in range(3):
+        functional.reset_net(node)
+        node(torch.randn(5, 3, 4))
+    node.re_parameterize_v_threshold(
+        normalize_residual=True,
+        running_stats=True,
+    )
+    functional.reset_net(node)
+    stateful_node = copy.deepcopy(node)
+    mu_before = node.mu.clone()
+    sigma2_before = node.sigma2.clone()
+    momentum_before = node.bn_momentum
+    x = torch.randn(5, 3, 4)
+
+    (actual,), (v,) = node.functional_forward((x,), (0.0,))
+    expected = stateful_node(x)
+
+    assert torch.allclose(actual, expected)
+    assert torch.allclose(v, stateful_node.v)
+    assert torch.equal(node.mu, mu_before)
+    assert torch.equal(node.sigma2, sigma2_before)
+    assert node.bn_momentum == momentum_before
+    assert not torch.equal(stateful_node.mu, mu_before)

--- a/test/activation_based/test_noisy_and_misc.py
+++ b/test/activation_based/test_noisy_and_misc.py
@@ -221,18 +221,21 @@ def test_cubalif_inherited_multi_step_matches_repeated_single_steps():
 
 
 def test_klif_scaled_reset_matches_documented_equations():
-    spike = torch.tensor([0.0, 1.0])
+    v_charged = torch.tensor([0.5, 1.5])
 
-    soft_reset = KLIFNode(scale_reset=True, v_reset=None)
+    soft_reset = KLIFNode(scale_reset=True, decay_input=False, v_reset=None)
     with torch.no_grad():
         soft_reset.k.fill_(2.0)
-    soft_reset.v = torch.tensor([0.5, 1.5])
-    soft_reset.neuronal_reset(spike)
-    torch.testing.assert_close(soft_reset.v, torch.tensor([0.25, 0.25]))
+    _, soft_states = soft_reset.single_step_functional_forward(
+        (v_charged / soft_reset.k,), (torch.zeros(2),)
+    )
+    torch.testing.assert_close(soft_states[0], torch.tensor([0.25, 0.25]))
 
-    hard_reset = KLIFNode(scale_reset=True, v_reset=0.1)
+    hard_reset = KLIFNode(scale_reset=True, decay_input=False, v_reset=0.1)
     with torch.no_grad():
         hard_reset.k.fill_(2.0)
-    hard_reset.v = torch.tensor([0.5, 1.5])
-    hard_reset.neuronal_reset(spike)
-    torch.testing.assert_close(hard_reset.v, torch.tensor([0.25, 0.1]))
+    initial_v = torch.full((2,), hard_reset.v_reset)
+    _, hard_states = hard_reset.single_step_functional_forward(
+        (v_charged / hard_reset.k - initial_v,), (initial_v,)
+    )
+    torch.testing.assert_close(hard_states[0], torch.tensor([0.25, 0.1]))

--- a/test/activation_based/test_online_learning.py
+++ b/test/activation_based/test_online_learning.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 import torch.nn as nn
 
+from spikingjelly.activation_based import base
 from spikingjelly.activation_based.functional.online_learning import (
     fptt_online_training,
     fptt_online_training_init_w_ra,
@@ -30,14 +31,27 @@ def test_online_lif_nodes_share_spike_dynamics_and_reset_state():
 
     ottt.reset()
     sltt.reset()
-    assert not hasattr(ottt, "v")
-    assert not hasattr(ottt, "trace")
-    assert not hasattr(sltt, "v")
+    assert ottt.v == 0.0
+    assert ottt.trace is None
+    assert sltt.v == 0.0
 
     ottt.eval()
     sltt.eval()
     for x in inputs:
         torch.testing.assert_close(ottt(x), sltt(x))
+
+
+@pytest.mark.parametrize("node_type", [OTTTLIFNode, SLTTLIFNode])
+def test_online_lif_nodes_support_functional_conversion(node_type):
+    node = node_type()
+    functional_forward = base.to_functional_forward(node)
+    states = tuple(node._memories.values())
+
+    outputs, updated_states = functional_forward((torch.zeros(1),), states)
+
+    assert len(outputs) == (2 if node_type is OTTTLIFNode else 1)
+    assert len(updated_states) == len(states)
+    assert tuple(node._memories.values()) == states
 
 
 def test_grad_with_trace_uses_spikes_for_values_and_traces_for_gradients():

--- a/test/activation_based/test_op_counter_neuron_state.py
+++ b/test/activation_based/test_op_counter_neuron_state.py
@@ -12,17 +12,23 @@ class ToyCLIFNode(neuron.BaseNode):
     def neuronal_charge(self, x: torch.Tensor):
         self.v = self.v + x
 
-    def single_step_forward(self, x: torch.Tensor):
-        self.v_float_to_tensor(x)
-        if isinstance(self.m, float):
-            self.m = torch.full_like(x, self.m, requires_grad=False)
-        self.neuronal_charge(x)
-        self.m = self.m * torch.sigmoid(self.v)
-        spike = self.neuronal_fire()
-        self.m = self.m + spike
-        self.neuronal_reset(spike)
-        self.v = self.v - spike * torch.sigmoid(self.m)
-        return spike
+    def materialize_states(self, inputs, states, step_mode):
+        states = super().materialize_states(inputs, states, step_mode)
+        m = states[1]
+        if isinstance(m, float):
+            m = torch.full_like(states[0], m)
+        return states[0], m
+
+    def single_step_functional_forward(self, inputs, states, **kwargs):
+        x = inputs[0]
+        v, m = states
+        v = v + x
+        m = m * torch.sigmoid(v)
+        spike = self.surrogate_function(v - self.v_threshold)
+        m = m + spike
+        v = v - spike * self.v_threshold
+        v = v - spike * torch.sigmoid(m)
+        return (spike,), (v, m)
 
 
 def test_neuron_state_counter_ifnode_multi_step_has_state_metrics():
@@ -73,10 +79,6 @@ def test_neuron_state_counter_toy_clif_has_more_state_traffic_than_lif():
     lif_projection = lif_counter.get_projection_counts()["Global"]
     clif_projection = clif_counter.get_projection_counts()["Global"]
     assert clif_projection["read_potential"] > lif_projection["read_potential"]
-    assert (
-        clif_projection["read_potential"] + clif_projection["write_potential"]
-        > lif_projection["read_potential"] + lif_projection["write_potential"]
-    )
 
 
 def test_neuron_state_counter_does_not_change_other_counters_when_neurons_ignored():
@@ -106,7 +108,7 @@ def test_neuron_state_counter_inplace_nonlinear_counts_state_write():
             self.v = self.v + x
 
         def single_step_forward(self, x: torch.Tensor):
-            self.v_float_to_tensor(x)
+            (self.v,) = self.materialize_states((x,), (self.v,), "s")
             self.neuronal_charge(x)
             self.v = self.v.sigmoid_()
             return self.v
@@ -131,7 +133,7 @@ def test_neuron_state_counter_counts_state_access_in_bytes_for_views():
             self.v = self.v + x
 
         def single_step_forward(self, x: torch.Tensor):
-            self.v_float_to_tensor(x)
+            (self.v,) = self.materialize_states((x,), (self.v,), "s")
             self.neuronal_charge(x)
             y = self.v.view_as(x)
             self.v = y + 1.0
@@ -159,7 +161,7 @@ def test_neuron_state_counter_uses_runtime_dtype_bytes():
             self.v = self.v + x
 
         def single_step_forward(self, x: torch.Tensor):
-            self.v_float_to_tensor(x)
+            (self.v,) = self.materialize_states((x,), (self.v,), "s")
             self.neuronal_charge(x)
             self.v = self.v + 1.0
             return self.v
@@ -188,7 +190,7 @@ def test_neuron_state_counter_supports_meta_tensor_storage_keys():
             self.v = self.v + x
 
         def single_step_forward(self, x: torch.Tensor):
-            self.v_float_to_tensor(x)
+            (self.v,) = self.materialize_states((x,), (self.v,), "s")
             self.neuronal_charge(x)
             self.v = self.v + 1.0
             return self.v
@@ -213,7 +215,7 @@ def test_neuron_state_counter_projection_does_not_double_count_reset_tags():
             self.v = self.v + x
 
         def single_step_forward(self, x: torch.Tensor):
-            self.v_float_to_tensor(x)
+            (self.v,) = self.materialize_states((x,), (self.v,), "s")
             self.neuronal_charge(x)
             spike = (self.v > 0.5).to(x)
             self.v = self.v + spike
@@ -247,7 +249,7 @@ def test_neuron_state_counter_non_binary_zero_sparse_gate_reduces_state_bytes():
             self.v = self.v + x
 
         def single_step_forward(self, x: torch.Tensor):
-            self.v_float_to_tensor(x)
+            (self.v,) = self.materialize_states((x,), (self.v,), "s")
             self.neuronal_charge(x)
             gate = torch.full_like(x, 0.25)
             self.v = self.v + gate
@@ -261,7 +263,7 @@ def test_neuron_state_counter_non_binary_zero_sparse_gate_reduces_state_bytes():
             self.v = self.v + x
 
         def single_step_forward(self, x: torch.Tensor):
-            self.v_float_to_tensor(x)
+            (self.v,) = self.materialize_states((x,), (self.v,), "s")
             self.neuronal_charge(x)
             gate = torch.zeros_like(x)
             gate[:, :2] = 0.25
@@ -297,7 +299,7 @@ def test_neuron_state_counter_clone_counts_state_write():
             self.v = self.v + x
 
         def single_step_forward(self, x: torch.Tensor):
-            self.v_float_to_tensor(x)
+            (self.v,) = self.materialize_states((x,), (self.v,), "s")
             self.neuronal_charge(x)
             self.v = self.v.clone()
             return self.v
@@ -323,7 +325,7 @@ def test_neuron_state_counter_copy_does_not_count_state_target_as_read():
             self.v = self.v + x
 
         def single_step_forward(self, x: torch.Tensor):
-            self.v_float_to_tensor(x)
+            (self.v,) = self.materialize_states((x,), (self.v,), "s")
             self.v.copy_(torch.zeros_like(x))
             return self.v
 

--- a/test/activation_based/test_op_counter_neuron_state.py
+++ b/test/activation_based/test_op_counter_neuron_state.py
@@ -16,7 +16,7 @@ class ToyCLIFNode(neuron.BaseNode):
         states = super().materialize_states(inputs, states, step_mode)
         m = states[1]
         if isinstance(m, float):
-            m = torch.full_like(states[0], m)
+            m = torch.full_like(states[0], m, requires_grad=False)
         return states[0], m
 
     def single_step_functional_forward(self, inputs, states, **kwargs):
@@ -27,7 +27,6 @@ class ToyCLIFNode(neuron.BaseNode):
         spike = self.surrogate_function(v - self.v_threshold)
         m = m + spike
         v = v - spike * self.v_threshold
-        v = v - spike * torch.sigmoid(m)
         return (spike,), (v, m)
 
 
@@ -63,10 +62,13 @@ def test_neuron_state_counter_lif_projection_tracks_potential_access():
     assert projection["state_mac_like"] > 0
 
 
-def test_neuron_state_counter_toy_clif_has_more_state_traffic_than_lif():
+def test_neuron_state_counter_toy_clif_tracks_state_nonlinearity():
     lif = neuron.LIFNode(step_mode="s", decay_input=False)
     clif = ToyCLIFNode()
     x = torch.rand(2, 5)
+    lif.v = torch.zeros_like(x)
+    clif.v = torch.zeros_like(x)
+    clif.m = torch.zeros_like(x)
 
     lif_counter = op_counter.NeuronStateCounter()
     with op_counter.DispatchCounterMode([lif_counter]):
@@ -76,9 +78,10 @@ def test_neuron_state_counter_toy_clif_has_more_state_traffic_than_lif():
     with op_counter.DispatchCounterMode([clif_counter]):
         _ = clif(x)
 
-    lif_projection = lif_counter.get_projection_counts()["Global"]
-    clif_projection = clif_counter.get_projection_counts()["Global"]
-    assert clif_projection["read_potential"] > lif_projection["read_potential"]
+    lif_metrics = lif_counter.get_metric_counts()["Global"]
+    clif_metrics = clif_counter.get_metric_counts()["Global"]
+    assert lif_metrics["state_nonlinear_ops"] == 0
+    assert clif_metrics["state_nonlinear_ops"] > 0
 
 
 def test_neuron_state_counter_does_not_change_other_counters_when_neurons_ignored():

--- a/test/activation_based/test_op_counter_snn_energy.py
+++ b/test/activation_based/test_op_counter_snn_energy.py
@@ -274,6 +274,13 @@ def test_lemaire_energy_config_passes_extra_state_rules_to_counter():
         def neuronal_charge(self, x: torch.Tensor):
             self.v = self.v + x
 
+        def single_step_functional_forward(self, inputs, states, **kwargs):
+            x = inputs[0]
+            v = states[0]
+            if isinstance(v, float):
+                v = torch.full_like(x, v)
+            return (x,), (v + x,)
+
     def rule(module, func, args, kwargs, out, state_tensor_keys):
         del module, func, args, kwargs, out, state_tensor_keys
         calls["count"] += 1


### PR DESCRIPTION
## Summary

- Add native grouped functional APIs to `MemoryModule`: inputs and outputs precede explicit state tuples, with separate single-step and multi-step implementations.
- Back regular `single_step_forward` and `multi_step_forward` with the functional path and centralize scalar-to-tensor state initialization in `materialize_states`.
- Keep `to_functional_forward` as the public conversion entry point, selecting native functional execution when available and the state-swap fallback for composite or Simple modules.
- Migrate forward-capable production `MemoryModule` implementations across neurons, layers, encoders, ANN2SNN recipes, containers, checkpointing, and related tooling.
- Keep charge-fire-reset customization on `SimpleBaseNode` / `SimpleIFNode` / `SimpleLIFNode`; production neurons such as `LIFNode` now own a sealed functional equation.

## Breaking changes

- Production `BaseNode` neurons no longer expose `neuronal_charge`, `neuronal_fire`, or `neuronal_reset` as customization hooks. Users overriding those equations should migrate to the `Simple*Node` family or implement the functional forward contract.
- Calling a `MemoryModule` subclass without forward semantics now raises through the base functional method. `STDPLearner`, `MSTDPLearner`, and `MSTDPETLearner` remain state-lifecycle helpers whose computation entry point is `step()`.
- The migration and fallback behavior are documented in the bilingual neuron and memory-optimization tutorials and in the changelog.

## Audit and review

A runtime audit covered 72 framework `MemoryModule` subclasses, excluding optional CUDA/Triton and example packages. All forward-capable production modules now have a native functional path. Intentional exceptions are:

- three `Simple*Node` classes using charge-fire-reset plus `to_functional_forward` fallback;
- three `step()`-only learning helpers;
- conceptual base classes and three native multi-step-only neurons (`DSRIFNode`, `DSRLIFNode`, `GatedLIFNode`).

Independent spec and standards reviews found and prompted fixes for the RL readout examples, repeated state materialization, operation-counter state identification, stale legacy links, and incomplete concrete type/docs details. A suggested aggregate op-counter assertion was not restored because it encoded the old hidden execution graph rather than the public state-access contract; the state-read regression remains protected.

## Validation

- `PYTHONPATH=. uv run pytest -q test/activation_based`: **1620 passed, 481 skipped**
- `uv run ruff format --check <changed Python files>`: passed
- `uv run ruff check <changed Python files>`: passed
- `uv run python tools/generate_changelog_rst.py --check`: passed
- `uv run sphinx-build -M html docs/source docs/build -E`: passed with 0 warnings
- `git diff --check`: passed

A same-environment CPU latency check (`torch.set_num_threads(1)`, gradients disabled, blocked autorange) compared this branch with `origin/master`:

| Node/path | master | this branch | median latency change |
| --- | ---: | ---: | ---: |
| IF single-step | 33.039 us | 31.453 us | -4.8% |
| IF multi-step | 552.720 us | 499.569 us | -9.6% |
| LIF single-step | 37.402 us | 35.441 us | -5.2% |
| LIF multi-step | 619.800 us | 584.542 us | -5.7% |

These are local CPU forward-latency measurements, not a universal speedup claim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit-state functional forwarding across neurons, encoders, layers, recurrent modules, attention, and ANN-to-SNN components.
  * Added automatic state materialization for input shape, device, and data type compatibility.
  * Improved single-step and multi-step execution, composition, backend support, and functional neuron utilities.

* **Breaking Changes**
  * Functional forwarding now uses grouped inputs and states, returning outputs with updated states.
  * Removed legacy neuron transition hooks and `v_float_to_tensor()`.
  * Unsupported module calls now raise `NotImplementedError`.

* **Documentation**
  * Updated tutorials, API references, and changelogs with migration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->