### PR TITLE
Add experimental sparse CUDA SpikeLinear kernels

### DIFF
--- a/benchmark/binary_kernel/benchmark_sparse_kernel_only.py
+++ b/benchmark/binary_kernel/benchmark_sparse_kernel_only.py
@@ -1,7 +1,4 @@
-"""Benchmark public sparse Linear strategies with correctness gates.
-
-The sparse timing includes row-index construction and weight transposition.
-"""
+"""Benchmark sparse Linear against dense PyTorch, including index/transpose costs."""
 
 import argparse
 import hashlib
@@ -62,27 +59,21 @@ def main():
         def dense():
             return torch.nn.functional.linear(s, W)
 
-        def torch_linear():
-            return sparse_linear(s, W, strategy="torch")
-
         def sparse():
             return sparse_linear(s, W, strategy="sparse")
 
         reference = dense()
         correctness_atol = 1e-5 if density <= 0.05 else 5e-5
-        torch.testing.assert_close(torch_linear(), reference, rtol=1e-4, atol=1e-5)
         torch.testing.assert_close(
             sparse(), reference, rtol=1e-4, atol=correctness_atol
         )
 
         times = {
             "dense_ms": time_fn(dense, args.warmup, args.iters),
-            "torch_ms": time_fn(torch_linear, args.warmup, args.iters),
             "sparse_ms": time_fn(sparse, args.warmup, args.iters),
         }
         nnz = int(s.to(torch.bool).sum().item())
         speedups = {
-            "torch": times["dense_ms"] / times["torch_ms"],
             "sparse": times["dense_ms"] / times["sparse_ms"],
         }
         case = {
@@ -98,7 +89,6 @@ def main():
         print(
             f"M={M:5d} K={K:5d} N={N:5d} d={density:.2f} nnz={nnz:7d}  "
             f"dense={times['dense_ms']:6.3f}ms "
-            f"torch={times['torch_ms']:6.3f}ms ({speedups['torch']:.2f}x) "
             f"sparse={times['sparse_ms']:6.3f}ms ({speedups['sparse']:.2f}x)"
         )
         results.append(case)

--- a/benchmark/binary_kernel/benchmark_sparse_kernel_only.py
+++ b/benchmark/binary_kernel/benchmark_sparse_kernel_only.py
@@ -1,0 +1,133 @@
+"""Benchmark public sparse Linear strategies with correctness gates.
+
+The v15 timing includes row-index construction and weight transposition.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+
+import cupy
+import torch
+
+from spikingjelly.activation_based.cuda_kernel import sparse_linear
+
+
+def _sync():
+    torch.cuda.synchronize()
+
+
+def time_fn(fn, warmup=20, iters=100):
+    for _ in range(warmup):
+        fn()
+    _sync()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    _sync()
+    return (time.perf_counter() - t0) * 1000 / iters
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", default="sparse_kernel_only.json")
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iters", type=int, default=100)
+    args = parser.parse_args()
+
+    device = torch.device("cuda")
+    torch.manual_seed(0)
+    results = []
+    cases = [
+        (M, K, N, density)
+        for density in [0.02, 0.05, 0.10, 0.20]
+        for M, K, N in [
+            (1024, 1024, 1024),
+            (2048, 2048, 2048),
+            (4096, 4096, 4096),
+        ]
+    ]
+
+    for M, K, N, density in cases:
+        s = (torch.rand(M, K, device=device) < density).float()
+        W = torch.randn(N, K, device=device)
+
+        def dense():
+            return torch.nn.functional.linear(s, W)
+
+        def torch_linear():
+            return sparse_linear(s, W, strategy="torch")
+
+        def v15_sparse():
+            return sparse_linear(s, W, strategy="v15_sparse")
+
+        reference = dense()
+        correctness_atol = 1e-5 if density <= 0.05 else 5e-5
+        torch.testing.assert_close(torch_linear(), reference, rtol=1e-4, atol=1e-5)
+        torch.testing.assert_close(
+            v15_sparse(), reference, rtol=1e-4, atol=correctness_atol
+        )
+
+        times = {
+            "dense_ms": time_fn(dense, args.warmup, args.iters),
+            "torch_ms": time_fn(torch_linear, args.warmup, args.iters),
+            "v15_sparse_ms": time_fn(v15_sparse, args.warmup, args.iters),
+        }
+        nnz = int(s.to(torch.bool).sum().item())
+        speedups = {
+            "torch": times["dense_ms"] / times["torch_ms"],
+            "v15_sparse": times["dense_ms"] / times["v15_sparse_ms"],
+        }
+        case = {
+            "M": M,
+            "K": K,
+            "N": N,
+            "density": density,
+            "correctness_atol": correctness_atol,
+            "nnz": nnz,
+            "times_ms": times,
+            "speedup_vs_dense": speedups,
+        }
+        print(
+            f"M={M:5d} K={K:5d} N={N:5d} d={density:.2f} nnz={nnz:7d}  "
+            f"dense={times['dense_ms']:6.3f}ms "
+            f"torch={times['torch_ms']:6.3f}ms ({speedups['torch']:.2f}x) "
+            f"v15={times['v15_sparse_ms']:6.3f}ms ({speedups['v15_sparse']:.2f}x)"
+        )
+        results.append(case)
+
+    properties = torch.cuda.get_device_properties(device)
+    source_path = Path(sparse_linear.__code__.co_filename)
+    source_sha256 = hashlib.sha256(source_path.read_bytes()).hexdigest()
+    output = {
+        "metadata": {
+            "source_revision": os.environ.get("SPIKINGJELLY_COMMIT"),
+            "source_file_sha256": source_sha256,
+            "evidence_kind": "single_process_exploratory",
+            "process_runs": 1,
+            "device_name": properties.name,
+            "compute_capability": f"{properties.major}.{properties.minor}",
+            "total_memory_bytes": properties.total_memory,
+            "torch_version": torch.__version__,
+            "cuda_version": torch.version.cuda,
+            "cupy_version": cupy.__version__,
+            "tf32_matmul": torch.backends.cuda.matmul.allow_tf32,
+            "warmup": args.warmup,
+            "iterations": args.iters,
+            "v15_includes_row_index_build": True,
+            "correctness_rtol": 1e-4,
+            "strict_low_density_atol": 1e-5,
+            "exploratory_high_density_atol": 5e-5,
+        },
+        "cases": results,
+    }
+    with open(args.out, "w") as f:
+        json.dump(output, f, indent=2)
+    print(f"\nSaved {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/binary_kernel/benchmark_sparse_kernel_only.py
+++ b/benchmark/binary_kernel/benchmark_sparse_kernel_only.py
@@ -1,6 +1,6 @@
 """Benchmark public sparse Linear strategies with correctness gates.
 
-The v15 timing includes row-index construction and weight transposition.
+The sparse timing includes row-index construction and weight transposition.
 """
 
 import argparse
@@ -37,6 +37,10 @@ def main():
     parser.add_argument("--warmup", type=int, default=20)
     parser.add_argument("--iters", type=int, default=100)
     args = parser.parse_args()
+    if args.warmup < 0:
+        parser.error("--warmup must be non-negative")
+    if args.iters <= 0:
+        parser.error("--iters must be positive")
 
     device = torch.device("cuda")
     torch.manual_seed(0)
@@ -61,25 +65,25 @@ def main():
         def torch_linear():
             return sparse_linear(s, W, strategy="torch")
 
-        def v15_sparse():
-            return sparse_linear(s, W, strategy="v15_sparse")
+        def sparse():
+            return sparse_linear(s, W, strategy="sparse")
 
         reference = dense()
         correctness_atol = 1e-5 if density <= 0.05 else 5e-5
         torch.testing.assert_close(torch_linear(), reference, rtol=1e-4, atol=1e-5)
         torch.testing.assert_close(
-            v15_sparse(), reference, rtol=1e-4, atol=correctness_atol
+            sparse(), reference, rtol=1e-4, atol=correctness_atol
         )
 
         times = {
             "dense_ms": time_fn(dense, args.warmup, args.iters),
             "torch_ms": time_fn(torch_linear, args.warmup, args.iters),
-            "v15_sparse_ms": time_fn(v15_sparse, args.warmup, args.iters),
+            "sparse_ms": time_fn(sparse, args.warmup, args.iters),
         }
         nnz = int(s.to(torch.bool).sum().item())
         speedups = {
             "torch": times["dense_ms"] / times["torch_ms"],
-            "v15_sparse": times["dense_ms"] / times["v15_sparse_ms"],
+            "sparse": times["dense_ms"] / times["sparse_ms"],
         }
         case = {
             "M": M,
@@ -95,7 +99,7 @@ def main():
             f"M={M:5d} K={K:5d} N={N:5d} d={density:.2f} nnz={nnz:7d}  "
             f"dense={times['dense_ms']:6.3f}ms "
             f"torch={times['torch_ms']:6.3f}ms ({speedups['torch']:.2f}x) "
-            f"v15={times['v15_sparse_ms']:6.3f}ms ({speedups['v15_sparse']:.2f}x)"
+            f"sparse={times['sparse_ms']:6.3f}ms ({speedups['sparse']:.2f}x)"
         )
         results.append(case)
 
@@ -117,7 +121,7 @@ def main():
             "tf32_matmul": torch.backends.cuda.matmul.allow_tf32,
             "warmup": args.warmup,
             "iterations": args.iters,
-            "v15_includes_row_index_build": True,
+            "sparse_includes_row_index_build": True,
             "correctness_rtol": 1e-4,
             "strict_low_density_atol": 1e-5,
             "exploratory_high_density_atol": 5e-5,

--- a/docs/source/APIs/spikingjelly.activation_based.cuda_kernel.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.cuda_kernel.rst
@@ -25,6 +25,7 @@ CuPy Neuron Kernels
 
    spike_op <spikingjelly.activation_based.cuda_kernel.spike_op>
    tensor_cache <spikingjelly.activation_based.cuda_kernel.tensor_cache>
+   spike_linear <spikingjelly.activation_based.cuda_kernel.spike_linear>
 
 Utilities
 ------------------------------------------------------------------

--- a/docs/source/APIs/spikingjelly.activation_based.cuda_kernel.spike_linear.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.cuda_kernel.spike_linear.rst
@@ -2,6 +2,6 @@ spikingjelly.activation_based.cuda_kernel.spike_linear
 ======================================================
 
 .. automodule:: spikingjelly.activation_based.cuda_kernel.spike_linear
-   :members: sparse_linear, bit_pack_spike_dense, cupy_spike_linear_v3_dense_forward, cupy_spike_linear_v15_sparse_forward
+   :members: sparse_linear, bit_pack_spike_dense, cupy_spike_linear_v3_dense_forward, cupy_spike_linear_sparse_forward
    :undoc-members:
    :show-inheritance:

--- a/docs/source/APIs/spikingjelly.activation_based.cuda_kernel.spike_linear.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.cuda_kernel.spike_linear.rst
@@ -1,0 +1,7 @@
+spikingjelly.activation_based.cuda_kernel.spike_linear
+======================================================
+
+.. automodule:: spikingjelly.activation_based.cuda_kernel.spike_linear
+   :members: sparse_linear, bit_pack_spike_dense, cupy_spike_linear_v3_dense_forward, cupy_spike_linear_v15_sparse_forward
+   :undoc-members:
+   :show-inheritance:

--- a/spikingjelly/activation_based/cuda_kernel/__init__.py
+++ b/spikingjelly/activation_based/cuda_kernel/__init__.py
@@ -32,8 +32,7 @@ from .spike_linear import (
 
 __all__ = [
     "auto_cuda",
-    "neuron_kernel",
-    # Experimental: hand-written CUDA sparse SpikeLinear
-    "sparse_linear",
     "bit_pack_spike_dense",
+    "neuron_kernel",
+    "sparse_linear",
 ]

--- a/spikingjelly/activation_based/cuda_kernel/__init__.py
+++ b/spikingjelly/activation_based/cuda_kernel/__init__.py
@@ -18,8 +18,22 @@ CUDA kernel 模块，提供代码生成、CuPy 神经元内核、脉冲算子和
 
 CUDA kernel module providing code generation, CuPy neuron kernels, spike
 operations, and runtime utilities.
+
+The ``spike_linear`` submodule provides experimental hand-written CUDA
+kernels for explicitly profiled binary SpikeLinear workloads. It does not
+perform automatic density-based dispatch.
 """
 
 from . import auto_cuda, neuron_kernel
+from .spike_linear import (
+    bit_pack_spike_dense,
+    sparse_linear,
+)
 
-__all__ = ["auto_cuda", "neuron_kernel"]
+__all__ = [
+    "auto_cuda",
+    "neuron_kernel",
+    # Experimental: hand-written CUDA sparse SpikeLinear
+    "sparse_linear",
+    "bit_pack_spike_dense",
+]

--- a/spikingjelly/activation_based/cuda_kernel/spike_linear.py
+++ b/spikingjelly/activation_based/cuda_kernel/spike_linear.py
@@ -62,7 +62,9 @@ extern "C" __global__ void pack_kernel(
 """
 
 
-_CUDA_SRC = r"""
+_CUDA_SRC = (
+    _BIT_PACK_SRC
+    + r"""
 #include <cuda_runtime.h>
 
 
@@ -229,6 +231,7 @@ extern "C" __global__ void spike_linear_v15_sparse_wT_kernel(
 }
 
 """
+)
 
 
 # ----------------------------------------------------------------------
@@ -236,7 +239,6 @@ extern "C" __global__ void spike_linear_v15_sparse_wT_kernel(
 # ----------------------------------------------------------------------
 
 _main_modules: dict[int, object] = {}
-_pack_modules: dict[int, object] = {}
 _kernel_cache: dict[tuple[int, str], object] = {}
 _MAX_CUDA_ELEMENTS = 2**31 - 1
 
@@ -253,31 +255,11 @@ def _get_main_module(device: int):
     return _main_modules[device]
 
 
-def _get_pack_module(device: int):
-    if cupy is None:
-        raise RuntimeError("cupy is required for bit pack kernel")
-    if device not in _pack_modules:
-        with cuda_utils.DeviceEnvironment(device):
-            _pack_modules[device] = RawModule(
-                code=_BIT_PACK_SRC,
-                options=("--use_fast_math",),
-            )
-    return _pack_modules[device]
-
-
 def _get_kernel(name: str, device: int):
     key = (device, name)
     if key not in _kernel_cache:
         with cuda_utils.DeviceEnvironment(device):
             _kernel_cache[key] = _get_main_module(device).get_function(name)
-    return _kernel_cache[key]
-
-
-def _get_pack_kernel(device: int):
-    key = (device, "pack_kernel")
-    if key not in _kernel_cache:
-        with cuda_utils.DeviceEnvironment(device):
-            _kernel_cache[key] = _get_pack_module(device).get_function("pack_kernel")
     return _kernel_cache[key]
 
 
@@ -362,7 +344,7 @@ def bit_pack_spike_dense(spike: torch.Tensor) -> torch.Tensor:
         return out
 
     device = spike.get_device()
-    kernel = _get_pack_kernel(device)
+    kernel = _get_kernel("pack_kernel", device)
     _launch(
         kernel,
         (M,),

--- a/spikingjelly/activation_based/cuda_kernel/spike_linear.py
+++ b/spikingjelly/activation_based/cuda_kernel/spike_linear.py
@@ -1,6 +1,6 @@
 """Experimental hand-written CUDA kernels for binary SpikeLinear.
 
-``sparse_linear`` exposes the v15 row-index kernel and a cuBLAS fallback.
+``sparse_linear`` exposes a row-index sparse kernel and a cuBLAS fallback.
 The slower v3 kernel remains available only as a low-level custom op for
 pre-packed spike tensors. Both kernels require CUDA, CuPy, contiguous FP32
 weights, and explicitly registered fake/autograd implementations.
@@ -22,8 +22,8 @@ except (ImportError, OSError) as e:
 
 
 __all__ = [
-    "sparse_linear",
     "bit_pack_spike_dense",
+    "sparse_linear",
 ]
 
 
@@ -33,9 +33,9 @@ __all__ = [
 
 _BIT_PACK_SRC = r"""
 extern "C" __global__ void pack_kernel(
-    const float* __restrict__ S,
+    const void* __restrict__ S,
     unsigned char* __restrict__ S_packed,
-    int M, int K, int K_PACKED)
+    int M, int K, int K_PACKED, int dtype)
 {
     int m = blockIdx.x;
     if (m >= M) return;
@@ -44,8 +44,17 @@ extern "C" __global__ void pack_kernel(
         #pragma unroll
         for (int i = 0; i < 8; i++) {
             int k = kp * 8 + i;
-            float v = (k < K) ? S[m * K + k] : 0.0f;
-            b |= ((unsigned char)(v > 0.5f)) << i;
+            int offset = m * K + k;
+            bool active = false;
+            if (k < K) {
+                if (dtype == 0) {
+                    active = static_cast<const float*>(S)[offset] > 0.5f;
+                } else {
+                    // FP16 and BF16 binary 0/1 values share zero/nonzero storage.
+                    active = static_cast<const unsigned short*>(S)[offset] != 0;
+                }
+            }
+            b |= ((unsigned char)active) << i;
         }
         S_packed[m * K_PACKED + kp] = b;
     }
@@ -323,12 +332,29 @@ def _check_weight_bias(
 
 
 def bit_pack_spike_dense(spike: torch.Tensor) -> torch.Tensor:
-    """Pack a contiguous binary FP32 CUDA matrix into row-major uint8 bytes.
+    """Pack a contiguous binary CUDA matrix into row-major uint8 bytes.
 
-    Bit ``i`` of byte ``b`` represents ``spike[:, b * 8 + i]``. A trailing
-    partial byte is zero-padded. Values greater than ``0.5`` are treated as 1.
+    ``spike`` may be FP32, FP16, or BF16. Bit ``i`` of byte ``b`` represents
+    ``spike[:, b * 8 + i]``; a trailing partial byte is zero-padded.
     """
-    _check_cuda_tensor(spike, "spike", torch.float32, 2)
+    if spike.dim() != 2:
+        raise ValueError("spike must be 2D")
+    dtype = {
+        torch.float32: 0,
+        torch.float16: 1,
+        torch.bfloat16: 2,
+    }.get(spike.dtype)
+    if dtype is None:
+        raise TypeError("spike must have dtype float32, float16, or bfloat16")
+    if not spike.is_cuda:
+        raise ValueError("spike must be a CUDA tensor")
+    if not spike.is_contiguous():
+        raise ValueError("spike must be contiguous")
+    if spike.numel() > _MAX_CUDA_ELEMENTS:
+        raise ValueError(
+            f"spike exceeds the {_MAX_CUDA_ELEMENTS}-element CUDA kernel limit"
+        )
+
     M, K = spike.shape
     K_PACKED = (K + 7) // 8
     out = torch.empty((M, K_PACKED), dtype=torch.uint8, device=spike.device)
@@ -341,7 +367,7 @@ def bit_pack_spike_dense(spike: torch.Tensor) -> torch.Tensor:
         kernel,
         (M,),
         (min(K_PACKED, 256),),
-        (spike.data_ptr(), out.data_ptr(), M, K, K_PACKED),
+        (spike.data_ptr(), out.data_ptr(), M, K, K_PACKED, dtype),
         device,
     )
     return out
@@ -436,6 +462,7 @@ def _cupy_spike_linear_v3_dense_forward_fake(
 
 
 def _setup_v3_context(ctx, inputs, output):
+    del output
     spike_packed, weight, bias = inputs
     ctx.save_for_backward(spike_packed, weight, bias)
 
@@ -467,8 +494,8 @@ torch.library.register_autograd(
 # ----------------------------------------------------------------------
 
 
-@torch.library.custom_op("sj::cupy_spike_linear_v15_sparse_forward", mutates_args=())
-def cupy_spike_linear_v15_sparse_forward(
+@torch.library.custom_op("sj::cupy_spike_linear_sparse_forward", mutates_args=())
+def cupy_spike_linear_sparse_forward(
     spike: torch.Tensor,
     weight: torch.Tensor,
     bias: Optional[torch.Tensor],
@@ -540,14 +567,14 @@ def cupy_spike_linear_v15_sparse_forward(
     return Y
 
 
-@torch.library.register_fake("sj::cupy_spike_linear_v15_sparse_forward")
-def _cupy_spike_linear_v15_sparse_forward_fake(
+@torch.library.register_fake("sj::cupy_spike_linear_sparse_forward")
+def _cupy_spike_linear_sparse_forward_fake(
     spike: torch.Tensor,
     weight: torch.Tensor,
     bias: Optional[torch.Tensor],
 ) -> torch.Tensor:
     if spike.dtype != torch.float32 or weight.dtype != torch.float32:
-        raise TypeError("v15 requires float32 spike and weight")
+        raise TypeError("sparse kernel requires float32 spike and weight")
     torch._check(spike.dim() == 2)
     torch._check(weight.dim() == 2)
     torch._check(
@@ -567,6 +594,7 @@ def _cupy_spike_linear_v15_sparse_forward_fake(
 
 
 def _setup_v15_context(ctx, inputs, output):
+    del output
     spike, weight, bias = inputs
     ctx.save_for_backward(spike, weight, bias)
 
@@ -581,7 +609,7 @@ def _v15_backward(ctx, grad_output):
 
 
 torch.library.register_autograd(
-    "sj::cupy_spike_linear_v15_sparse_forward",
+    "sj::cupy_spike_linear_sparse_forward",
     _v15_backward,
     setup_context=_setup_v15_context,
 )
@@ -596,30 +624,33 @@ def sparse_linear(
     spike: torch.Tensor,
     weight: torch.Tensor,
     bias: Optional[torch.Tensor] = None,
-    strategy: Literal["torch", "v15_sparse"] = "torch",
+    strategy: Literal["torch", "sparse"] = "torch",
 ) -> torch.Tensor:
     """Apply Linear to an unbitpacked binary spike tensor.
 
     Args:
-        spike: FP32 tensor with shape ``[M, K]`` containing only 0 and 1.
+        spike: input tensor containing only 0 and 1.
         weight: FP32 tensor with shape ``[N, K]``.
         bias: optional FP32 tensor with shape ``[N]``.
-        strategy: ``"torch"`` (default) or ``"v15_sparse"``.
+        strategy: ``"torch"`` (default) or ``"sparse"``.
 
-    ``"v15_sparse"`` requires CUDA and CuPy and is intended for explicitly
-    profiled low-density workloads. ``"torch"`` calls
-    :func:`torch.nn.functional.linear`. There is no automatic strategy
-    selection or density synchronization.
+    ``"sparse"`` requires a 2D FP32 CUDA ``spike`` and CuPy. It uses an
+    int32 ``[M, K]`` workspace (``4 * M * K`` bytes) and is intended for
+    explicitly profiled low-density workloads. It thresholds values at
+    ``> 0.5`` and treats selected values as 1; the caller must guarantee the
+    binary input contract because checking values would synchronize the device.
+
+    ``"torch"`` calls :func:`torch.nn.functional.linear` and accepts all input
+    shapes and dtypes supported by that function. There is no automatic
+    strategy selection or density synchronization.
     """
-    if strategy not in ("torch", "v15_sparse"):
+    if strategy not in ("torch", "sparse"):
         raise ValueError(
-            f"Unknown strategy: {strategy!r}. Choose from: 'torch', 'v15_sparse'."
+            f"Unknown strategy: {strategy!r}. Choose from: 'torch', 'sparse'."
         )
     if strategy == "torch":
         return torch.nn.functional.linear(spike, weight, bias)
-    if cupy is None:
-        raise RuntimeError("strategy='v15_sparse' requires cupy and CUDA")
-    return cupy_spike_linear_v15_sparse_forward(
+    return cupy_spike_linear_sparse_forward(
         spike.contiguous(),
         weight.contiguous(),
         None if bias is None else bias.contiguous(),

--- a/spikingjelly/activation_based/cuda_kernel/spike_linear.py
+++ b/spikingjelly/activation_based/cuda_kernel/spike_linear.py
@@ -1,0 +1,626 @@
+"""Experimental hand-written CUDA kernels for binary SpikeLinear.
+
+``sparse_linear`` exposes the v15 row-index kernel and a cuBLAS fallback.
+The slower v3 kernel remains available only as a low-level custom op for
+pre-packed spike tensors. Both kernels require CUDA, CuPy, contiguous FP32
+weights, and explicitly registered fake/autograd implementations.
+"""
+
+from typing import Literal, Optional
+
+import torch
+
+from . import cuda_utils
+from spikingjelly.logger import logger
+
+try:
+    import cupy
+    from cupy import RawModule
+except (ImportError, OSError) as e:
+    logger.debug("spikingjelly.activation_based.cuda_kernel.spike_linear: %s", e)
+    cupy = None
+
+
+__all__ = [
+    "sparse_linear",
+    "bit_pack_spike_dense",
+]
+
+
+# ----------------------------------------------------------------------
+# CUDA sources: bit-pack helper, low-level v3, and sparse v15
+# ----------------------------------------------------------------------
+
+_BIT_PACK_SRC = r"""
+extern "C" __global__ void pack_kernel(
+    const float* __restrict__ S,
+    unsigned char* __restrict__ S_packed,
+    int M, int K, int K_PACKED)
+{
+    int m = blockIdx.x;
+    if (m >= M) return;
+    for (int kp = threadIdx.x; kp < K_PACKED; kp += blockDim.x) {
+        unsigned char b = 0;
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            int k = kp * 8 + i;
+            float v = (k < K) ? S[m * K + k] : 0.0f;
+            b |= ((unsigned char)(v > 0.5f)) << i;
+        }
+        S_packed[m * K_PACKED + kp] = b;
+    }
+}
+"""
+
+
+_CUDA_SRC = r"""
+#include <cuda_runtime.h>
+
+
+// ====================================================================
+// v3: bit-packed dense GEMM with register tiling and shared-mem tile.
+// Block: (16, 8) = 128 threads, each computes TM=8 x TN=8 = 64 outputs.
+// Block tile: BM=64 rows, BN=128 cols, BK_PACKED=8 (=64 K values per
+// inner iter). Shared mem: 128*64*4 + 64*8 = 33KB (within 48KB limit).
+// ====================================================================
+
+#define TY_V3 8
+#define TX_V3 16
+#define TM_V3 8
+#define TN_V3 8
+#define BK_PACKED_V3 8
+#define BM_V3 (TY_V3 * TM_V3)
+#define BN_V3 (TX_V3 * TN_V3)
+
+extern "C" __global__ void spike_linear_v3_tiled_kernel(
+    const unsigned char* __restrict__ S_packed,
+    const float*   __restrict__ W,
+    float*         __restrict__ Y,
+    int M, int N, int K, int K_PACKED)
+{
+    __shared__ float s_W[BN_V3][BK_PACKED_V3 * 8];
+    __shared__ unsigned char s_S[BM_V3][BK_PACKED_V3];
+
+    int blocks_n = (N + BN_V3 - 1) / BN_V3;
+    int block_index = blockIdx.x;
+    int n0 = (block_index % blocks_n) * BN_V3;
+    int m0 = (block_index / blocks_n) * BM_V3;
+    int ty = threadIdx.y;
+    int tx = threadIdx.x;
+
+    float acc[TM_V3][TN_V3];
+    #pragma unroll
+    for (int i = 0; i < TM_V3; i++)
+        #pragma unroll
+        for (int j = 0; j < TN_V3; j++)
+            acc[i][j] = 0.0f;
+
+    int tid = ty * TX_V3 + tx;
+    int block_threads = TY_V3 * TX_V3;
+
+    for (int k_chunk = 0; k_chunk < K_PACKED; k_chunk += BK_PACKED_V3) {
+        int w_total = BN_V3 * BK_PACKED_V3 * 8;
+        for (int idx = tid; idx < w_total; idx += block_threads) {
+            int n_local = idx / (BK_PACKED_V3 * 8);
+            int kk = idx % (BK_PACKED_V3 * 8);
+            int n_global = n0 + n_local;
+            int k_global = k_chunk * 8 + kk;
+            float w = 0.0f;
+            if (n_global < N && k_global < K) {
+                w = W[n_global * K + k_global];
+            }
+            s_W[n_local][kk] = w;
+        }
+
+        int s_total = BM_V3 * BK_PACKED_V3;
+        for (int idx = tid; idx < s_total; idx += block_threads) {
+            int m_local = idx / BK_PACKED_V3;
+            int kp_local = idx % BK_PACKED_V3;
+            int m_global = m0 + m_local;
+            int kp_global = k_chunk + kp_local;
+            unsigned char s = 0;
+            if (m_global < M && kp_global < K_PACKED) {
+                s = S_packed[m_global * K_PACKED + kp_global];
+            }
+            s_S[m_local][kp_local] = s;
+        }
+
+        __syncthreads();
+
+        #pragma unroll
+        for (int kp = 0; kp < BK_PACKED_V3; kp++) {
+            unsigned char s_bits[TM_V3];
+            float w_vals[TN_V3][8];
+            #pragma unroll
+            for (int i = 0; i < TM_V3; i++) {
+                s_bits[i] = s_S[ty * TM_V3 + i][kp];
+            }
+            #pragma unroll
+            for (int j = 0; j < TN_V3; j++) {
+                #pragma unroll
+                for (int i = 0; i < 8; i++) {
+                    w_vals[j][i] = s_W[tx * TN_V3 + j][kp * 8 + i];
+                }
+            }
+            #pragma unroll
+            for (int i = 0; i < TM_V3; i++) {
+                #pragma unroll
+                for (int j = 0; j < TN_V3; j++) {
+                    #pragma unroll
+                    for (int b = 0; b < 8; b++) {
+                        acc[i][j] += w_vals[j][b] * (float)((s_bits[i] >> b) & 1);
+                    }
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (int i = 0; i < TM_V3; i++) {
+        int m_global = m0 + ty * TM_V3 + i;
+        if (m_global >= M) continue;
+        #pragma unroll
+        for (int j = 0; j < TN_V3; j++) {
+            int n_global = n0 + tx * TN_V3 + j;
+            if (n_global >= N) continue;
+            Y[m_global * N + n_global] = acc[i][j];
+        }
+    }
+}
+
+
+// ====================================================================
+// v15: per-row sparse indices + W transposed for coalesced reads.
+// The fixed-capacity [M, K] index workspace avoids data-dependent host
+// synchronization when allocating a compact CSR buffer.
+// ====================================================================
+
+extern "C" __global__ void spike_to_row_indices_kernel(
+    const float* __restrict__ S,
+    int* __restrict__ row_counts,
+    int* __restrict__ row_indices,
+    int M, int K)
+{
+    int m = blockIdx.x;
+    if (m >= M || threadIdx.x != 0) return;
+
+    int count = 0;
+    for (int k = 0; k < K; k++) {
+        if (S[m * K + k] > 0.5f) {
+            row_indices[m * K + count] = k;
+            count++;
+        }
+    }
+    row_counts[m] = count;
+}
+
+extern "C" __global__ void spike_linear_v15_sparse_wT_kernel(
+    const int* __restrict__ row_counts,
+    const int* __restrict__ row_indices,
+    const float* __restrict__ W_T,
+    float* __restrict__ Y,
+    int M, int N, int K)
+{
+    int blocks_n = (N + blockDim.x - 1) / blockDim.x;
+    int block_index = blockIdx.x;
+    int m = block_index / blocks_n;
+    if (m >= M) return;
+
+    int n = (block_index % blocks_n) * blockDim.x + threadIdx.x;
+    if (n >= N) return;
+
+    int row_nnz = row_counts[m];
+    float acc = 0.0f;
+    for (int j = 0; j < row_nnz; j++) {
+        int k = row_indices[m * K + j];
+        acc += W_T[k * N + n];
+    }
+    Y[m * N + n] = acc;
+}
+
+"""
+
+
+# ----------------------------------------------------------------------
+# Module-level compile / cache
+# ----------------------------------------------------------------------
+
+_main_modules: dict[int, object] = {}
+_pack_modules: dict[int, object] = {}
+_kernel_cache: dict[tuple[int, str], object] = {}
+_MAX_CUDA_ELEMENTS = 2**31 - 1
+
+
+def _get_main_module(device: int):
+    if cupy is None:
+        raise RuntimeError("cupy is required for CUDA SpikeLinear")
+    if device not in _main_modules:
+        with cuda_utils.DeviceEnvironment(device):
+            _main_modules[device] = RawModule(
+                code=_CUDA_SRC,
+                options=("--use_fast_math",),
+            )
+    return _main_modules[device]
+
+
+def _get_pack_module(device: int):
+    if cupy is None:
+        raise RuntimeError("cupy is required for bit pack kernel")
+    if device not in _pack_modules:
+        with cuda_utils.DeviceEnvironment(device):
+            _pack_modules[device] = RawModule(
+                code=_BIT_PACK_SRC,
+                options=("--use_fast_math",),
+            )
+    return _pack_modules[device]
+
+
+def _get_kernel(name: str, device: int):
+    key = (device, name)
+    if key not in _kernel_cache:
+        with cuda_utils.DeviceEnvironment(device):
+            _kernel_cache[key] = _get_main_module(device).get_function(name)
+    return _kernel_cache[key]
+
+
+def _get_pack_kernel(device: int):
+    key = (device, "pack_kernel")
+    if key not in _kernel_cache:
+        with cuda_utils.DeviceEnvironment(device):
+            _kernel_cache[key] = _get_pack_module(device).get_function("pack_kernel")
+    return _kernel_cache[key]
+
+
+def _launch(kernel, grid, block, args, device: int):
+    with cuda_utils.DeviceEnvironment(device):
+        stream = cupy.cuda.ExternalStream(torch.cuda.current_stream(device).cuda_stream)
+        kernel(grid, block, args, stream=stream)
+
+
+def _check_cuda_tensor(
+    tensor: torch.Tensor,
+    name: str,
+    dtype: torch.dtype,
+    ndim: int,
+) -> None:
+    if tensor.dim() != ndim:
+        raise ValueError(f"{name} must be {ndim}D")
+    if tensor.dtype != dtype:
+        raise TypeError(f"{name} must have dtype {dtype}")
+    if not tensor.is_cuda:
+        raise ValueError(f"{name} must be a CUDA tensor")
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+    if tensor.numel() > _MAX_CUDA_ELEMENTS:
+        raise ValueError(
+            f"{name} exceeds the {_MAX_CUDA_ELEMENTS}-element CUDA kernel limit"
+        )
+
+
+def _check_weight_bias(
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    K: int,
+    device: torch.device,
+) -> None:
+    _check_cuda_tensor(weight, "weight", torch.float32, 2)
+    if weight.shape[1] != K:
+        raise ValueError(f"weight.shape[1] must equal {K}, got {weight.shape[1]}")
+    if weight.device != device:
+        raise ValueError("spike and weight must be on the same CUDA device")
+    if bias is not None:
+        _check_cuda_tensor(bias, "bias", torch.float32, 1)
+        if bias.shape[0] != weight.shape[0]:
+            raise ValueError("bias.shape[0] must equal weight.shape[0]")
+        if bias.device != device:
+            raise ValueError("spike and bias must be on the same CUDA device")
+
+
+# ----------------------------------------------------------------------
+# Bit-pack helper (also used directly as a public utility)
+# ----------------------------------------------------------------------
+
+
+def bit_pack_spike_dense(spike: torch.Tensor) -> torch.Tensor:
+    """Pack a contiguous binary FP32 CUDA matrix into row-major uint8 bytes.
+
+    Bit ``i`` of byte ``b`` represents ``spike[:, b * 8 + i]``. A trailing
+    partial byte is zero-padded. Values greater than ``0.5`` are treated as 1.
+    """
+    _check_cuda_tensor(spike, "spike", torch.float32, 2)
+    M, K = spike.shape
+    K_PACKED = (K + 7) // 8
+    out = torch.empty((M, K_PACKED), dtype=torch.uint8, device=spike.device)
+    if M == 0 or K_PACKED == 0:
+        return out
+
+    device = spike.get_device()
+    kernel = _get_pack_kernel(device)
+    _launch(
+        kernel,
+        (M,),
+        (min(K_PACKED, 256),),
+        (spike.data_ptr(), out.data_ptr(), M, K, K_PACKED),
+        device,
+    )
+    return out
+
+
+# ----------------------------------------------------------------------
+# v3 (dense, bit-packed) — custom_op
+# ----------------------------------------------------------------------
+
+
+@torch.library.custom_op("sj::cupy_spike_linear_v3_dense_forward", mutates_args=())
+def cupy_spike_linear_v3_dense_forward(
+    spike_packed: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+) -> torch.Tensor:
+    """Apply Linear to a pre-packed binary spike matrix.
+
+    Args:
+        spike_packed: contiguous uint8 tensor with shape
+            ``[M, ceil(K / 8)]``.
+        weight: contiguous FP32 CUDA tensor with shape ``[N, K]``.
+        bias: optional contiguous FP32 CUDA tensor with shape ``[N]``.
+    """
+    if cupy is None:
+        raise RuntimeError("cupy is required for CUDA SpikeLinear")
+    _check_cuda_tensor(spike_packed, "spike_packed", torch.uint8, 2)
+    if weight.dim() != 2:
+        raise ValueError("weight must be 2D")
+    M, K_PACKED = spike_packed.shape
+    N, K = weight.shape
+    _check_weight_bias(weight, bias, K, spike_packed.device)
+    if K_PACKED != (K + 7) // 8:
+        raise ValueError("spike_packed.shape[1] must equal ceil(weight.shape[1] / 8)")
+    if M * N > _MAX_CUDA_ELEMENTS:
+        raise ValueError("output exceeds the CUDA kernel element limit")
+
+    Y = torch.empty((M, N), dtype=torch.float32, device=spike_packed.device)
+    if M > 0 and N > 0:
+        if K == 0:
+            Y.zero_()
+        else:
+            device = spike_packed.get_device()
+            kernel = _get_kernel("spike_linear_v3_tiled_kernel", device)
+            gx = (N + 16 * 8 - 1) // (16 * 8)
+            gy = (M + 8 * 8 - 1) // (8 * 8)
+            _launch(
+                kernel,
+                (gx * gy,),
+                (16, 8),
+                (
+                    spike_packed.data_ptr(),
+                    weight.data_ptr(),
+                    Y.data_ptr(),
+                    M,
+                    N,
+                    K,
+                    K_PACKED,
+                ),
+                device,
+            )
+
+    if bias is not None:
+        Y = Y + bias
+    return Y
+
+
+@torch.library.register_fake("sj::cupy_spike_linear_v3_dense_forward")
+def _cupy_spike_linear_v3_dense_forward_fake(
+    spike_packed: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+) -> torch.Tensor:
+    if spike_packed.dtype != torch.uint8 or weight.dtype != torch.float32:
+        raise TypeError("v3 requires uint8 spike_packed and float32 weight")
+    torch._check(spike_packed.dim() == 2)
+    torch._check(weight.dim() == 2)
+    torch._check(
+        spike_packed.shape[1] == (weight.shape[1] + 7) // 8,
+        lambda: "packed width must equal ceil(K / 8)",
+    )
+    if bias is not None:
+        if bias.dtype != torch.float32:
+            raise TypeError("bias must be float32")
+        torch._check(bias.dim() == 1)
+        torch._check(bias.shape[0] == weight.shape[0])
+    return torch.empty(
+        (spike_packed.shape[0], weight.shape[0]),
+        dtype=torch.float32,
+        device=spike_packed.device,
+    )
+
+
+def _setup_v3_context(ctx, inputs, output):
+    spike_packed, weight, bias = inputs
+    ctx.save_for_backward(spike_packed, weight, bias)
+
+
+def _v3_backward(ctx, grad_output):
+    spike_packed, weight, bias = ctx.saved_tensors
+    M, K_PACKED = spike_packed.shape
+    K = weight.shape[1]
+    with torch.cuda.device(weight.device):
+        bits = (
+            spike_packed.unsqueeze(-1)
+            >> torch.arange(8, dtype=torch.uint8, device=spike_packed.device)
+        ) & 1
+        spike = bits.reshape(M, K_PACKED * 8)[:, :K].to(grad_output.dtype)
+        grad_weight = torch.mm(grad_output.t(), spike)
+        grad_bias = grad_output.sum(0) if bias is not None else None
+    return None, grad_weight, grad_bias
+
+
+torch.library.register_autograd(
+    "sj::cupy_spike_linear_v3_dense_forward",
+    _v3_backward,
+    setup_context=_setup_v3_context,
+)
+
+
+# ----------------------------------------------------------------------
+# v15 (true-sparse, W transposed) — custom_op
+# ----------------------------------------------------------------------
+
+
+@torch.library.custom_op("sj::cupy_spike_linear_v15_sparse_forward", mutates_args=())
+def cupy_spike_linear_v15_sparse_forward(
+    spike: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+) -> torch.Tensor:
+    """Apply Linear using per-row spike indices and transposed weights.
+
+    The CUDA preprocessing kernel writes a fixed-capacity ``[M, K]`` index
+    workspace. This avoids the host synchronization required to allocate a
+    compact data-dependent CSR buffer.
+
+    Args:
+        spike: contiguous binary FP32 CUDA tensor with shape ``[M, K]``.
+        weight: contiguous FP32 CUDA tensor with shape ``[N, K]``.
+        bias: optional contiguous FP32 CUDA tensor with shape ``[N]``.
+    """
+    if cupy is None:
+        raise RuntimeError("cupy is required for CUDA SpikeLinear")
+    _check_cuda_tensor(spike, "spike", torch.float32, 2)
+    if weight.dim() != 2:
+        raise ValueError("weight must be 2D")
+    M, K = spike.shape
+    N = weight.shape[0]
+    _check_weight_bias(weight, bias, K, spike.device)
+    if M * N > _MAX_CUDA_ELEMENTS:
+        raise ValueError("output exceeds the CUDA kernel element limit")
+
+    Y = torch.empty((M, N), dtype=torch.float32, device=spike.device)
+    if M > 0 and N > 0:
+        device = spike.get_device()
+        row_counts = torch.zeros(M, dtype=torch.int32, device=spike.device)
+        row_indices = torch.empty((M, K), dtype=torch.int32, device=spike.device)
+        if K > 0:
+            index_kernel = _get_kernel("spike_to_row_indices_kernel", device)
+            _launch(
+                index_kernel,
+                (M,),
+                (1,),
+                (
+                    spike.data_ptr(),
+                    row_counts.data_ptr(),
+                    row_indices.data_ptr(),
+                    M,
+                    K,
+                ),
+                device,
+            )
+
+        weight_t = weight.t().contiguous()
+        kernel = _get_kernel("spike_linear_v15_sparse_wT_kernel", device)
+        n_blocks = (N + 255) // 256
+        _launch(
+            kernel,
+            (M * n_blocks,),
+            (256, 1, 1),
+            (
+                row_counts.data_ptr(),
+                row_indices.data_ptr(),
+                weight_t.data_ptr(),
+                Y.data_ptr(),
+                M,
+                N,
+                K,
+            ),
+            device,
+        )
+
+    if bias is not None:
+        Y = Y + bias
+    return Y
+
+
+@torch.library.register_fake("sj::cupy_spike_linear_v15_sparse_forward")
+def _cupy_spike_linear_v15_sparse_forward_fake(
+    spike: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+) -> torch.Tensor:
+    if spike.dtype != torch.float32 or weight.dtype != torch.float32:
+        raise TypeError("v15 requires float32 spike and weight")
+    torch._check(spike.dim() == 2)
+    torch._check(weight.dim() == 2)
+    torch._check(
+        spike.shape[1] == weight.shape[1],
+        lambda: "spike and weight K dimensions must match",
+    )
+    if bias is not None:
+        if bias.dtype != torch.float32:
+            raise TypeError("bias must be float32")
+        torch._check(bias.dim() == 1)
+        torch._check(bias.shape[0] == weight.shape[0])
+    return torch.empty(
+        (spike.shape[0], weight.shape[0]),
+        dtype=torch.float32,
+        device=spike.device,
+    )
+
+
+def _setup_v15_context(ctx, inputs, output):
+    spike, weight, bias = inputs
+    ctx.save_for_backward(spike, weight, bias)
+
+
+def _v15_backward(ctx, grad_output):
+    spike, weight, bias = ctx.saved_tensors
+    with torch.cuda.device(weight.device):
+        grad_spike = torch.mm(grad_output, weight)
+        grad_weight = torch.mm(grad_output.t(), spike.to(grad_output.dtype))
+        grad_bias = grad_output.sum(0) if bias is not None else None
+    return grad_spike, grad_weight, grad_bias
+
+
+torch.library.register_autograd(
+    "sj::cupy_spike_linear_v15_sparse_forward",
+    _v15_backward,
+    setup_context=_setup_v15_context,
+)
+
+
+# ----------------------------------------------------------------------
+# Public API: sparse_linear
+# ----------------------------------------------------------------------
+
+
+def sparse_linear(
+    spike: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    strategy: Literal["torch", "v15_sparse"] = "torch",
+) -> torch.Tensor:
+    """Apply Linear to an unbitpacked binary spike tensor.
+
+    Args:
+        spike: FP32 tensor with shape ``[M, K]`` containing only 0 and 1.
+        weight: FP32 tensor with shape ``[N, K]``.
+        bias: optional FP32 tensor with shape ``[N]``.
+        strategy: ``"torch"`` (default) or ``"v15_sparse"``.
+
+    ``"v15_sparse"`` requires CUDA and CuPy and is intended for explicitly
+    profiled low-density workloads. ``"torch"`` calls
+    :func:`torch.nn.functional.linear`. There is no automatic strategy
+    selection or density synchronization.
+    """
+    if strategy not in ("torch", "v15_sparse"):
+        raise ValueError(
+            f"Unknown strategy: {strategy!r}. Choose from: 'torch', 'v15_sparse'."
+        )
+    if strategy == "torch":
+        return torch.nn.functional.linear(spike, weight, bias)
+    if cupy is None:
+        raise RuntimeError("strategy='v15_sparse' requires cupy and CUDA")
+    return cupy_spike_linear_v15_sparse_forward(
+        spike.contiguous(),
+        weight.contiguous(),
+        None if bias is None else bias.contiguous(),
+    )

--- a/test/activation_based/test_cuda_sparse_linear.py
+++ b/test/activation_based/test_cuda_sparse_linear.py
@@ -31,7 +31,6 @@ pytestmark = pytest.mark.skipif(
 @pytest.mark.parametrize("density", [0.02, 0.05, 0.10])
 @pytest.mark.parametrize("M,K,N", [(64, 128, 64), (256, 512, 256), (512, 1024, 512)])
 def test_sparse_linear_matches_dense(density, M, K, N):
-    """sparse_linear must match F.linear for all density cells."""
     torch.manual_seed(0)
     s = (torch.rand(M, K, device="cuda") < density).float()
     W = torch.randn(N, K, device="cuda")
@@ -75,7 +74,6 @@ def test_sparse_linear_backward():
 
 
 def test_unknown_strategy_raises():
-    """Unknown strategy should raise ValueError, not silently fall back."""
     torch.manual_seed(0)
     M, K, N = 64, 128, 64
     s = (torch.rand(M, K, device="cuda") < 0.1).float()
@@ -161,7 +159,6 @@ def test_flattened_grid_exceeds_legacy_y_limit():
 
 @pytest.mark.parametrize("strategy", ["torch", "sparse"])
 def test_sparse_linear_explicit_strategies(strategy):
-    """Each explicit strategy must produce correct results."""
     torch.manual_seed(0)
     M, K, N = 128, 256, 128
     s = (torch.rand(M, K, device="cuda") < 0.1).float()
@@ -172,24 +169,7 @@ def test_sparse_linear_explicit_strategies(strategy):
     torch.testing.assert_close(y_test, y_ref, rtol=1e-4, atol=1e-5)
 
 
-def test_strategy_torch_skips_custom_op():
-    """strategy='torch' should not call any custom CUDA kernel."""
-    torch.manual_seed(0)
-    M, K, N = 64, 128, 64
-    s = (torch.rand(M, K, device="cuda") < 0.05).float()
-    W = torch.randn(N, K, device="cuda")
-
-    # We can't easily intercept the custom op, but we can verify the
-    # result is bit-exactly equal to F.linear (custom ops introduce
-    # ~1e-6 float round-off in the bit-pack path).
-    y_ref = torch.nn.functional.linear(s, W)
-    y_test = sparse_linear(s, W, strategy="torch")
-    err = (y_ref - y_test).abs().max().item()
-    assert err == 0.0, f"strategy=torch should be bit-exact F.linear, err={err}"
-
-
 def test_default_strategy_is_torch():
-    """The safe default is the dense torch implementation."""
     torch.manual_seed(0)
     s = (torch.rand(128, 256, device="cuda") < 0.1).float()
     W = torch.randn(128, 256, device="cuda")
@@ -199,10 +179,6 @@ def test_default_strategy_is_torch():
 
 
 def test_v3_takes_prepacked_input():
-    """v3 custom op takes uint8 [M, K_PACKED]; no internal bit-pack.
-
-    This is the right pattern when the user pre-packs (e.g. when
-    calling v3 multiple times with the same spike)."""
     torch.manual_seed(0)
     M, K, N = 64, 128, 64
     s = (torch.rand(M, K, device="cuda") < 0.1).float()
@@ -218,7 +194,6 @@ def test_v3_takes_prepacked_input():
 
 
 def test_v3_user_packs_repeated_calls():
-    """User can pack once and call v3 multiple times (no re-pack)."""
     torch.manual_seed(0)
     M, K = 1024, 1024
     s = (torch.rand(M, K, device="cuda") < 0.05).float()
@@ -236,7 +211,6 @@ def test_v3_user_packs_repeated_calls():
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 def test_bit_pack_roundtrip(dtype):
-    """bit_pack_spike_dense followed by unpack should be lossless."""
     torch.manual_seed(0)
     M, K = 64, 130  # 130 not a multiple of 8
     s = (torch.rand(M, K, device="cuda") < 0.3).to(dtype)
@@ -250,14 +224,7 @@ def test_bit_pack_roundtrip(dtype):
     assert torch.equal(s, s_back)
 
 
-def test_custom_op_registered():
-    """Both forward custom ops must be registered with torch.library."""
-    assert hasattr(torch.ops.sj, "cupy_spike_linear_v3_dense_forward")
-    assert hasattr(torch.ops.sj, "cupy_spike_linear_sparse_forward")
-
-
 def test_fake_tensor_shape():
-    """The fake implementation should produce a tensor of the right shape."""
     torch.manual_seed(0)
     M, K, N = 64, 128, 64
     # Build meta tensors to exercise both fake implementations.
@@ -276,7 +243,6 @@ def test_fake_tensor_shape():
 
 
 def test_via_torch_compile():
-    """sparse_linear should compile as one graph without graph breaks."""
     torch.manual_seed(0)
     M, K, N = 64, 128, 64
     s = (torch.rand(M, K, device="cuda") < 0.05).float()

--- a/test/activation_based/test_cuda_sparse_linear.py
+++ b/test/activation_based/test_cuda_sparse_linear.py
@@ -1,6 +1,6 @@
 """Tests for the experimental CUDA SpikeLinear kernels.
 
-The public ``sparse_linear`` API exposes only the torch and v15 strategies.
+The public ``sparse_linear`` API exposes only the torch and sparse strategies.
 The slower v3 kernel remains available as a low-level custom op that requires
 a pre-packed uint8 spike tensor.
 """
@@ -16,7 +16,7 @@ except (ImportError, OSError):
 
 from spikingjelly.activation_based.cuda_kernel.spike_linear import (
     bit_pack_spike_dense,
-    cupy_spike_linear_v15_sparse_forward,
+    cupy_spike_linear_sparse_forward,
     cupy_spike_linear_v3_dense_forward,
     sparse_linear,
 )
@@ -36,7 +36,7 @@ def test_sparse_linear_matches_dense(density, M, K, N):
     s = (torch.rand(M, K, device="cuda") < density).float()
     W = torch.randn(N, K, device="cuda")
     y_ref = torch.nn.functional.linear(s, W)
-    y_test = sparse_linear(s, W, strategy="v15_sparse")
+    y_test = sparse_linear(s, W, strategy="sparse")
     torch.testing.assert_close(y_test, y_ref, rtol=1e-4, atol=1e-5)
 
 
@@ -50,7 +50,7 @@ def test_sparse_linear_with_bias():
     W = torch.randn(N, K, device="cuda")
     b = torch.randn(N, device="cuda")
     y_ref = torch.nn.functional.linear(s, W, b)
-    y_test = sparse_linear(s, W, b, strategy="v15_sparse")
+    y_test = sparse_linear(s, W, b, strategy="sparse")
     torch.testing.assert_close(y_test, y_ref, rtol=1e-4, atol=1e-5)
 
 
@@ -66,7 +66,7 @@ def test_sparse_linear_backward():
     b_ref = b.detach().clone().requires_grad_()
     grad_output = torch.randn(M, N, device="cuda")
 
-    sparse_linear(s, W, b, strategy="v15_sparse").backward(grad_output)
+    sparse_linear(s, W, b, strategy="sparse").backward(grad_output)
     torch.nn.functional.linear(s_ref, W_ref, b_ref).backward(grad_output)
 
     torch.testing.assert_close(s.grad, s_ref.grad, rtol=1e-3, atol=1e-4)
@@ -92,13 +92,15 @@ def test_custom_ops_validate_input_contracts():
     s = torch.zeros(4, 16, device="cuda")
     W = torch.zeros(8, 16, device="cuda")
 
+    with pytest.raises(TypeError, match="float32, float16, or bfloat16"):
+        bit_pack_spike_dense(torch.zeros(4, 16, dtype=torch.int32, device="cuda"))
     with pytest.raises(TypeError, match="float32"):
-        cupy_spike_linear_v15_sparse_forward(s.half(), W, None)
-    with pytest.raises(ValueError, match="weight.shape"):
-        cupy_spike_linear_v15_sparse_forward(s, W[:, :-1].contiguous(), None)
+        cupy_spike_linear_sparse_forward(s.half(), W, None)
+    with pytest.raises(ValueError, match=r"weight\.shape"):
+        cupy_spike_linear_sparse_forward(s, W[:, :-1].contiguous(), None)
     with pytest.raises(ValueError, match="contiguous"):
-        cupy_spike_linear_v15_sparse_forward(s[:, ::2], W[:, ::2], None)
-    with pytest.raises(ValueError, match="packed.shape"):
+        cupy_spike_linear_sparse_forward(s[:, ::2], W[:, ::2], None)
+    with pytest.raises(ValueError, match=r"packed\.shape"):
         cupy_spike_linear_v3_dense_forward(
             torch.zeros(4, 1, dtype=torch.uint8, device="cuda"), W, None
         )
@@ -109,7 +111,7 @@ def test_nondefault_stream():
     with torch.cuda.stream(stream):
         s = (torch.rand(64, 128, device="cuda") < 0.05).float()
         W = torch.randn(32, 128, device="cuda")
-        y = sparse_linear(s, W, strategy="v15_sparse")
+        y = sparse_linear(s, W, strategy="sparse")
         y_ref = torch.nn.functional.linear(s, W)
     torch.cuda.current_stream().wait_stream(stream)
     torch.testing.assert_close(y, y_ref, rtol=1e-4, atol=1e-5)
@@ -120,7 +122,7 @@ def test_noncurrent_cuda_device():
     with torch.cuda.device(1):
         s = (torch.rand(32, 64, device="cuda:1") < 0.05).float()
         W = torch.randn(16, 64, device="cuda:1", requires_grad=True)
-        y = sparse_linear(s, W, strategy="v15_sparse")
+        y = sparse_linear(s, W, strategy="sparse")
         y_ref = torch.nn.functional.linear(s, W)
         y.sum().backward()
     assert y.device == torch.device("cuda:1")
@@ -129,14 +131,14 @@ def test_noncurrent_cuda_device():
 
     W_other = torch.randn(16, 64, device="cuda:0")
     with pytest.raises(ValueError, match="same CUDA device"):
-        cupy_spike_linear_v15_sparse_forward(s, W_other, None)
+        cupy_spike_linear_sparse_forward(s, W_other, None)
 
 
 @pytest.mark.parametrize("M,K,N", [(0, 8, 4), (4, 8, 0), (4, 0, 8)])
 def test_zero_dimensions(M, K, N):
     s = torch.empty(M, K, device="cuda")
     W = torch.empty(N, K, device="cuda")
-    y = sparse_linear(s, W, strategy="v15_sparse")
+    y = sparse_linear(s, W, strategy="sparse")
     y_ref = torch.nn.functional.linear(s, W)
     torch.testing.assert_close(y, y_ref, rtol=0, atol=0)
 
@@ -145,7 +147,7 @@ def test_flattened_grid_exceeds_legacy_y_limit():
     N = 256 * 65_535 + 1
     s = torch.empty(1, 0, device="cuda")
     W = torch.empty(N, 0, device="cuda")
-    y = cupy_spike_linear_v15_sparse_forward(s, W, None)
+    y = cupy_spike_linear_sparse_forward(s, W, None)
     assert y.shape == (1, N)
     assert torch.count_nonzero(y).item() == 0
 
@@ -157,7 +159,7 @@ def test_flattened_grid_exceeds_legacy_y_limit():
     assert torch.count_nonzero(y).item() == 0
 
 
-@pytest.mark.parametrize("strategy", ["torch", "v15_sparse"])
+@pytest.mark.parametrize("strategy", ["torch", "sparse"])
 def test_sparse_linear_explicit_strategies(strategy):
     """Each explicit strategy must produce correct results."""
     torch.manual_seed(0)
@@ -232,25 +234,26 @@ def test_v3_user_packs_repeated_calls():
     torch.testing.assert_close(y2, y_ref2, rtol=1e-4, atol=1e-5)
 
 
-def test_bit_pack_roundtrip():
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_bit_pack_roundtrip(dtype):
     """bit_pack_spike_dense followed by unpack should be lossless."""
     torch.manual_seed(0)
     M, K = 64, 130  # 130 not a multiple of 8
-    s = (torch.rand(M, K, device="cuda") < 0.3).float()
+    s = (torch.rand(M, K, device="cuda") < 0.3).to(dtype)
     packed = bit_pack_spike_dense(s)
     # Unpack manually
     bits = (
         packed.unsqueeze(-1) >> torch.arange(8, dtype=torch.uint8, device="cuda")
     ) & 1
     bits = bits.reshape(M, packed.shape[1] * 8)[:, :K]
-    s_back = bits.float()
+    s_back = bits.to(dtype)
     assert torch.equal(s, s_back)
 
 
 def test_custom_op_registered():
     """Both forward custom ops must be registered with torch.library."""
     assert hasattr(torch.ops.sj, "cupy_spike_linear_v3_dense_forward")
-    assert hasattr(torch.ops.sj, "cupy_spike_linear_v15_sparse_forward")
+    assert hasattr(torch.ops.sj, "cupy_spike_linear_sparse_forward")
 
 
 def test_fake_tensor_shape():
@@ -264,12 +267,12 @@ def test_fake_tensor_shape():
     y_meta = torch.ops.sj.cupy_spike_linear_v3_dense_forward(packed_meta, W_meta, None)
     assert y_meta.shape == (M, N)
     assert y_meta.dtype == W_meta.dtype
-    y_meta = torch.ops.sj.cupy_spike_linear_v15_sparse_forward(s_meta, W_meta, None)
+    y_meta = torch.ops.sj.cupy_spike_linear_sparse_forward(s_meta, W_meta, None)
     assert y_meta.shape == (M, N)
     assert y_meta.dtype == W_meta.dtype
 
     with pytest.raises(TypeError, match="float32"):
-        torch.ops.sj.cupy_spike_linear_v15_sparse_forward(s_meta.half(), W_meta, None)
+        torch.ops.sj.cupy_spike_linear_sparse_forward(s_meta.half(), W_meta, None)
 
 
 def test_via_torch_compile():
@@ -280,7 +283,7 @@ def test_via_torch_compile():
     W = torch.randn(N, K, device="cuda")
 
     def f(s, W):
-        return sparse_linear(s, W, strategy="v15_sparse")
+        return sparse_linear(s, W, strategy="sparse")
 
     explanation = torch._dynamo.explain(f)(s, W)
     assert explanation.graph_count == 1

--- a/test/activation_based/test_cuda_sparse_linear.py
+++ b/test/activation_based/test_cuda_sparse_linear.py
@@ -1,0 +1,292 @@
+"""Tests for the experimental CUDA SpikeLinear kernels.
+
+The public ``sparse_linear`` API exposes only the torch and v15 strategies.
+The slower v3 kernel remains available as a low-level custom op that requires
+a pre-packed uint8 spike tensor.
+"""
+
+import pytest
+import torch
+
+try:
+    __import__("cupy")
+    _HAS_CUPY = True
+except (ImportError, OSError):
+    _HAS_CUPY = False
+
+from spikingjelly.activation_based.cuda_kernel.spike_linear import (
+    bit_pack_spike_dense,
+    cupy_spike_linear_v15_sparse_forward,
+    cupy_spike_linear_v3_dense_forward,
+    sparse_linear,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_CUPY or not torch.cuda.is_available(),
+    reason="requires cupy and CUDA",
+)
+
+
+@pytest.mark.parametrize("density", [0.02, 0.05, 0.10])
+@pytest.mark.parametrize("M,K,N", [(64, 128, 64), (256, 512, 256), (512, 1024, 512)])
+def test_sparse_linear_matches_dense(density, M, K, N):
+    """sparse_linear must match F.linear for all density cells."""
+    torch.manual_seed(0)
+    s = (torch.rand(M, K, device="cuda") < density).float()
+    W = torch.randn(N, K, device="cuda")
+    y_ref = torch.nn.functional.linear(s, W)
+    y_test = sparse_linear(s, W, strategy="v15_sparse")
+    torch.testing.assert_close(y_test, y_ref, rtol=1e-4, atol=1e-5)
+
+
+def test_sparse_linear_with_bias():
+    """Mixed empty/nonempty rows must be initialized before adding bias."""
+    torch.manual_seed(0)
+    M, K, N = 8, 128, 32
+    s = torch.zeros(M, K, device="cuda")
+    s[1, ::17] = 1.0
+    s[6, ::11] = 1.0
+    W = torch.randn(N, K, device="cuda")
+    b = torch.randn(N, device="cuda")
+    y_ref = torch.nn.functional.linear(s, W, b)
+    y_test = sparse_linear(s, W, b, strategy="v15_sparse")
+    torch.testing.assert_close(y_test, y_ref, rtol=1e-4, atol=1e-5)
+
+
+def test_sparse_linear_backward():
+    """Input, weight, and bias gradients must match F.linear."""
+    torch.manual_seed(0)
+    M, K, N = 64, 128, 64
+    s = (torch.rand(M, K, device="cuda") < 0.05).float().requires_grad_()
+    W = torch.randn(N, K, device="cuda", requires_grad=True)
+    b = torch.randn(N, device="cuda", requires_grad=True)
+    s_ref = s.detach().clone().requires_grad_()
+    W_ref = W.detach().clone().requires_grad_()
+    b_ref = b.detach().clone().requires_grad_()
+    grad_output = torch.randn(M, N, device="cuda")
+
+    sparse_linear(s, W, b, strategy="v15_sparse").backward(grad_output)
+    torch.nn.functional.linear(s_ref, W_ref, b_ref).backward(grad_output)
+
+    torch.testing.assert_close(s.grad, s_ref.grad, rtol=1e-3, atol=1e-4)
+    torch.testing.assert_close(W.grad, W_ref.grad, rtol=1e-3, atol=1e-4)
+    torch.testing.assert_close(b.grad, b_ref.grad, rtol=1e-3, atol=1e-4)
+
+
+def test_unknown_strategy_raises():
+    """Unknown strategy should raise ValueError, not silently fall back."""
+    torch.manual_seed(0)
+    M, K, N = 64, 128, 64
+    s = (torch.rand(M, K, device="cuda") < 0.1).float()
+    W = torch.randn(N, K, device="cuda")
+    with pytest.raises(ValueError, match="Unknown strategy"):
+        sparse_linear(s, W, strategy="auto")
+    with pytest.raises(ValueError, match="Unknown strategy"):
+        sparse_linear(s, W, strategy="v3_dense")
+    with pytest.raises(ValueError, match="Unknown strategy"):
+        sparse_linear(s, W, strategy="bogus")
+
+
+def test_custom_ops_validate_input_contracts():
+    s = torch.zeros(4, 16, device="cuda")
+    W = torch.zeros(8, 16, device="cuda")
+
+    with pytest.raises(TypeError, match="float32"):
+        cupy_spike_linear_v15_sparse_forward(s.half(), W, None)
+    with pytest.raises(ValueError, match="weight.shape"):
+        cupy_spike_linear_v15_sparse_forward(s, W[:, :-1].contiguous(), None)
+    with pytest.raises(ValueError, match="contiguous"):
+        cupy_spike_linear_v15_sparse_forward(s[:, ::2], W[:, ::2], None)
+    with pytest.raises(ValueError, match="packed.shape"):
+        cupy_spike_linear_v3_dense_forward(
+            torch.zeros(4, 1, dtype=torch.uint8, device="cuda"), W, None
+        )
+
+
+def test_nondefault_stream():
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        s = (torch.rand(64, 128, device="cuda") < 0.05).float()
+        W = torch.randn(32, 128, device="cuda")
+        y = sparse_linear(s, W, strategy="v15_sparse")
+        y_ref = torch.nn.functional.linear(s, W)
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.testing.assert_close(y, y_ref, rtol=1e-4, atol=1e-5)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires two CUDA devices")
+def test_noncurrent_cuda_device():
+    with torch.cuda.device(1):
+        s = (torch.rand(32, 64, device="cuda:1") < 0.05).float()
+        W = torch.randn(16, 64, device="cuda:1", requires_grad=True)
+        y = sparse_linear(s, W, strategy="v15_sparse")
+        y_ref = torch.nn.functional.linear(s, W)
+        y.sum().backward()
+    assert y.device == torch.device("cuda:1")
+    assert W.grad.device == torch.device("cuda:1")
+    torch.testing.assert_close(y, y_ref, rtol=1e-4, atol=1e-5)
+
+    W_other = torch.randn(16, 64, device="cuda:0")
+    with pytest.raises(ValueError, match="same CUDA device"):
+        cupy_spike_linear_v15_sparse_forward(s, W_other, None)
+
+
+@pytest.mark.parametrize("M,K,N", [(0, 8, 4), (4, 8, 0), (4, 0, 8)])
+def test_zero_dimensions(M, K, N):
+    s = torch.empty(M, K, device="cuda")
+    W = torch.empty(N, K, device="cuda")
+    y = sparse_linear(s, W, strategy="v15_sparse")
+    y_ref = torch.nn.functional.linear(s, W)
+    torch.testing.assert_close(y, y_ref, rtol=0, atol=0)
+
+
+def test_flattened_grid_exceeds_legacy_y_limit():
+    N = 256 * 65_535 + 1
+    s = torch.empty(1, 0, device="cuda")
+    W = torch.empty(N, 0, device="cuda")
+    y = cupy_spike_linear_v15_sparse_forward(s, W, None)
+    assert y.shape == (1, N)
+    assert torch.count_nonzero(y).item() == 0
+
+    M = 64 * 65_535 + 1
+    packed = torch.zeros(M, 1, dtype=torch.uint8, device="cuda")
+    W = torch.zeros(1, 1, device="cuda")
+    y = cupy_spike_linear_v3_dense_forward(packed, W, None)
+    assert y.shape == (M, 1)
+    assert torch.count_nonzero(y).item() == 0
+
+
+@pytest.mark.parametrize("strategy", ["torch", "v15_sparse"])
+def test_sparse_linear_explicit_strategies(strategy):
+    """Each explicit strategy must produce correct results."""
+    torch.manual_seed(0)
+    M, K, N = 128, 256, 128
+    s = (torch.rand(M, K, device="cuda") < 0.1).float()
+    W = torch.randn(N, K, device="cuda")
+    b = torch.randn(N, device="cuda")
+    y_ref = torch.nn.functional.linear(s, W, b)
+    y_test = sparse_linear(s, W, b, strategy=strategy)
+    torch.testing.assert_close(y_test, y_ref, rtol=1e-4, atol=1e-5)
+
+
+def test_strategy_torch_skips_custom_op():
+    """strategy='torch' should not call any custom CUDA kernel."""
+    torch.manual_seed(0)
+    M, K, N = 64, 128, 64
+    s = (torch.rand(M, K, device="cuda") < 0.05).float()
+    W = torch.randn(N, K, device="cuda")
+
+    # We can't easily intercept the custom op, but we can verify the
+    # result is bit-exactly equal to F.linear (custom ops introduce
+    # ~1e-6 float round-off in the bit-pack path).
+    y_ref = torch.nn.functional.linear(s, W)
+    y_test = sparse_linear(s, W, strategy="torch")
+    err = (y_ref - y_test).abs().max().item()
+    assert err == 0.0, f"strategy=torch should be bit-exact F.linear, err={err}"
+
+
+def test_default_strategy_is_torch():
+    """The safe default is the dense torch implementation."""
+    torch.manual_seed(0)
+    s = (torch.rand(128, 256, device="cuda") < 0.1).float()
+    W = torch.randn(128, 256, device="cuda")
+    y_default = sparse_linear(s, W)
+    y_ref = torch.nn.functional.linear(s, W)
+    assert torch.equal(y_default, y_ref)
+
+
+def test_v3_takes_prepacked_input():
+    """v3 custom op takes uint8 [M, K_PACKED]; no internal bit-pack.
+
+    This is the right pattern when the user pre-packs (e.g. when
+    calling v3 multiple times with the same spike)."""
+    torch.manual_seed(0)
+    M, K, N = 64, 128, 64
+    s = (torch.rand(M, K, device="cuda") < 0.1).float()
+    W = torch.randn(N, K, device="cuda", requires_grad=True)
+    packed = bit_pack_spike_dense(s)
+    y_ref = torch.nn.functional.linear(s, W)
+    y_v3 = cupy_spike_linear_v3_dense_forward(packed, W, None)
+    torch.testing.assert_close(y_v3, y_ref, rtol=1e-4, atol=1e-5)
+
+    y_v3.sum().backward()
+    expected_grad = s.sum(0).expand_as(W)
+    assert torch.allclose(W.grad, expected_grad, atol=1e-5)
+
+
+def test_v3_user_packs_repeated_calls():
+    """User can pack once and call v3 multiple times (no re-pack)."""
+    torch.manual_seed(0)
+    M, K = 1024, 1024
+    s = (torch.rand(M, K, device="cuda") < 0.05).float()
+    W1 = torch.randn(M, K, device="cuda")
+    W2 = torch.randn(M, K, device="cuda")
+    y_ref1 = torch.nn.functional.linear(s, W1)
+    y_ref2 = torch.nn.functional.linear(s, W2)
+
+    packed = bit_pack_spike_dense(s)
+    y1 = cupy_spike_linear_v3_dense_forward(packed, W1, None)
+    y2 = cupy_spike_linear_v3_dense_forward(packed, W2, None)
+    torch.testing.assert_close(y1, y_ref1, rtol=1e-4, atol=1e-5)
+    torch.testing.assert_close(y2, y_ref2, rtol=1e-4, atol=1e-5)
+
+
+def test_bit_pack_roundtrip():
+    """bit_pack_spike_dense followed by unpack should be lossless."""
+    torch.manual_seed(0)
+    M, K = 64, 130  # 130 not a multiple of 8
+    s = (torch.rand(M, K, device="cuda") < 0.3).float()
+    packed = bit_pack_spike_dense(s)
+    # Unpack manually
+    bits = (
+        packed.unsqueeze(-1) >> torch.arange(8, dtype=torch.uint8, device="cuda")
+    ) & 1
+    bits = bits.reshape(M, packed.shape[1] * 8)[:, :K]
+    s_back = bits.float()
+    assert torch.equal(s, s_back)
+
+
+def test_custom_op_registered():
+    """Both forward custom ops must be registered with torch.library."""
+    assert hasattr(torch.ops.sj, "cupy_spike_linear_v3_dense_forward")
+    assert hasattr(torch.ops.sj, "cupy_spike_linear_v15_sparse_forward")
+
+
+def test_fake_tensor_shape():
+    """The fake implementation should produce a tensor of the right shape."""
+    torch.manual_seed(0)
+    M, K, N = 64, 128, 64
+    # Build meta tensors to exercise both fake implementations.
+    s_meta = torch.randn(M, K, device="meta")
+    packed_meta = torch.empty(M, (K + 7) // 8, dtype=torch.uint8, device="meta")
+    W_meta = torch.randn(N, K, device="meta")
+    y_meta = torch.ops.sj.cupy_spike_linear_v3_dense_forward(packed_meta, W_meta, None)
+    assert y_meta.shape == (M, N)
+    assert y_meta.dtype == W_meta.dtype
+    y_meta = torch.ops.sj.cupy_spike_linear_v15_sparse_forward(s_meta, W_meta, None)
+    assert y_meta.shape == (M, N)
+    assert y_meta.dtype == W_meta.dtype
+
+    with pytest.raises(TypeError, match="float32"):
+        torch.ops.sj.cupy_spike_linear_v15_sparse_forward(s_meta.half(), W_meta, None)
+
+
+def test_via_torch_compile():
+    """sparse_linear should compile as one graph without graph breaks."""
+    torch.manual_seed(0)
+    M, K, N = 64, 128, 64
+    s = (torch.rand(M, K, device="cuda") < 0.05).float()
+    W = torch.randn(N, K, device="cuda")
+
+    def f(s, W):
+        return sparse_linear(s, W, strategy="v15_sparse")
+
+    explanation = torch._dynamo.explain(f)(s, W)
+    assert explanation.graph_count == 1
+    assert explanation.graph_break_count == 0
+
+    compiled = torch.compile(f, fullgraph=True, dynamic=False)
+    y = compiled(s, W)
+    y_ref = torch.nn.functional.linear(s, W)
+    torch.testing.assert_close(y, y_ref, rtol=1e-4, atol=1e-5)


### PR DESCRIPTION
## Summary

- add experimental hand-written CUDA SpikeLinear kernels compiled through CuPy/NVRTC
- register packed-dense and row-sparse custom ops with fake implementations and autograd formulas
- expose `sparse_linear` with explicit `torch` and `sparse` strategies; default to the safe PyTorch implementation and perform no density synchronization
- keep v3 as a low-level custom op for caller-owned pre-packed `uint8` spikes
- support FP32, FP16, and BF16 inputs in the bit-pack utility
- add CUDA safety validation, device/stream handling, per-device kernel caches, API docs, and focused tests

## Scope

This PR proposes experimental kernels and kernel-level evidence only. It does not claim end-to-end model speedup or automatic production dispatch. `sparse` is opt-in and intended for workloads profiled by the caller; dense and higher-density cases can be slower than cuBLAS.

## Validation

- A100: `73 passed, 1 warning`
- RTX 4090: `73 passed, 1 warning`
- formatter, Ruff, compileall, `git diff --check`, and the new Sphinx API page pass
- first backward may emit PyTorch's one-time cuBLAS primary-context warning after CuPy initializes CUDA; correctness is unaffected

The benchmark results below were generated from implementation commit `e78a0f99`. The review follow-up renamed public symbols and extended bit packing; the timed row-sparse CUDA implementation is unchanged. Raw benchmark JSON is intentionally not checked in.

Representative sparse-kernel speedups versus dense `F.linear`:

| GPU | Density | 1024^3 | 2048^3 | 4096^3 |
| --- | ---: | ---: | ---: | ---: |
| A100 | 0.02 | 1.62x | 2.84x | 1.82x |
| A100 | 0.05 | 1.39x | 1.85x | 1.22x |
| RTX 4090 | 0.02 | 1.10x | 1.80x | 2.09x |

End-to-end integration and model-level performance evaluation are intentionally deferred to follow-up work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental CUDA-accelerated binary spike linear operations with dense and sparse execution strategies.
  * Added bit-packing support for spike tensors and exposed the new APIs publicly.
  * Added API documentation for the spike linear module.

* **Performance**
  * Added benchmarks comparing dense and sparse execution across matrix sizes and densities, with timing, speedup, and correctness results.

* **Tests**
  * Added comprehensive coverage for numerical accuracy, gradients, validation, devices, streams, edge cases, and compilation compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->